### PR TITLE
0.5.1 — Dataverse API hardening, robust pac parsing & error surfacing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,10 @@ test-resources/
 templates/plugin/plugin.csproj/obj/
 templates/plugin/plugins_src.csproj/obj/
 templates/plugin/plugins_srctest.csproj/obj/
+templates/plugin/PROJECTNAMESPACE.csproj/obj/
+templates/plugin/PROJECTNAMESPACE_tests.csproj/obj/
+templates/plugin/**/bin/
+templates/plugin/**/obj/
 WindowsCredentialManager/bin/
 WindowsCredentialManager/obj/
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,36 @@
 
 All notable changes to the "dataverse-powertools" extension will be documented in this file.
 
+## 0.5.1
+
+- Fixed new plugin-package creation, which failed on Dataverse's `204 No Content` response — the id is now read from the `OData-EntityId` header instead of parsing an empty body.
+- Centralised all Dataverse Web API calls through a single URL/version helper so requests no longer target mixed API versions; fixed the organisation URL used by form registration and the connection-string parsing in typings generation (#77).
+- Replaced hard-coded `\\` path separators in template generation with `path.join`, fixing webresource/template scaffolding off-Windows (#73).
+- Portal commands now parse the `pac` CLI table by anchoring on its column headers instead of whitespace/index scraping, so an environment display name (or any spaced value) and pac column-width changes no longer break website selection (#75).
+- Dataverse HTTP errors are now surfaced consistently — every list/register/form call logs the operation, status, and response body (and one form-listing call that silently swallowed failures now reports them) (#76).
+- Added success logging when webresources and plugin packages are pushed, so the output channel confirms what was created/updated/deployed (#76).
+- Testing: added an opt-in live end-to-end tier (form decoration, solution pack/unpack/export via `pac`, plugin scaffold + `dotnet build` + package push) that self-skips without credentials, expanded the ExTester UI coverage, and hardened overlay handling in UI/screenshot runs (#65, #80).
+
+## 0.5.0
+
+- Added interactive Dataverse sign-in (MSAL loopback public-client flow using Microsoft's well-known Dataverse sample app id — no app registration required): sign in once, pick your environment from a Global Discovery list, pick a solution (publisher prefix inferred), with a branded loopback success/error page (#62).
+- Service-principal (client secret) auth is now credentials-first with the same environment picker.
+- Token cache is persisted to VS Code secret storage; the extension connects silently on load and re-authenticates on genuine expiry without re-entering environment/solution details.
+- Added a "Switch Dataverse Environment" command (change environments without re-entering credentials) and a "Refresh Connection" command; renamed the connection command to "Update Dataverse Authentication".
+- Status bar item now shows a `$(database)` icon so the connection reads as Dataverse PowerTools.
+- Dropped certificate auth (a back-end/CI pattern, not an interactive-coding path).
+- Fixed the generated webresource class template: form registration now matches the `OnLoad` function, the library global uses the solution prefix, and the form name is handled correctly (#70).
+
+## 0.4.0
+
+- Migrated solution commands from `spkl.exe` to the Power Platform CLI (`pac`), so extract/pack/deploy run on Windows, macOS, and Linux; removed hard-coded Windows path separators that broke settings I/O off-Windows (`spkl` now only remains in the deprecated `plugins_old` path).
+- Fixed token auto-refresh dying ~1h into a session (client-credentials was using a `refresh_token` grant that always failed).
+- `npm ls -g` output is now parsed even on non-zero exit, so installed globals aren't reported as missing.
+- Webresource build/deploy is now awaited and gated on the build result (was detached), with corrected ANSI stripping and a narrower error match.
+- Publish operations now check `response.ok` and log failures instead of swallowing them; added shared, unit-tested connection-string and path helpers.
+- Added a test foundation (unit / integration / UI layers plus an opt-in live tier) with a CI gate — publishing to the Marketplace is now gated on lint + compile + unit + integration passing.
+- Rewrote the README as a concise Marketplace store page with real UI screenshots, and rebuilt the wiki to match the current feature set.
+
 ## 0.3.2
 
 - Added plugin unit testing support, including setup, test class generation, and test execution commands.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "dataverse-powertools",
-  "version": "0.4.1",
+  "version": "0.5.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
@@ -10838,7 +10838,7 @@
       }
     },
     "node_modules/xml2js": {
-      "version": "0.5.0",
+      "version": "0.5.1",
       "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.5.0.tgz",
       "integrity": "sha512-drPFnkQJik/O+uPKpqSgr22mpuFHqKdbS835iAQrUC73L2F5WkboIRd63ai/2Yg6I1jzifPFKH2NTK+cfglkIA==",
       "dev": true,

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "type": "git",
     "url": "https://github.com/pete-mc/dataverse-powertools"
   },
-  "version": "0.5.0",
+  "version": "0.5.1",
   "engines": {
     "vscode": "^1.93.0"
   },

--- a/src/general/dataverse/DataverseForm.ts
+++ b/src/general/dataverse/DataverseForm.ts
@@ -32,7 +32,7 @@ export class DataverseForm {
       this.context.channel.appendLine("Could not connect to dataverse.");
       return;
     }
-    const organisationUrl = this.context.connectionString.split(";")[2].replace("Url=", "");
+    const organisationUrl = this.context.dataverse.organizationUrl;
     /* eslint-disable @typescript-eslint/naming-convention */
     const options = {
       headers: {
@@ -65,7 +65,7 @@ export class DataverseForm {
       this.context.channel.appendLine("Could not connect to dataverse.");
       return;
     }
-    const organisationUrl = this.context.connectionString.split(";")[2].replace("Url=", "");
+    const organisationUrl = this.context.dataverse.organizationUrl;
     try {
       /* eslint-disable @typescript-eslint/naming-convention */
       const options = {

--- a/src/general/dataverse/DataverseForm.ts
+++ b/src/general/dataverse/DataverseForm.ts
@@ -2,6 +2,7 @@ import fetch from "node-fetch";
 import DataversePowerToolsContext from "../../context";
 import { XMLBuilder, XMLParser } from "fast-xml-parser";
 import { Options } from "./dataverseContext";
+import { dataverseApiUrl } from "./webApi";
 
 export class DataverseForm {
   id: string;
@@ -44,7 +45,7 @@ export class DataverseForm {
     /* eslint-enable @typescript-eslint/naming-convention */
     try {
       this.context.channel.appendLine(`Loading Form: ${this.id}`);
-      const url = organisationUrl + "/api/data/v9.1/systemforms(" + this.id + ")?$select=formxml";
+      const url = dataverseApiUrl(organisationUrl, `systemforms(${this.id})?$select=formxml`);
       const response = await fetch(url, options);
       if (response.ok === false) {
         this.context.channel.appendLine(await response.text());
@@ -79,7 +80,7 @@ export class DataverseForm {
       /* eslint-enable @typescript-eslint/naming-convention */
       const formxml = (await new XMLBuilder(this.parsingOptions).build(this.form)).replace(/&quot;/g, '"');
       options.body = JSON.stringify({ formxml: formxml });
-      const url = organisationUrl + "/api/data/v9.1/systemforms(" + this.id + ")";
+      const url = dataverseApiUrl(organisationUrl, `systemforms(${this.id})`);
       const response = await fetch(url, options);
       const data: any = await response.text();
       if (data === null || data === "") {

--- a/src/general/dataverse/DataverseForm.ts
+++ b/src/general/dataverse/DataverseForm.ts
@@ -2,7 +2,7 @@ import fetch from "node-fetch";
 import DataversePowerToolsContext from "../../context";
 import { XMLBuilder, XMLParser } from "fast-xml-parser";
 import { Options } from "./dataverseContext";
-import { dataverseApiUrl } from "./webApi";
+import { dataverseApiUrl, logDataverseHttpError, logDataverseError } from "./webApi";
 
 export class DataverseForm {
   id: string;
@@ -48,7 +48,7 @@ export class DataverseForm {
       const url = dataverseApiUrl(organisationUrl, `systemforms(${this.id})?$select=formxml`);
       const response = await fetch(url, options);
       if (response.ok === false) {
-        this.context.channel.appendLine(await response.text());
+        await logDataverseHttpError(this.context.channel, `load form '${this.id}'`, response);
         return;
       }
       const data: any = await response.json();
@@ -57,7 +57,7 @@ export class DataverseForm {
       }
       this.form = await new XMLParser(this.parsingOptions).parse(data.formxml);
     } catch (e) {
-      this.context.channel.appendLine(JSON.stringify(e));
+      logDataverseError(this.context.channel, `load form '${this.id}'`, e);
     }
   }
 
@@ -82,14 +82,13 @@ export class DataverseForm {
       options.body = JSON.stringify({ formxml: formxml });
       const url = dataverseApiUrl(organisationUrl, `systemforms(${this.id})`);
       const response = await fetch(url, options);
-      const data: any = await response.text();
-      if (data === null || data === "") {
-        this.context.channel.appendLine(`Saved Form: ${this.id}`);
+      if (!response.ok) {
+        await logDataverseHttpError(this.context.channel, `save form '${this.id}'`, response);
         return;
       }
-      this.context.channel.appendLine(data);
+      this.context.channel.appendLine(`Saved Form: ${this.id}`);
     } catch (e) {
-      this.context.channel.appendLine(JSON.stringify(e));
+      logDataverseError(this.context.channel, `save form '${this.id}'`, e);
     }
   }
 }

--- a/src/general/dataverse/DataverseWebresource.ts
+++ b/src/general/dataverse/DataverseWebresource.ts
@@ -80,6 +80,7 @@ export class DataverseWebresource {
       const action = this.id ? "update" : "create";
       throw new Error(`Failed to ${action} webresource ${this.name}: ${responseText}`);
     }
+    this.context.channel.appendLine(`Webresource '${this.name}' ${this.id ? "updated" : "created"} in Dataverse.`);
   }
 
   public async addToSolution(solutionUniqueName: string): Promise<void> {
@@ -122,6 +123,7 @@ export class DataverseWebresource {
 
     const response = await fetch(dataverseApiUrl(organisationUrl, "AddSolutionComponent"), options);
     if (response.ok) {
+      this.context.channel.appendLine(`Added webresource '${this.name}' to solution '${solutionUniqueName}'.`);
       return;
     }
 

--- a/src/general/dataverse/DataverseWebresource.ts
+++ b/src/general/dataverse/DataverseWebresource.ts
@@ -1,6 +1,7 @@
 import fetch from "node-fetch";
 import DataversePowerToolsContext from "../../context";
 import { Options } from "./dataverseContext";
+import { dataverseApiUrl } from "./webApi";
 
 export class DataverseWebresource {
   id: string | undefined;
@@ -20,7 +21,7 @@ export class DataverseWebresource {
     }
 
     const escapedName = this.name.replace(/'/g, "''");
-    const url = `${organisationUrl}/api/data/v9.1/webresourceset?$select=webresourceid,name&$filter=name eq '${escapedName}'`;
+    const url = dataverseApiUrl(organisationUrl, `webresourceset?$select=webresourceid,name&$filter=name eq '${escapedName}'`);
 
     /* eslint-disable @typescript-eslint/naming-convention */
     const options = {
@@ -71,7 +72,7 @@ export class DataverseWebresource {
     } as Options;
     /* eslint-enable @typescript-eslint/naming-convention */
 
-    const url = this.id ? `${organisationUrl}/api/data/v9.1/webresourceset(${this.id})` : `${organisationUrl}/api/data/v9.1/webresourceset`;
+    const url = this.id ? dataverseApiUrl(organisationUrl, `webresourceset(${this.id})`) : dataverseApiUrl(organisationUrl, "webresourceset");
     const response = await fetch(url, options);
 
     if (!response.ok) {
@@ -119,7 +120,7 @@ export class DataverseWebresource {
     } as Options;
     /* eslint-enable @typescript-eslint/naming-convention */
 
-    const response = await fetch(`${organisationUrl}/api/data/v9.1/AddSolutionComponent`, options);
+    const response = await fetch(dataverseApiUrl(organisationUrl, "AddSolutionComponent"), options);
     if (response.ok) {
       return;
     }

--- a/src/general/dataverse/addDataverseSolutionComponent.ts
+++ b/src/general/dataverse/addDataverseSolutionComponent.ts
@@ -1,7 +1,7 @@
 import fetch from "node-fetch";
 import DataversePowerToolsContext from "../../context";
 import { DataverseContext, Options } from "./dataverseContext";
-import { dataverseApiUrl } from "./webApi";
+import { dataverseApiUrl, logDataverseHttpError } from "./webApi";
 
 async function ensureDataverseContext(context: DataversePowerToolsContext): Promise<boolean> {
   if (!context.dataverse) {
@@ -59,7 +59,11 @@ export async function addDataverseSolutionComponent(context: DataversePowerTools
     return true;
   }
 
-  context.channel.appendLine(responseText);
+  // Body already consumed for the "already in solution" check above, so format the
+  // failure inline in the same shape as logDataverseHttpError rather than re-reading.
+  const status = `${response.status}${response.statusText ? ` ${response.statusText}` : ""}`.trim();
+  context.channel.appendLine(`Failed to add component to solution '${solutionUniqueName}': ${status}${responseText ? ` — ${responseText}` : ""}`);
+  context.channel.show();
   return false;
 }
 
@@ -88,7 +92,7 @@ async function resolveSolutionComponentTypeByObjectId(context: DataversePowerToo
   const response = await fetch(dataverseApiUrl(context.dataverse.organizationUrl, `solutioncomponents?$select=componenttype,objectid&$filter=objectid eq ${componentId}`), options);
 
   if (!response.ok) {
-    context.channel.appendLine(await response.text());
+    await logDataverseHttpError(context.channel, `resolve solution component type for '${componentId}'`, response);
     return undefined;
   }
 

--- a/src/general/dataverse/addDataverseSolutionComponent.ts
+++ b/src/general/dataverse/addDataverseSolutionComponent.ts
@@ -1,6 +1,7 @@
 import fetch from "node-fetch";
 import DataversePowerToolsContext from "../../context";
 import { DataverseContext, Options } from "./dataverseContext";
+import { dataverseApiUrl } from "./webApi";
 
 async function ensureDataverseContext(context: DataversePowerToolsContext): Promise<boolean> {
   if (!context.dataverse) {
@@ -47,7 +48,7 @@ export async function addDataverseSolutionComponent(context: DataversePowerTools
   } as Options;
   /* eslint-enable @typescript-eslint/naming-convention */
 
-  const response = await fetch(`${context.dataverse.organizationUrl}/api/data/v9.1/AddSolutionComponent`, options);
+  const response = await fetch(dataverseApiUrl(context.dataverse.organizationUrl, "AddSolutionComponent"), options);
   if (response.ok) {
     return true;
   }
@@ -84,7 +85,7 @@ async function resolveSolutionComponentTypeByObjectId(context: DataversePowerToo
   } as Options;
   /* eslint-enable @typescript-eslint/naming-convention */
 
-  const response = await fetch(`${context.dataverse.organizationUrl}/api/data/v9.1/solutioncomponents?$select=componenttype,objectid&$filter=objectid eq ${componentId}`, options);
+  const response = await fetch(dataverseApiUrl(context.dataverse.organizationUrl, `solutioncomponents?$select=componenttype,objectid&$filter=objectid eq ${componentId}`), options);
 
   if (!response.ok) {
     context.channel.appendLine(await response.text());

--- a/src/general/dataverse/dataverseContext.ts
+++ b/src/general/dataverse/dataverseContext.ts
@@ -3,6 +3,7 @@ import DataversePowerToolsContext from "../../context";
 import { parseConnectionString, normalizeOrganizationUrl } from "../connectionString";
 import { parseAuthType, DataverseAuthType } from "./authTypes";
 import { acquireClientSecretToken, acquireInteractiveToken, TokenResult } from "./tokenAcquisition";
+import { dataverseApiUrl } from "./webApi";
 
 export class DataverseContext {
   public authorizationToken: string = "";
@@ -123,7 +124,7 @@ export class DataverseContext {
     };
     /* eslint-enable @typescript-eslint/naming-convention */
     try {
-      const url = this.organizationUrl + "/api/data/v9.1/PublishAllXml";
+      const url = dataverseApiUrl(this.organizationUrl, "PublishAllXml");
       const response = await fetch(url, options);
       if (!response.ok) {
         const responseText = await response.text();
@@ -153,7 +154,7 @@ export class DataverseContext {
     };
     /* eslint-enable @typescript-eslint/naming-convention */
     try {
-      const url = this.organizationUrl + "/api/data/v9.1/PublishXml";
+      const url = dataverseApiUrl(this.organizationUrl, "PublishXml");
       const response = await fetch(url, options);
       if (!response.ok) {
         const responseText = await response.text();

--- a/src/general/dataverse/getDataverseForms.ts
+++ b/src/general/dataverse/getDataverseForms.ts
@@ -1,7 +1,7 @@
 import fetch from "node-fetch";
 import { Options } from "./dataverseContext";
 import DataversePowerToolsContext from "../../context";
-import { dataverseApiUrl } from "./webApi";
+import { dataverseApiUrl, logDataverseHttpError, logDataverseError } from "./webApi";
 
 export async function getDataverseForms(context: DataversePowerToolsContext, entity: string): Promise<DataverseFormRecord[]> {
   if (!context.dataverse.isValid) {
@@ -27,6 +27,10 @@ export async function getDataverseForms(context: DataversePowerToolsContext, ent
       `msdyn_solutioncomponentsummaries?$filter=((msdyn_componenttype%20eq%2060))%20and%20(msdyn_primaryentityname%20eq%20%27${entity}%27)&$select=msdyn_name,msdyn_objectid,msdyn_componenttypename`,
     );
     const response = await fetch(url, options);
+    if (!response.ok) {
+      await logDataverseHttpError(context.channel, `load forms for '${entity}'`, response);
+      return [];
+    }
     const data: any = await response.json();
     if (data === null) {
       return [];
@@ -39,7 +43,8 @@ export async function getDataverseForms(context: DataversePowerToolsContext, ent
       } as DataverseFormRecord;
     });
     return forms;
-  } catch {
+  } catch (e) {
+    logDataverseError(context.channel, `load forms for '${entity}'`, e);
     return [];
   }
 }

--- a/src/general/dataverse/getDataverseForms.ts
+++ b/src/general/dataverse/getDataverseForms.ts
@@ -1,6 +1,7 @@
 import fetch from "node-fetch";
 import { Options } from "./dataverseContext";
 import DataversePowerToolsContext from "../../context";
+import { dataverseApiUrl } from "./webApi";
 
 export async function getDataverseForms(context: DataversePowerToolsContext, entity: string): Promise<DataverseFormRecord[]> {
   if (!context.dataverse.isValid) {
@@ -21,9 +22,10 @@ export async function getDataverseForms(context: DataversePowerToolsContext, ent
     return [];
   }
   try {
-    const url =
-      context.dataverse?.organizationUrl +
-      `/api/data/v9.2/msdyn_solutioncomponentsummaries?$filter=((msdyn_componenttype%20eq%2060))%20and%20(msdyn_primaryentityname%20eq%20%27${entity}%27)&$select=msdyn_name,msdyn_objectid,msdyn_componenttypename`;
+    const url = dataverseApiUrl(
+      context.dataverse?.organizationUrl,
+      `msdyn_solutioncomponentsummaries?$filter=((msdyn_componenttype%20eq%2060))%20and%20(msdyn_primaryentityname%20eq%20%27${entity}%27)&$select=msdyn_name,msdyn_objectid,msdyn_componenttypename`,
+    );
     const response = await fetch(url, options);
     const data: any = await response.json();
     if (data === null) {

--- a/src/general/dataverse/getDataverseMessages.ts
+++ b/src/general/dataverse/getDataverseMessages.ts
@@ -1,7 +1,7 @@
 import fetch from "node-fetch";
 import { DataverseContext, Options } from "./dataverseContext";
 import DataversePowerToolsContext from "../../context";
-import { dataverseApiUrl } from "./webApi";
+import { dataverseApiUrl, logDataverseHttpError, logDataverseError } from "./webApi";
 
 export async function getDataverseMessages(context: DataversePowerToolsContext): Promise<string[]> {
   if (!context.dataverse) {
@@ -23,8 +23,7 @@ export async function getDataverseMessages(context: DataversePowerToolsContext):
     const url = dataverseApiUrl(context.dataverse?.organizationUrl, "sdkmessages?$select=name&$filter=isprivate eq false");
     const response = await fetch(url, options);
     if (!response.ok) {
-      const data: any = await response.text();
-      context.channel.appendLine(data);
+      await logDataverseHttpError(context.channel, "load messages", response);
       return [];
     }
     const data: any = await response.json();
@@ -39,7 +38,8 @@ export async function getDataverseMessages(context: DataversePowerToolsContext):
       .sort((a: string, b: string) => (a > b ? 1 : -1));
 
     return messages;
-  } catch {
+  } catch (e) {
+    logDataverseError(context.channel, "load messages", e);
     return [];
   }
 }

--- a/src/general/dataverse/getDataverseMessages.ts
+++ b/src/general/dataverse/getDataverseMessages.ts
@@ -1,6 +1,7 @@
 import fetch from "node-fetch";
 import { DataverseContext, Options } from "./dataverseContext";
 import DataversePowerToolsContext from "../../context";
+import { dataverseApiUrl } from "./webApi";
 
 export async function getDataverseMessages(context: DataversePowerToolsContext): Promise<string[]> {
   if (!context.dataverse) {
@@ -19,7 +20,7 @@ export async function getDataverseMessages(context: DataversePowerToolsContext):
   /* eslint-enable @typescript-eslint/naming-convention */
 
   try {
-    const url = context.dataverse?.organizationUrl + "/api/data/v9.1/sdkmessages?$select=name&$filter=isprivate eq false";
+    const url = dataverseApiUrl(context.dataverse?.organizationUrl, "sdkmessages?$select=name&$filter=isprivate eq false");
     const response = await fetch(url, options);
     if (!response.ok) {
       const data: any = await response.text();

--- a/src/general/dataverse/getDataversePluginAssembly.ts
+++ b/src/general/dataverse/getDataversePluginAssembly.ts
@@ -2,6 +2,7 @@ import fetch from "node-fetch";
 import * as fs from "fs";
 import DataversePowerToolsContext from "../../context";
 import { DataverseContext, Options } from "./dataverseContext";
+import { dataverseApiUrl } from "./webApi";
 
 function escapeODataString(value: string): string {
   return value.replace(/'/g, "''");
@@ -43,7 +44,7 @@ export async function getDataversePluginAssemblyId(context: DataversePowerToolsC
 
   try {
     const escapedAssemblyName = escapeODataString(assemblyName);
-    const url = `${context.dataverse.organizationUrl}/api/data/v9.1/pluginassemblies?$select=pluginassemblyid,name&$filter=name eq '${escapedAssemblyName}'`;
+    const url = dataverseApiUrl(context.dataverse.organizationUrl, `pluginassemblies?$select=pluginassemblyid,name&$filter=name eq '${escapedAssemblyName}'`);
     const response = await fetch(url, options);
     if (!response.ok) {
       const errorText = await response.text();
@@ -99,7 +100,7 @@ export async function createDataversePluginAssembly(context: DataversePowerTools
   /* eslint-enable @typescript-eslint/naming-convention */
 
   try {
-    const url = `${context.dataverse.organizationUrl}/api/data/v9.1/pluginassemblies`;
+    const url = dataverseApiUrl(context.dataverse.organizationUrl, "pluginassemblies");
     const response = await fetch(url, options);
     if (!response.ok) {
       context.channel.appendLine(await response.text());
@@ -158,7 +159,7 @@ export async function updateDataversePluginAssemblyContent(context: DataversePow
   /* eslint-enable @typescript-eslint/naming-convention */
 
   try {
-    const url = `${context.dataverse.organizationUrl}/api/data/v9.1/pluginassemblies(${assemblyId})`;
+    const url = dataverseApiUrl(context.dataverse.organizationUrl, `pluginassemblies(${assemblyId})`);
     const response = await fetch(url, options);
     if (!response.ok) {
       const errorText = await response.text();

--- a/src/general/dataverse/getDataversePluginAssembly.ts
+++ b/src/general/dataverse/getDataversePluginAssembly.ts
@@ -2,7 +2,7 @@ import fetch from "node-fetch";
 import * as fs from "fs";
 import DataversePowerToolsContext from "../../context";
 import { DataverseContext, Options } from "./dataverseContext";
-import { dataverseApiUrl } from "./webApi";
+import { dataverseApiUrl, logDataverseHttpError, logDataverseError } from "./webApi";
 
 function escapeODataString(value: string): string {
   return value.replace(/'/g, "''");
@@ -47,8 +47,7 @@ export async function getDataversePluginAssemblyId(context: DataversePowerToolsC
     const url = dataverseApiUrl(context.dataverse.organizationUrl, `pluginassemblies?$select=pluginassemblyid,name&$filter=name eq '${escapedAssemblyName}'`);
     const response = await fetch(url, options);
     if (!response.ok) {
-      const errorText = await response.text();
-      context.channel.appendLine(errorText);
+      const errorText = await logDataverseHttpError(context.channel, `look up plugin assembly '${assemblyName}'`, response);
       if (isStrongNameRequiredError(errorText)) {
         logStrongNameRequiredGuidance(context);
       }
@@ -61,7 +60,8 @@ export async function getDataversePluginAssemblyId(context: DataversePowerToolsC
     }
 
     return data.value[0]?.pluginassemblyid;
-  } catch {
+  } catch (e) {
+    logDataverseError(context.channel, `look up plugin assembly '${assemblyName}'`, e);
     return undefined;
   }
 }
@@ -103,13 +103,17 @@ export async function createDataversePluginAssembly(context: DataversePowerTools
     const url = dataverseApiUrl(context.dataverse.organizationUrl, "pluginassemblies");
     const response = await fetch(url, options);
     if (!response.ok) {
-      context.channel.appendLine(await response.text());
+      const errorText = await logDataverseHttpError(context.channel, `create plugin assembly '${assemblyName}'`, response);
+      if (isStrongNameRequiredError(errorText)) {
+        logStrongNameRequiredGuidance(context);
+      }
       return undefined;
     }
 
     const created = (await response.json()) as { pluginassemblyid?: string };
     return created.pluginassemblyid;
-  } catch {
+  } catch (e) {
+    logDataverseError(context.channel, `create plugin assembly '${assemblyName}'`, e);
     return undefined;
   }
 }
@@ -162,8 +166,7 @@ export async function updateDataversePluginAssemblyContent(context: DataversePow
     const url = dataverseApiUrl(context.dataverse.organizationUrl, `pluginassemblies(${assemblyId})`);
     const response = await fetch(url, options);
     if (!response.ok) {
-      const errorText = await response.text();
-      context.channel.appendLine(errorText);
+      const errorText = await logDataverseHttpError(context.channel, "update plugin assembly content", response);
       if (isStrongNameRequiredError(errorText)) {
         logStrongNameRequiredGuidance(context);
       }
@@ -171,7 +174,8 @@ export async function updateDataversePluginAssemblyContent(context: DataversePow
     }
 
     return true;
-  } catch {
+  } catch (e) {
+    logDataverseError(context.channel, "update plugin assembly content", e);
     return false;
   }
 }

--- a/src/general/dataverse/getDataversePluginPackage.ts
+++ b/src/general/dataverse/getDataversePluginPackage.ts
@@ -2,7 +2,7 @@ import fetch from "node-fetch";
 import * as fs from "fs";
 import DataversePowerToolsContext from "../../context";
 import { DataverseContext, Options } from "./dataverseContext";
-import { dataverseApiUrl } from "./webApi";
+import { dataverseApiUrl, logDataverseHttpError } from "./webApi";
 
 function escapeODataString(value: string): string {
   return value.replace(/'/g, "''");
@@ -80,7 +80,7 @@ export async function getDataversePluginPackageId(context: DataversePowerToolsCo
   const url = dataverseApiUrl(auth.baseUrl, `pluginpackages?$select=pluginpackageid,uniquename,name&$filter=uniquename eq '${escapedUniqueName}'`);
   const response = await fetch(url, createRequestOptions(auth.token, "GET"));
   if (!response.ok) {
-    context.channel.appendLine(await response.text());
+    await logDataverseHttpError(context.channel, `look up plugin package '${uniqueName}'`, response);
     return undefined;
   }
 
@@ -108,7 +108,7 @@ async function createDataversePluginPackage(context: DataversePowerToolsContext,
   const url = dataverseApiUrl(auth.baseUrl, "pluginpackages");
   const response = await fetch(url, createRequestOptions(auth.token, "POST", payload));
   if (!response.ok) {
-    context.channel.appendLine(await response.text());
+    await logDataverseHttpError(context.channel, `create plugin package '${metadata.uniqueName}'`, response);
     return undefined;
   }
 
@@ -142,7 +142,7 @@ async function updateDataversePluginPackage(context: DataversePowerToolsContext,
   const url = dataverseApiUrl(auth.baseUrl, `pluginpackages(${pluginPackageId})`);
   const response = await fetch(url, createRequestOptions(auth.token, "PATCH", payload));
   if (!response.ok) {
-    context.channel.appendLine(await response.text());
+    await logDataverseHttpError(context.channel, `update plugin package '${metadata.uniqueName}'`, response);
     return false;
   }
 
@@ -189,7 +189,7 @@ export async function waitForDataversePluginAssemblyFromPackage(
   while (Date.now() - startTime <= maxWaitMs) {
     const response = await fetch(query, createRequestOptions(auth.token, "GET"));
     if (!response.ok) {
-      context.channel.appendLine(await response.text());
+      await logDataverseHttpError(context.channel, `wait for plugin assembly '${assemblyName}'`, response);
       return undefined;
     }
 

--- a/src/general/dataverse/getDataversePluginPackage.ts
+++ b/src/general/dataverse/getDataversePluginPackage.ts
@@ -153,10 +153,16 @@ export async function upsertDataversePluginPackage(context: DataversePowerToolsC
   const existingId = await getDataversePluginPackageId(context, metadata.uniqueName);
   if (existingId) {
     const updated = await updateDataversePluginPackage(context, existingId, metadata, packagePath);
+    if (updated) {
+      context.channel.appendLine(`Plugin package '${metadata.uniqueName}' (v${metadata.version}) updated in Dataverse.`);
+    }
     return { pluginPackageId: existingId, created: false, updated };
   }
 
   const createdId = await createDataversePluginPackage(context, metadata, packagePath);
+  if (createdId) {
+    context.channel.appendLine(`Plugin package '${metadata.uniqueName}' (v${metadata.version}) created in Dataverse (${createdId}).`);
+  }
   return { pluginPackageId: createdId, created: !!createdId, updated: false };
 }
 

--- a/src/general/dataverse/getDataversePluginPackage.ts
+++ b/src/general/dataverse/getDataversePluginPackage.ts
@@ -2,6 +2,7 @@ import fetch from "node-fetch";
 import * as fs from "fs";
 import DataversePowerToolsContext from "../../context";
 import { DataverseContext, Options } from "./dataverseContext";
+import { dataverseApiUrl } from "./webApi";
 
 function escapeODataString(value: string): string {
   return value.replace(/'/g, "''");
@@ -76,7 +77,7 @@ export async function getDataversePluginPackageId(context: DataversePowerToolsCo
   }
 
   const escapedUniqueName = escapeODataString(uniqueName);
-  const url = `${auth.baseUrl}/api/data/v9.1/pluginpackages?$select=pluginpackageid,uniquename,name&$filter=uniquename eq '${escapedUniqueName}'`;
+  const url = dataverseApiUrl(auth.baseUrl, `pluginpackages?$select=pluginpackageid,uniquename,name&$filter=uniquename eq '${escapedUniqueName}'`);
   const response = await fetch(url, createRequestOptions(auth.token, "GET"));
   if (!response.ok) {
     context.channel.appendLine(await response.text());
@@ -104,7 +105,7 @@ async function createDataversePluginPackage(context: DataversePowerToolsContext,
     content: await readPackageContentBase64(packagePath),
   };
 
-  const url = `${auth.baseUrl}/api/data/v9.1/pluginpackages`;
+  const url = dataverseApiUrl(auth.baseUrl, "pluginpackages");
   const response = await fetch(url, createRequestOptions(auth.token, "POST", payload));
   if (!response.ok) {
     context.channel.appendLine(await response.text());
@@ -138,7 +139,7 @@ async function updateDataversePluginPackage(context: DataversePowerToolsContext,
     content: await readPackageContentBase64(packagePath),
   };
 
-  const url = `${auth.baseUrl}/api/data/v9.1/pluginpackages(${pluginPackageId})`;
+  const url = dataverseApiUrl(auth.baseUrl, `pluginpackages(${pluginPackageId})`);
   const response = await fetch(url, createRequestOptions(auth.token, "PATCH", payload));
   if (!response.ok) {
     context.channel.appendLine(await response.text());
@@ -176,8 +177,7 @@ export async function waitForDataversePluginAssemblyFromPackage(
   }
 
   const escapedAssemblyName = escapeODataString(assemblyName);
-  const query =
-    `${auth.baseUrl}/api/data/v9.1/pluginassemblies` + `?$select=pluginassemblyid,name` + `&$filter=_packageid_value eq ${pluginPackageId} and name eq '${escapedAssemblyName}'`;
+  const query = dataverseApiUrl(auth.baseUrl, `pluginassemblies?$select=pluginassemblyid,name&$filter=_packageid_value eq ${pluginPackageId} and name eq '${escapedAssemblyName}'`);
 
   const startTime = Date.now();
   while (Date.now() - startTime <= maxWaitMs) {

--- a/src/general/dataverse/getDataversePluginPackage.ts
+++ b/src/general/dataverse/getDataversePluginPackage.ts
@@ -111,8 +111,19 @@ async function createDataversePluginPackage(context: DataversePowerToolsContext,
     return undefined;
   }
 
-  const created = (await response.json()) as { pluginpackageid?: string };
-  return created.pluginpackageid;
+  // Dataverse returns 204 No Content on create, with the new record's id in the
+  // OData-EntityId header (there's no JSON body to parse unless return=representation
+  // was requested). Read the id from the header, falling back to a body if present.
+  const entityId = response.headers.get("OData-EntityId") ?? "";
+  const idFromHeader = entityId.match(/\(([^)]+)\)/)?.[1];
+  if (idFromHeader) {
+    return idFromHeader;
+  }
+  try {
+    return ((await response.json()) as { pluginpackageid?: string }).pluginpackageid;
+  } catch {
+    return undefined;
+  }
 }
 
 async function updateDataversePluginPackage(context: DataversePowerToolsContext, pluginPackageId: string, metadata: PluginPackageMetadata, packagePath: string): Promise<boolean> {

--- a/src/general/dataverse/getDataverseTableAttributes.ts
+++ b/src/general/dataverse/getDataverseTableAttributes.ts
@@ -1,7 +1,7 @@
 import fetch from "node-fetch";
 import { DataverseContext, Options } from "./dataverseContext";
 import DataversePowerToolsContext from "../../context";
-import { dataverseApiUrl } from "./webApi";
+import { dataverseApiUrl, logDataverseHttpError, logDataverseError } from "./webApi";
 
 export async function getDataverseTableAttributes(context: DataversePowerToolsContext, tableLogicalName: string): Promise<string[]> {
   if (!context.dataverse) {
@@ -27,11 +27,13 @@ export async function getDataverseTableAttributes(context: DataversePowerToolsCo
   /* eslint-enable @typescript-eslint/naming-convention */
 
   try {
-    const url = dataverseApiUrl(context.dataverse.organizationUrl, `EntityDefinitions(LogicalName='${escapedTableLogicalName}')/Attributes?$select=LogicalName&$filter=AttributeOf eq null`);
+    const url = dataverseApiUrl(
+      context.dataverse.organizationUrl,
+      `EntityDefinitions(LogicalName='${escapedTableLogicalName}')/Attributes?$select=LogicalName&$filter=AttributeOf eq null`,
+    );
     const response = await fetch(url, options);
     if (!response.ok) {
-      const data: any = await response.text();
-      context.channel.appendLine(data);
+      await logDataverseHttpError(context.channel, `load attributes for table '${tableLogicalName}'`, response);
       return [];
     }
 
@@ -45,7 +47,8 @@ export async function getDataverseTableAttributes(context: DataversePowerToolsCo
       .map((name: string | undefined) => (typeof name === "string" ? name.trim() : ""))
       .filter((name: string) => name.length > 0)
       .sort((a: string, b: string) => a.localeCompare(b));
-  } catch {
+  } catch (e) {
+    logDataverseError(context.channel, `load attributes for table '${tableLogicalName}'`, e);
     return [];
   }
 }

--- a/src/general/dataverse/getDataverseTableAttributes.ts
+++ b/src/general/dataverse/getDataverseTableAttributes.ts
@@ -1,6 +1,7 @@
 import fetch from "node-fetch";
 import { DataverseContext, Options } from "./dataverseContext";
 import DataversePowerToolsContext from "../../context";
+import { dataverseApiUrl } from "./webApi";
 
 export async function getDataverseTableAttributes(context: DataversePowerToolsContext, tableLogicalName: string): Promise<string[]> {
   if (!context.dataverse) {
@@ -26,7 +27,7 @@ export async function getDataverseTableAttributes(context: DataversePowerToolsCo
   /* eslint-enable @typescript-eslint/naming-convention */
 
   try {
-    const url = `${context.dataverse.organizationUrl}/api/data/v9.1/EntityDefinitions(LogicalName='${escapedTableLogicalName}')/Attributes?$select=LogicalName&$filter=AttributeOf eq null`;
+    const url = dataverseApiUrl(context.dataverse.organizationUrl, `EntityDefinitions(LogicalName='${escapedTableLogicalName}')/Attributes?$select=LogicalName&$filter=AttributeOf eq null`);
     const response = await fetch(url, options);
     if (!response.ok) {
       const data: any = await response.text();

--- a/src/general/dataverse/getDataverseTables.ts
+++ b/src/general/dataverse/getDataverseTables.ts
@@ -1,7 +1,7 @@
 import fetch from "node-fetch";
 import { DataverseContext, Options } from "./dataverseContext";
 import DataversePowerToolsContext from "../../context";
-import { dataverseApiUrl } from "./webApi";
+import { dataverseApiUrl, logDataverseHttpError, logDataverseError } from "./webApi";
 
 export async function getDataverseTables(context: DataversePowerToolsContext): Promise<string[]> {
   if (!context.dataverse) {
@@ -21,8 +21,7 @@ export async function getDataverseTables(context: DataversePowerToolsContext): P
     const url = dataverseApiUrl(context.dataverse?.organizationUrl, "EntityDefinitions?$select=LogicalName");
     const response = await fetch(url, options);
     if (!response.ok) {
-      const data: any = await response.text();
-      context.channel.appendLine(data);
+      await logDataverseHttpError(context.channel, "load tables", response);
       return [];
     }
     const data: any = await response.json();
@@ -34,7 +33,8 @@ export async function getDataverseTables(context: DataversePowerToolsContext): P
       .map((name: string | undefined) => (typeof name === "string" ? name.trim() : ""))
       .filter((name: string) => name.length > 0);
     return tables;
-  } catch {
+  } catch (e) {
+    logDataverseError(context.channel, "load tables", e);
     return [];
   }
 }

--- a/src/general/dataverse/getDataverseTables.ts
+++ b/src/general/dataverse/getDataverseTables.ts
@@ -1,6 +1,7 @@
 import fetch from "node-fetch";
 import { DataverseContext, Options } from "./dataverseContext";
 import DataversePowerToolsContext from "../../context";
+import { dataverseApiUrl } from "./webApi";
 
 export async function getDataverseTables(context: DataversePowerToolsContext): Promise<string[]> {
   if (!context.dataverse) {
@@ -17,7 +18,7 @@ export async function getDataverseTables(context: DataversePowerToolsContext): P
   } as Options;
   /* eslint-enable @typescript-eslint/naming-convention */
   try {
-    const url = context.dataverse?.organizationUrl + "/api/data/v9.1/EntityDefinitions?$select=LogicalName";
+    const url = dataverseApiUrl(context.dataverse?.organizationUrl, "EntityDefinitions?$select=LogicalName");
     const response = await fetch(url, options);
     if (!response.ok) {
       const data: any = await response.text();

--- a/src/general/dataverse/getSolutions.ts
+++ b/src/general/dataverse/getSolutions.ts
@@ -1,7 +1,7 @@
 import fetch from "node-fetch";
 import { DataverseContext, Options } from "./dataverseContext";
 import DataversePowerToolsContext from "../../context";
-import { dataverseApiUrl } from "./webApi";
+import { dataverseApiUrl, logDataverseHttpError, logDataverseError } from "./webApi";
 
 export async function getSolutions(context: DataversePowerToolsContext): Promise<DataverseSolution[] | undefined> {
   /* eslint-disable @typescript-eslint/naming-convention */
@@ -29,9 +29,7 @@ export async function getSolutions(context: DataversePowerToolsContext): Promise
     );
     const response = await fetch(url, options);
     if (!response.ok) {
-      const body = await response.text();
-      context.channel.appendLine(`Failed to list solutions: ${response.status} ${response.statusText} ${body}`);
-      context.channel.show();
+      await logDataverseHttpError(context.channel, "list solutions", response);
       return undefined;
     }
     const data: any = await response.json();
@@ -41,9 +39,8 @@ export async function getSolutions(context: DataversePowerToolsContext): Promise
     }
     const solutions = data.value.map((record: SolutionResult) => new DataverseSolution(record));
     return solutions;
-  } catch (e: any) {
-    context.channel.appendLine(`Error listing solutions: ${e?.message || JSON.stringify(e)}`);
-    context.channel.show();
+  } catch (e) {
+    logDataverseError(context.channel, "list solutions", e);
     return undefined;
   }
 }

--- a/src/general/dataverse/getSolutions.ts
+++ b/src/general/dataverse/getSolutions.ts
@@ -1,6 +1,7 @@
 import fetch from "node-fetch";
 import { DataverseContext, Options } from "./dataverseContext";
 import DataversePowerToolsContext from "../../context";
+import { dataverseApiUrl } from "./webApi";
 
 export async function getSolutions(context: DataversePowerToolsContext): Promise<DataverseSolution[] | undefined> {
   /* eslint-disable @typescript-eslint/naming-convention */
@@ -22,9 +23,10 @@ export async function getSolutions(context: DataversePowerToolsContext): Promise
     return undefined;
   }
   try {
-    const url =
-      context.dataverse?.organizationUrl +
-      "/api/data/v9.1/solutions?$select=friendlyname,uniquename,solutionid,publisherid&$filter=ismanaged%20eq%20false&$expand=publisherid($select=friendlyname,customizationprefix,publisherid)";
+    const url = dataverseApiUrl(
+      context.dataverse?.organizationUrl,
+      "solutions?$select=friendlyname,uniquename,solutionid,publisherid&$filter=ismanaged%20eq%20false&$expand=publisherid($select=friendlyname,customizationprefix,publisherid)",
+    );
     const response = await fetch(url, options);
     if (!response.ok) {
       const body = await response.text();

--- a/src/general/dataverse/registerPluginSteps.ts
+++ b/src/general/dataverse/registerPluginSteps.ts
@@ -2,6 +2,13 @@ import fetch from "node-fetch";
 import DataversePowerToolsContext from "../../context";
 import { addDataverseSolutionComponent } from "./addDataverseSolutionComponent";
 import { DataverseContext, Options } from "./dataverseContext";
+import { dataverseApiUrl } from "./webApi";
+
+// The helpers below take "/api/data/v9.x/<resource>" relative urls; strip the version
+// segment and rebuild via the central helper so every request targets one API version.
+function toApiUrl(baseUrl: string, relativeUrl: string): string {
+  return dataverseApiUrl(baseUrl, relativeUrl.replace(/^\/?api\/data\/v9\.[0-9]\//, ""));
+}
 
 export interface PluginStepRegistration {
   className: string;
@@ -54,7 +61,7 @@ async function getJson(context: DataversePowerToolsContext, relativeUrl: string)
   } as Options;
   /* eslint-enable @typescript-eslint/naming-convention */
 
-  const response = await fetch(`${baseUrl}${relativeUrl}`, options);
+  const response = await fetch(toApiUrl(baseUrl, relativeUrl), options);
   if (!response.ok) {
     context.channel.appendLine(await response.text());
     return undefined;
@@ -86,7 +93,7 @@ async function sendJson(context: DataversePowerToolsContext, method: "POST" | "P
   } as Options;
   /* eslint-enable @typescript-eslint/naming-convention */
 
-  const response = await fetch(`${baseUrl}${relativeUrl}`, options);
+  const response = await fetch(toApiUrl(baseUrl, relativeUrl), options);
   if (!response.ok) {
     context.channel.appendLine(await response.text());
     return undefined;
@@ -184,7 +191,7 @@ async function doesStepExistById(context: DataversePowerToolsContext, stepId: st
   } as Options;
   /* eslint-enable @typescript-eslint/naming-convention */
 
-  const response = await fetch(`${baseUrl}/api/data/v9.1/sdkmessageprocessingsteps(${stepId})?$select=sdkmessageprocessingstepid`, options);
+  const response = await fetch(toApiUrl(baseUrl, `/api/data/v9.1/sdkmessageprocessingsteps(${stepId})?$select=sdkmessageprocessingstepid`), options);
   if (response.ok) {
     return true;
   }

--- a/src/general/dataverse/registerPluginSteps.ts
+++ b/src/general/dataverse/registerPluginSteps.ts
@@ -2,7 +2,7 @@ import fetch from "node-fetch";
 import DataversePowerToolsContext from "../../context";
 import { addDataverseSolutionComponent } from "./addDataverseSolutionComponent";
 import { DataverseContext, Options } from "./dataverseContext";
-import { dataverseApiUrl } from "./webApi";
+import { dataverseApiUrl, logDataverseHttpError } from "./webApi";
 
 // The helpers below take "/api/data/v9.x/<resource>" relative urls; strip the version
 // segment and rebuild via the central helper so every request targets one API version.
@@ -63,7 +63,7 @@ async function getJson(context: DataversePowerToolsContext, relativeUrl: string)
 
   const response = await fetch(toApiUrl(baseUrl, relativeUrl), options);
   if (!response.ok) {
-    context.channel.appendLine(await response.text());
+    await logDataverseHttpError(context.channel, `GET ${relativeUrl}`, response);
     return undefined;
   }
 
@@ -95,7 +95,7 @@ async function sendJson(context: DataversePowerToolsContext, method: "POST" | "P
 
   const response = await fetch(toApiUrl(baseUrl, relativeUrl), options);
   if (!response.ok) {
-    context.channel.appendLine(await response.text());
+    await logDataverseHttpError(context.channel, `${method} ${relativeUrl}`, response);
     return undefined;
   }
 
@@ -200,7 +200,7 @@ async function doesStepExistById(context: DataversePowerToolsContext, stepId: st
     return false;
   }
 
-  context.channel.appendLine(await response.text());
+  await logDataverseHttpError(context.channel, `check plugin step '${stepId}'`, response);
   return false;
 }
 

--- a/src/general/dataverse/registerWorkflowActivities.ts
+++ b/src/general/dataverse/registerWorkflowActivities.ts
@@ -2,7 +2,7 @@ import fetch from "node-fetch";
 import DataversePowerToolsContext from "../../context";
 import { addDataverseSolutionComponent } from "./addDataverseSolutionComponent";
 import { DataverseContext, Options } from "./dataverseContext";
-import { dataverseApiUrl } from "./webApi";
+import { dataverseApiUrl, logDataverseHttpError } from "./webApi";
 
 // Callers pass "/api/data/v9.x/<resource>" relative urls; strip the version segment
 // and rebuild via the central helper so every request targets one API version.
@@ -81,7 +81,7 @@ async function getJson(context: DataversePowerToolsContext, relativeUrl: string)
 
   const response = await fetch(toApiUrl(baseUrl, relativeUrl), options);
   if (!response.ok) {
-    context.channel.appendLine(await response.text());
+    await logDataverseHttpError(context.channel, `GET ${relativeUrl}`, response);
     return undefined;
   }
 
@@ -116,7 +116,7 @@ async function patchJson(context: DataversePowerToolsContext, relativeUrl: strin
     return true;
   }
 
-  context.channel.appendLine(await response.text());
+  await logDataverseHttpError(context.channel, `PATCH ${relativeUrl}`, response);
   return false;
 }
 

--- a/src/general/dataverse/registerWorkflowActivities.ts
+++ b/src/general/dataverse/registerWorkflowActivities.ts
@@ -2,6 +2,13 @@ import fetch from "node-fetch";
 import DataversePowerToolsContext from "../../context";
 import { addDataverseSolutionComponent } from "./addDataverseSolutionComponent";
 import { DataverseContext, Options } from "./dataverseContext";
+import { dataverseApiUrl } from "./webApi";
+
+// Callers pass "/api/data/v9.x/<resource>" relative urls; strip the version segment
+// and rebuild via the central helper so every request targets one API version.
+function toApiUrl(baseUrl: string, relativeUrl: string): string {
+  return dataverseApiUrl(baseUrl, relativeUrl.replace(/^\/?api\/data\/v9\.[0-9]\//, ""));
+}
 
 export interface WorkflowActivityRegistration {
   className: string;
@@ -72,7 +79,7 @@ async function getJson(context: DataversePowerToolsContext, relativeUrl: string)
   } as Options;
   /* eslint-enable @typescript-eslint/naming-convention */
 
-  const response = await fetch(`${baseUrl}${relativeUrl}`, options);
+  const response = await fetch(toApiUrl(baseUrl, relativeUrl), options);
   if (!response.ok) {
     context.channel.appendLine(await response.text());
     return undefined;
@@ -104,7 +111,7 @@ async function patchJson(context: DataversePowerToolsContext, relativeUrl: strin
   } as Options;
   /* eslint-enable @typescript-eslint/naming-convention */
 
-  const response = await fetch(`${baseUrl}${relativeUrl}`, options);
+  const response = await fetch(toApiUrl(baseUrl, relativeUrl), options);
   if (response.ok) {
     return true;
   }

--- a/src/general/dataverse/webApi.spec.ts
+++ b/src/general/dataverse/webApi.spec.ts
@@ -1,5 +1,9 @@
-import { describe, it, expect } from "vitest";
-import { dataverseApiUrl, DATAVERSE_API_VERSION } from "./webApi";
+import { describe, it, expect, vi } from "vitest";
+import { dataverseApiUrl, DATAVERSE_API_VERSION, logDataverseHttpError, logDataverseError } from "./webApi";
+
+function fakeChannel() {
+  return { appendLine: vi.fn(), show: vi.fn() };
+}
 
 describe("dataverseApiUrl", () => {
   it("joins the org url and resource with the configured api version", () => {
@@ -11,10 +15,59 @@ describe("dataverseApiUrl", () => {
   });
 
   it("keeps query strings intact", () => {
-    expect(dataverseApiUrl("https://org.crm.dynamics.com", "solutions?$select=solutionid")).toBe(`https://org.crm.dynamics.com/api/data/${DATAVERSE_API_VERSION}/solutions?$select=solutionid`);
+    expect(dataverseApiUrl("https://org.crm.dynamics.com", "solutions?$select=solutionid")).toBe(
+      `https://org.crm.dynamics.com/api/data/${DATAVERSE_API_VERSION}/solutions?$select=solutionid`,
+    );
   });
 
   it("handles a missing org url", () => {
     expect(dataverseApiUrl(undefined, "WhoAmI")).toBe(`/api/data/${DATAVERSE_API_VERSION}/WhoAmI`);
+  });
+});
+
+describe("logDataverseHttpError", () => {
+  it("logs the operation, status line, and body, and surfaces the channel", async () => {
+    const channel = fakeChannel();
+    const body = await logDataverseHttpError(channel, "load tables", {
+      status: 401,
+      statusText: "Unauthorized",
+      text: async () => "token expired",
+    });
+    expect(body).toBe("token expired");
+    expect(channel.appendLine).toHaveBeenCalledWith("Failed to load tables: 401 Unauthorized — token expired");
+    expect(channel.show).toHaveBeenCalled();
+  });
+
+  it("omits the body separator when the response body is empty", async () => {
+    const channel = fakeChannel();
+    await logDataverseHttpError(channel, "load messages", { status: 500, statusText: "", text: async () => "" });
+    expect(channel.appendLine).toHaveBeenCalledWith("Failed to load messages: 500");
+  });
+
+  it("still logs when reading the body throws", async () => {
+    const channel = fakeChannel();
+    await logDataverseHttpError(channel, "load forms", {
+      status: 502,
+      statusText: "Bad Gateway",
+      text: async () => {
+        throw new Error("stream closed");
+      },
+    });
+    expect(channel.appendLine).toHaveBeenCalledWith("Failed to load forms: 502 Bad Gateway");
+  });
+});
+
+describe("logDataverseError", () => {
+  it("logs an Error message with context and surfaces the channel", () => {
+    const channel = fakeChannel();
+    logDataverseError(channel, "load solutions", new Error("network down"));
+    expect(channel.appendLine).toHaveBeenCalledWith("Error while trying to load solutions: network down");
+    expect(channel.show).toHaveBeenCalled();
+  });
+
+  it("stringifies non-Error throwables", () => {
+    const channel = fakeChannel();
+    logDataverseError(channel, "load attributes", { code: 42 });
+    expect(channel.appendLine).toHaveBeenCalledWith('Error while trying to load attributes: {"code":42}');
   });
 });

--- a/src/general/dataverse/webApi.spec.ts
+++ b/src/general/dataverse/webApi.spec.ts
@@ -1,0 +1,20 @@
+import { describe, it, expect } from "vitest";
+import { dataverseApiUrl, DATAVERSE_API_VERSION } from "./webApi";
+
+describe("dataverseApiUrl", () => {
+  it("joins the org url and resource with the configured api version", () => {
+    expect(dataverseApiUrl("https://org.crm.dynamics.com", "WhoAmI")).toBe(`https://org.crm.dynamics.com/api/data/${DATAVERSE_API_VERSION}/WhoAmI`);
+  });
+
+  it("tolerates trailing/leading slashes on either part", () => {
+    expect(dataverseApiUrl("https://org.crm.dynamics.com/", "/webresourceset")).toBe(`https://org.crm.dynamics.com/api/data/${DATAVERSE_API_VERSION}/webresourceset`);
+  });
+
+  it("keeps query strings intact", () => {
+    expect(dataverseApiUrl("https://org.crm.dynamics.com", "solutions?$select=solutionid")).toBe(`https://org.crm.dynamics.com/api/data/${DATAVERSE_API_VERSION}/solutions?$select=solutionid`);
+  });
+
+  it("handles a missing org url", () => {
+    expect(dataverseApiUrl(undefined, "WhoAmI")).toBe(`/api/data/${DATAVERSE_API_VERSION}/WhoAmI`);
+  });
+});

--- a/src/general/dataverse/webApi.ts
+++ b/src/general/dataverse/webApi.ts
@@ -15,3 +15,42 @@ export function dataverseApiUrl(organizationUrl: string | undefined | null, reso
   const resource = (resourcePath ?? "").replace(/^\/+/, "");
   return `${base}/api/data/${DATAVERSE_API_VERSION}/${resource}`;
 }
+
+/** Minimal output-channel surface the error helpers need (VS Code's OutputChannel satisfies it). */
+export interface DataverseLogChannel {
+  appendLine(value: string): void;
+  show(preserveFocus?: boolean): void;
+}
+
+/** Minimal HTTP-response surface the error helpers need (node-fetch's Response satisfies it). */
+export interface DataverseHttpResponse {
+  status: number;
+  statusText: string;
+  text(): Promise<string>;
+}
+
+/**
+ * Log a failed Dataverse HTTP response with consistent context — the operation that
+ * was attempted, the status line, and the response body — then surface the output
+ * channel. Returns the raw body so callers can inspect it (e.g. detect a specific
+ * error signature) without reading the stream twice.
+ */
+export async function logDataverseHttpError(channel: DataverseLogChannel, operation: string, response: DataverseHttpResponse): Promise<string> {
+  let body = "";
+  try {
+    body = await response.text();
+  } catch {
+    /* ignore body read failure */
+  }
+  const status = `${response.status}${response.statusText ? ` ${response.statusText}` : ""}`.trim();
+  channel.appendLine(`Failed to ${operation}: ${status}${body ? ` — ${body}` : ""}`);
+  channel.show();
+  return body;
+}
+
+/** Log a thrown error from a Dataverse operation with consistent context, then surface the channel. */
+export function logDataverseError(channel: DataverseLogChannel, operation: string, error: unknown): void {
+  const message = error instanceof Error ? error.message : typeof error === "string" ? error : JSON.stringify(error);
+  channel.appendLine(`Error while trying to ${operation}: ${message}`);
+  channel.show();
+}

--- a/src/general/dataverse/webApi.ts
+++ b/src/general/dataverse/webApi.ts
@@ -4,6 +4,26 @@
 /** The Web API version the extension targets. */
 export const DATAVERSE_API_VERSION = "v9.2";
 
+const SLASH = "/".charCodeAt(0);
+
+/** Remove trailing "/" characters. Non-regex (linear) to avoid backtracking on input. */
+export function stripTrailingSlashes(value: string): string {
+  let end = value.length;
+  while (end > 0 && value.charCodeAt(end - 1) === SLASH) {
+    end--;
+  }
+  return value.slice(0, end);
+}
+
+/** Remove leading "/" characters. Non-regex (linear) to avoid backtracking on input. */
+export function stripLeadingSlashes(value: string): string {
+  let start = 0;
+  while (start < value.length && value.charCodeAt(start) === SLASH) {
+    start++;
+  }
+  return value.slice(start);
+}
+
 /**
  * Build a Dataverse Web API URL from the organization URL and a resource path, e.g.
  * dataverseApiUrl("https://org.crm.dynamics.com", "WhoAmI") ->
@@ -11,8 +31,8 @@ export const DATAVERSE_API_VERSION = "v9.2";
  * slashes on either part.
  */
 export function dataverseApiUrl(organizationUrl: string | undefined | null, resourcePath: string): string {
-  const base = (organizationUrl ?? "").replace(/\/+$/, "");
-  const resource = (resourcePath ?? "").replace(/^\/+/, "");
+  const base = stripTrailingSlashes(organizationUrl ?? "");
+  const resource = stripLeadingSlashes(resourcePath ?? "");
   return `${base}/api/data/${DATAVERSE_API_VERSION}/${resource}`;
 }
 

--- a/src/general/dataverse/webApi.ts
+++ b/src/general/dataverse/webApi.ts
@@ -1,0 +1,17 @@
+// Single source of truth for the Dataverse Web API base URL + version, so call sites
+// don't hand-build `${org}/api/data/v9.x/...` inconsistently (versions were mixed).
+
+/** The Web API version the extension targets. */
+export const DATAVERSE_API_VERSION = "v9.2";
+
+/**
+ * Build a Dataverse Web API URL from the organization URL and a resource path, e.g.
+ * dataverseApiUrl("https://org.crm.dynamics.com", "WhoAmI") ->
+ * "https://org.crm.dynamics.com/api/data/v9.2/WhoAmI". Tolerates leading/trailing
+ * slashes on either part.
+ */
+export function dataverseApiUrl(organizationUrl: string | undefined | null, resourcePath: string): string {
+  const base = (organizationUrl ?? "").replace(/\/+$/, "");
+  const resource = (resourcePath ?? "").replace(/^\/+/, "");
+  return `${base}/api/data/${DATAVERSE_API_VERSION}/${resource}`;
+}

--- a/src/general/generateTemplates.ts
+++ b/src/general/generateTemplates.ts
@@ -373,7 +373,7 @@ export async function generateTemplates(context: DataversePowerToolsContext) {
   }
   const folderPath = vscode.workspace.workspaceFolders[0].uri.fsPath;
   var templateFilePath = context.vscode.asAbsolutePath(path.join("templates", context.projectSettings.type));
-  const templateToCopy = JSON.parse(fs.readFileSync(templateFilePath + "\\template.json", "utf8")).find(
+  const templateToCopy = JSON.parse(fs.readFileSync(path.join(templateFilePath, "template.json"), "utf8")).find(
     (t: PowertoolsTemplate) => t.version === context.projectSettings.templateversion,
   ) as PowertoolsTemplate;
   if (!templateToCopy) {
@@ -395,7 +395,7 @@ export async function generateTemplates(context: DataversePowerToolsContext) {
   context.projectSettings.placeholders = placeholders;
   templateToCopy.files?.every(async (f) => {
     const extension = f.extension === ".tstemplate" ? ".ts" : f.extension; // This is done because the .ts files do not copy into the published extension thus we overwrite it when actually copying from extension into the code
-    var data = fs.readFileSync(templateFilePath + "\\" + f.filename + f.extension + "\\" + f.version + f.extension, "utf8");
+    var data = fs.readFileSync(path.join(templateFilePath, f.filename + f.extension, f.version + f.extension), "utf8");
     data = data.replace(/\SOLUTIONPREFIX/g, context.projectSettings.prefix || "SOLUTIONPREFIX");
     data = data.replace(/\SOLUTIONPLACEHOLDER/g, context.projectSettings.solutionName || "SOLUTIONPLACEHOLDER");
     const destPath = f.path;
@@ -425,7 +425,7 @@ export async function createTemplatedFile(
 ) {
   if (context.projectSettings.type && context.projectSettings.templateversion && vscode.workspace.workspaceFolders) {
     var fullFilePath = context.vscode.asAbsolutePath(path.join("templates", context.projectSettings.type));
-    var templates = JSON.parse(fs.readFileSync(fullFilePath + "\\template.json", "utf8")) as Array<PowertoolsTemplate>;
+    var templates = JSON.parse(fs.readFileSync(path.join(fullFilePath, "template.json"), "utf8")) as Array<PowertoolsTemplate>;
     var templateToCopy = {} as PowertoolsTemplate;
     for (const t of templates) {
       if (t.version === context.projectSettings.templateversion) {
@@ -438,7 +438,7 @@ export async function createTemplatedFile(
         const pluginTemplate = templateToCopy.files.find((x) => x.filename === sourceFilename);
         if (pluginTemplate !== undefined) {
           var data = fs.readFileSync(
-            fullFilePath + "\\" + pluginTemplate.filename + pluginTemplate.extension + "\\" + context.projectSettings.templateversion + pluginTemplate.extension,
+            path.join(fullFilePath, pluginTemplate.filename + pluginTemplate.extension, `${context.projectSettings.templateversion}${pluginTemplate.extension}`),
             "utf8",
           );
           if (vscode.workspace.workspaceFolders) {

--- a/src/portals/connectPortal.ts
+++ b/src/portals/connectPortal.ts
@@ -2,6 +2,8 @@ import * as vscode from "vscode";
 import * as cp from "child_process";
 import DataversePowerToolsContext from "../context";
 import { window } from "vscode";
+import { getOrganizationUrl } from "../general/connectionString";
+import { parsePacAuthList, findAuthProfileForUrl, parsePacPagesList } from "./pacOutput";
 import path = require("path");
 
 export async function connectPortal(context: DataversePowerToolsContext, command: string) {
@@ -84,19 +86,22 @@ export async function connectPortalExec(context: DataversePowerToolsContext, pac
     try {
       const stdout = await runPac(context, pacLocation, ["auth", "list"]);
       if (stdout !== null && stdout !== "") {
-        const connectionStringSplit = context.connectionString.substring(context.connectionString.indexOf("Url=") + 4, context.connectionString.length - 1);
-        const name = connectionStringSplit.split(";")[0];
-        const arrayOfString = stdout.replace(/\s\s+/g, " ").split(" ");
-        const indexOfName = arrayOfString.findIndex((x) => x.includes(name)) - 1;
-        const nameOfPortal = arrayOfString[indexOfName];
-        context.channel.appendLine(nameOfPortal || "");
-        context.channel.show();
         context.channel.appendLine(stdout);
-        if (!nameOfPortal) {
+        const targetUrl = getOrganizationUrl(context.connectionString);
+        const profile = findAuthProfileForUrl(parsePacAuthList(stdout), targetUrl);
+        if (!profile) {
           vscode.window.showErrorMessage("Error finding matching portal.");
-          await createPACConnection(context, pacLocation, name);
+          await createPACConnection(context, pacLocation, targetUrl);
         } else {
-          await selectEnvironment(context, pacLocation, nameOfPortal);
+          // Prefer selecting by profile name; fall back to its index when unnamed.
+          const selector = profile.name ? ["-n", profile.name] : profile.index !== undefined ? ["--index", String(profile.index)] : undefined;
+          if (!selector) {
+            vscode.window.showErrorMessage("Error finding matching portal.");
+            return;
+          }
+          context.channel.appendLine(`Selecting auth profile: ${profile.name || `#${profile.index}`}`);
+          context.channel.show();
+          await selectEnvironment(context, pacLocation, selector);
         }
       }
     } catch (error: any) {
@@ -107,27 +112,15 @@ export async function connectPortalExec(context: DataversePowerToolsContext, pac
   }
 }
 
-export async function selectEnvironment(context: DataversePowerToolsContext, pacLocation: string, name: string) {
+export async function selectEnvironment(context: DataversePowerToolsContext, pacLocation: string, selector: string[]) {
   if (vscode.workspace.workspaceFolders !== undefined) {
     try {
-      const stdout = await runPac(context, pacLocation, ["auth", "select", "-n", name]);
+      const stdout = await runPac(context, pacLocation, ["auth", "select", ...selector]);
       if (stdout !== null && stdout !== "") {
-        const connectionStringSplit = context.connectionString.substring(context.connectionString.indexOf("Url=") + 4, context.connectionString.length - 1);
-        const currentName = connectionStringSplit.split(";")[0];
-        const arrayOfString = stdout.replace(/\s\s+/g, " ").split(" ");
-        const indexOfName = arrayOfString.findIndex((x) => x === currentName) - 1;
-        const nameOfPortal = arrayOfString[indexOfName];
-        context.channel.appendLine(nameOfPortal || "");
+        context.channel.appendLine(stdout);
         context.channel.show();
-
-        const authListOutput = await runPac(context, pacLocation, ["auth", "list"]);
-        if (authListOutput !== null && authListOutput !== "") {
-          context.channel.appendLine(nameOfPortal || "");
-          context.channel.show();
-          context.channel.appendLine(authListOutput);
-          await downloadPortal(context, pacLocation);
-        }
       }
+      await downloadPortal(context, pacLocation);
     } catch (error: any) {
       vscode.window.showErrorMessage("Error finding Portals.");
       context.channel.appendLine(error?.error?.message || error?.message || JSON.stringify(error));
@@ -142,12 +135,14 @@ export async function downloadPortal(context: DataversePowerToolsContext, pacLoc
     try {
       const stdout = await runPac(context, pacLocation, ["pages", "list"]);
       if (stdout !== null && stdout !== "") {
-        const arrayOfString = stdout.replace(/\s\s+/g, "\r").split("\r");
-        const indexBeforeInformation = arrayOfString.findIndex((x) => x === "Friendly Name") + 1;
-        const quickPickArray: { label: string; target: string }[] = [];
-        for (let i = indexBeforeInformation; i <= arrayOfString.length - 2; i += 3) {
-          quickPickArray.push({ label: arrayOfString[i + 2], target: arrayOfString[i + 1] });
+        context.channel.appendLine(stdout);
+        const pages = parsePacPagesList(stdout);
+        if (pages.length === 0) {
+          vscode.window.showErrorMessage("No Power Pages websites were found in this environment.");
+          context.channel.show();
+          return;
         }
+        const quickPickArray = pages.map((page) => ({ label: page.friendlyName || page.websiteId, target: page.websiteId }));
 
         const result = await window.showQuickPick(quickPickArray, { placeHolder: "Select a Power Pages website." });
         if (!result?.target) {
@@ -159,10 +154,8 @@ export async function downloadPortal(context: DataversePowerToolsContext, pacLoc
         const downloadOutput = await runPac(context, pacLocation, ["pages", "download", "-id", result.target, "-p", downloadPath]);
         if (downloadOutput !== null && downloadOutput !== "") {
           context.channel.appendLine(downloadOutput);
-          context.channel.show();
         }
         context.channel.show();
-        context.channel.appendLine(stdout);
       }
     } catch (error: any) {
       vscode.window.showErrorMessage("Error finding Portals.");

--- a/src/portals/pacOutput.spec.ts
+++ b/src/portals/pacOutput.spec.ts
@@ -1,0 +1,92 @@
+import { describe, it, expect } from "vitest";
+import { parsePacAuthList, parsePacPagesList, findAuthProfileForUrl, parsePacTable } from "./pacOutput";
+
+// Real `pac auth list` output captured from pac 2.8.1. Note two things that broke the
+// old whitespace-splitting parser: the "Name" cell is empty for the first profile, and
+// the "Environment" cell of the second is a display name WITH SPACES ("Peter McDonald's
+// Environment") sitting right before the Environment Url column.
+const REAL_AUTH_LIST = [
+  "Index Active Kind      Name              User                                 Cloud  Type            Environment                  Environment Url",
+  "[1]          UNIVERSAL                   Peter.Mcdonald@nrmmrrd.qld.gov.au    Public OperatingSystem                              ",
+  "[2]   *      UNIVERSAL dvpt-portal-probe f906614e-e545-4be0-a5e6-e802941fb305 Public Application     Peter McDonald's Environment https://org32218dcd.crm11.dynamics.com/",
+  "",
+].join("\r\n");
+
+describe("parsePacAuthList", () => {
+  it("parses every profile including empty and space-containing cells", () => {
+    const profiles = parsePacAuthList(REAL_AUTH_LIST);
+    expect(profiles).toHaveLength(2);
+
+    expect(profiles[0]).toEqual({ index: 1, active: false, name: "", environmentUrl: "" });
+    expect(profiles[1]).toEqual({
+      index: 2,
+      active: true,
+      name: "dvpt-portal-probe",
+      environmentUrl: "https://org32218dcd.crm11.dynamics.com/",
+    });
+  });
+
+  it("returns [] when there is no table (e.g. an error message)", () => {
+    expect(parsePacAuthList("Error: not authenticated")).toEqual([]);
+  });
+});
+
+describe("findAuthProfileForUrl", () => {
+  const profiles = parsePacAuthList(REAL_AUTH_LIST);
+
+  it("matches the profile for a url ignoring scheme and trailing slash", () => {
+    const match = findAuthProfileForUrl(profiles, "https://org32218dcd.crm11.dynamics.com");
+    expect(match?.name).toBe("dvpt-portal-probe");
+  });
+
+  it("matches when the connection string host has no scheme", () => {
+    const match = findAuthProfileForUrl(profiles, "org32218dcd.crm11.dynamics.com");
+    expect(match?.name).toBe("dvpt-portal-probe");
+  });
+
+  it("returns undefined when no profile matches", () => {
+    expect(findAuthProfileForUrl(profiles, "https://other.crm.dynamics.com")).toBeUndefined();
+  });
+});
+
+describe("parsePacPagesList", () => {
+  it("parses website id and friendly name (friendly names may contain spaces)", () => {
+    const output = [
+      "Connected as f906614e-e545-4be0-a5e6-e802941fb305",
+      "Connected to... Contoso Environment",
+      "",
+      "Index Name              WebSiteId                            Data Model",
+      "[1]   Contoso Marketing d44574f9-acc3-4ccc-8d8d-85cf5b7ad141 Enhanced",
+      "[2]   Support Site      a1b2c3d4-1111-2222-3333-444455556666 Standard",
+      "",
+    ].join("\r\n");
+
+    const pages = parsePacPagesList(output);
+    expect(pages).toEqual([
+      { websiteId: "d44574f9-acc3-4ccc-8d8d-85cf5b7ad141", friendlyName: "Contoso Marketing" },
+      { websiteId: "a1b2c3d4-1111-2222-3333-444455556666", friendlyName: "Support Site" },
+    ]);
+  });
+
+  it("tolerates the 'Friendly Name' / 'Website Id' header spellings", () => {
+    // Built with padEnd so header labels and data cells share exact column offsets.
+    const header = "Index".padEnd(6) + "Website Id".padEnd(37) + "Friendly Name";
+    const row = "[1]".padEnd(6) + "d44574f9-acc3-4ccc-8d8d-85cf5b7ad141".padEnd(37) + "My Portal";
+    const output = [header, row, ""].join("\r\n");
+    expect(parsePacPagesList(output)).toEqual([{ websiteId: "d44574f9-acc3-4ccc-8d8d-85cf5b7ad141", friendlyName: "My Portal" }]);
+  });
+
+  it("returns [] when no websites exist", () => {
+    expect(parsePacPagesList("No Power Pages website records exist")).toEqual([]);
+  });
+});
+
+describe("parsePacTable", () => {
+  it("skips headers that are not present rather than misaligning the rest", () => {
+    const output = ["Index Name    Value", "[1]   Alpha   100", ""].join("\r\n");
+    const rows = parsePacTable(output, ["Index", "Name", "Missing", "Value"]);
+    // Rows are keyed by pac's literal (PascalCase) header names.
+    // eslint-disable-next-line @typescript-eslint/naming-convention
+    expect(rows).toEqual([{ Index: "[1]", Name: "Alpha", Value: "100" }]);
+  });
+});

--- a/src/portals/pacOutput.ts
+++ b/src/portals/pacOutput.ts
@@ -10,6 +10,8 @@
 // widest cell and prints each header at that column's start offset, so slicing data
 // rows at the header offsets is stable regardless of spacing or in-cell spaces.
 
+import { stripTrailingSlashes } from "../general/dataverse/webApi";
+
 export interface PacTableRow {
   [header: string]: string;
 }
@@ -124,12 +126,7 @@ export function parsePacAuthList(output: string): PacAuthProfile[] {
  * undefined if none line up.
  */
 export function findAuthProfileForUrl(profiles: PacAuthProfile[], environmentUrl: string): PacAuthProfile | undefined {
-  const normalize = (value: string): string =>
-    value
-      .trim()
-      .replace(/^https?:\/\//i, "")
-      .replace(/\/+$/, "")
-      .toLowerCase();
+  const normalize = (value: string): string => stripTrailingSlashes(value.trim().replace(/^https?:\/\//i, "")).toLowerCase();
   const target = normalize(environmentUrl);
   if (!target) {
     return undefined;

--- a/src/portals/pacOutput.ts
+++ b/src/portals/pacOutput.ts
@@ -1,0 +1,159 @@
+// Pure parsers for `pac` CLI output — no `vscode`/`child_process`, so they unit-test
+// without an editor or a live environment.
+//
+// The portal commands used to reverse-engineer pac's human-readable table by
+// whitespace-splitting and index arithmetic, which broke the moment a value
+// contained a space (e.g. an environment display name like "Contoso Ltd") or pac
+// nudged its column widths. pac's `auth list` / `pages list` verbs do NOT support
+// `--json` (as of pac 2.8.x — only some verbs like `org list` do), so instead of
+// scraping we anchor on the documented column HEADERS: pac pads every column to its
+// widest cell and prints each header at that column's start offset, so slicing data
+// rows at the header offsets is stable regardless of spacing or in-cell spaces.
+
+export interface PacTableRow {
+  [header: string]: string;
+}
+
+interface Column {
+  name: string;
+  start: number;
+}
+
+/**
+ * Find `header` in `line` as a standalone column label — bounded by whitespace (or
+ * the line edges) and not overlapping a span already claimed by a longer header —
+ * and return its start offset, or -1. The boundary check stops "Name" from matching
+ * inside "Friendly Name" and the claimed-span check stops it from matching the tail
+ * of a longer header that was located first.
+ */
+function indexOfHeader(line: string, header: string, claimed: Array<[number, number]>): number {
+  let from = 0;
+  for (;;) {
+    const idx = line.indexOf(header, from);
+    if (idx === -1) {
+      return -1;
+    }
+    const before = idx === 0 ? " " : line[idx - 1];
+    const afterIdx = idx + header.length;
+    const after = afterIdx >= line.length ? " " : line[afterIdx];
+    const overlapsClaimed = claimed.some(([s, e]) => idx < e && afterIdx > s);
+    if (before === " " && after === " " && !overlapsClaimed) {
+      return idx;
+    }
+    from = idx + 1;
+  }
+}
+
+/** Locate the start offset of each expected header present in the header line. */
+function locateColumns(headerLine: string, headers: string[]): Column[] {
+  const claimed: Array<[number, number]> = [];
+  const found: Column[] = [];
+  // Longest labels first so "Friendly Name" claims its span before "Name" is sought.
+  for (const name of [...headers].sort((a, b) => b.length - a.length)) {
+    const start = indexOfHeader(headerLine, name, claimed);
+    if (start === -1) {
+      continue;
+    }
+    claimed.push([start, start + name.length]);
+    found.push({ name, start });
+  }
+  return found.sort((a, b) => a.start - b.start);
+}
+
+function sliceRow(line: string, columns: Column[]): PacTableRow {
+  const row: PacTableRow = {};
+  for (let i = 0; i < columns.length; i++) {
+    const start = columns[i].start;
+    const end = i + 1 < columns.length ? columns[i + 1].start : line.length;
+    row[columns[i].name] = line.slice(start, end).trim();
+  }
+  return row;
+}
+
+/**
+ * Parse a pac fixed-width table into row objects keyed by header. `headers` is the
+ * set of expected column labels; any not found are skipped (so a renamed or extra
+ * column doesn't break the rest). Returns [] if no header line is found.
+ */
+export function parsePacTable(output: string, headers: string[]): PacTableRow[] {
+  const lines = output.split(/\r?\n/);
+  const headerLineIndex = lines.findIndex((line) => headers.filter((h) => indexOfHeader(line, h, []) !== -1).length >= 2);
+  if (headerLineIndex === -1) {
+    return [];
+  }
+  const columns = locateColumns(lines[headerLineIndex], headers);
+  if (columns.length === 0) {
+    return [];
+  }
+  const rows: PacTableRow[] = [];
+  for (const line of lines.slice(headerLineIndex + 1)) {
+    if (line.trim().length === 0) {
+      continue;
+    }
+    rows.push(sliceRow(line, columns));
+  }
+  return rows;
+}
+
+export interface PacAuthProfile {
+  index?: number;
+  active: boolean;
+  name: string;
+  environmentUrl: string;
+}
+
+// Documented `pac auth list` columns, left-to-right.
+const AUTH_LIST_HEADERS = ["Index", "Active", "Kind", "Name", "User", "Cloud", "Type", "Environment", "Environment Url"];
+
+export function parsePacAuthList(output: string): PacAuthProfile[] {
+  return parsePacTable(output, AUTH_LIST_HEADERS).map((row) => {
+    const rawIndex = (row["Index"] ?? "").replace(/[[\]]/g, "");
+    const parsedIndex = Number.parseInt(rawIndex, 10);
+    return {
+      index: Number.isNaN(parsedIndex) ? undefined : parsedIndex,
+      active: row["Active"] === "*",
+      name: row["Name"] ?? "",
+      environmentUrl: row["Environment Url"] ?? "",
+    };
+  });
+}
+
+/**
+ * Find the auth profile whose environment matches `environmentUrl` (host-insensitive
+ * to a trailing slash / scheme differences). Returns the matching profile, or
+ * undefined if none line up.
+ */
+export function findAuthProfileForUrl(profiles: PacAuthProfile[], environmentUrl: string): PacAuthProfile | undefined {
+  const normalize = (value: string): string =>
+    value
+      .trim()
+      .replace(/^https?:\/\//i, "")
+      .replace(/\/+$/, "")
+      .toLowerCase();
+  const target = normalize(environmentUrl);
+  if (!target) {
+    return undefined;
+  }
+  return profiles.find((profile) => {
+    const candidate = normalize(profile.environmentUrl);
+    return candidate.length > 0 && (candidate === target || candidate.includes(target) || target.includes(candidate));
+  });
+}
+
+export interface PacPage {
+  websiteId: string;
+  friendlyName: string;
+}
+
+// `pac pages list` column spellings seen across pac versions. Only the two fields we
+// need — the website id (passed to `pac pages download -id`) and the friendly name.
+const PAGES_LIST_HEADERS = ["Index", "Friendly Name", "Name", "WebSiteId", "Website Id", "Data Model", "DataModel", "Data Model Version"];
+
+export function parsePacPagesList(output: string): PacPage[] {
+  return parsePacTable(output, PAGES_LIST_HEADERS)
+    .map((row) => ({
+      websiteId: row["WebSiteId"] ?? row["Website Id"] ?? "",
+      friendlyName: row["Friendly Name"] ?? row["Name"] ?? "",
+    }))
+    .filter((page) => page.websiteId.length > 0);
+}

--- a/src/ui-test/activityBar.test.ts
+++ b/src/ui-test/activityBar.test.ts
@@ -10,7 +10,7 @@ import { ActivityBar, VSBrowser, ViewControl } from "vscode-extension-tester";
 async function dismissOverlays(): Promise<void> {
   try {
     await VSBrowser.instance.driver.executeScript(
-      "for (const s of ['.onboarding-a-overlay','.monaco-dialog-box','.notification-toast','.notifications-toasts']) { document.querySelectorAll(s).forEach(function(e){ e.remove(); }); }",
+      "for (const s of ['.onboarding-a-overlay','.monaco-dialog-box','.monaco-dialog-modal-block','.notification-toast','.notifications-toasts']) { document.querySelectorAll(s).forEach(function(e){ e.remove(); }); }",
     );
   } catch {
     /* ignore */

--- a/src/ui-test/activityBar.test.ts
+++ b/src/ui-test/activityBar.test.ts
@@ -1,12 +1,11 @@
 import * as assert from "assert";
-import { ActivityBar, VSBrowser } from "vscode-extension-tester";
+import { ActivityBar, VSBrowser, ViewControl } from "vscode-extension-tester";
 
-// True UI-level test driven by ExTester (Selenium/WebDriver against the real
+// True UI-level tests driven by ExTester (Selenium/WebDriver against the real
 // VS Code UI). Use this layer only for things the extension-host API can't
 // assert directly. Kept resilient to CI flakiness: strip VS Code's onboarding
-// overlay (which intercepts interaction on a fresh install) and poll for the
-// view control instead of asserting on the first try. `retries` is set in
-// .mocharc-ui.json.
+// overlay (which intercepts interaction on a fresh install) and poll instead of
+// asserting on the first try. `retries` is set in .mocharc-ui.json.
 
 async function dismissOverlays(): Promise<void> {
   try {
@@ -22,6 +21,19 @@ function sleep(ms: number): Promise<void> {
   return new Promise((r) => setTimeout(r, ms));
 }
 
+/** Poll for the Dataverse PowerTools activity-bar view control (fresh installs are slow). */
+async function getViewControl(): Promise<ViewControl | undefined> {
+  let control: ViewControl | undefined;
+  for (let i = 0; i < 12 && !control; i++) {
+    await dismissOverlays();
+    control = await new ActivityBar().getViewControl("Dataverse PowerTools");
+    if (!control) {
+      await sleep(1000);
+    }
+  }
+  return control;
+}
+
 describe("Dataverse PowerTools activity bar", function () {
   this.timeout(120000);
 
@@ -32,14 +44,33 @@ describe("Dataverse PowerTools activity bar", function () {
   });
 
   it("contributes the Dataverse PowerTools view container", async () => {
-    let control;
-    for (let i = 0; i < 12 && !control; i++) {
-      await dismissOverlays();
-      control = await new ActivityBar().getViewControl("Dataverse PowerTools");
-      if (!control) {
+    const control = await getViewControl();
+    assert.ok(control, "Expected the Dataverse PowerTools view container in the activity bar");
+  });
+
+  it("renders its contributed tree views", async () => {
+    const control = await getViewControl();
+    assert.ok(control, "Expected the Dataverse PowerTools view container");
+    const sideBar = await control.openView();
+    await sleep(1000);
+    await dismissOverlays();
+
+    let titles: string[] = [];
+    for (let i = 0; i < 10 && titles.length === 0; i++) {
+      try {
+        const sections = await sideBar.getContent().getSections();
+        titles = await Promise.all(sections.map((s) => s.getTitle().catch(() => "")));
+      } catch {
+        /* view still rendering */
+      }
+      if (titles.length === 0) {
         await sleep(1000);
       }
     }
-    assert.ok(control, "Expected the Dataverse PowerTools view container in the activity bar");
+
+    assert.ok(
+      titles.some((t) => /System Requirements|Local Settings|Actions/i.test(t)),
+      `Expected a known Dataverse PowerTools view section; got: [${titles.join(", ")}]`,
+    );
   });
 });

--- a/src/ui-test/connectLog.ts
+++ b/src/ui-test/connectLog.ts
@@ -1,0 +1,98 @@
+import * as path from "path";
+import * as fs from "fs";
+import { VSBrowser, Workbench, InputBox } from "vscode-extension-tester";
+
+// Local generator (NOT a .test.ts, so not in the CI glob). Connects to the REAL test
+// environment via the service-principal wizard (headless — no browser), deploys the
+// bin/dvpt_library.js webresource bundle, then opens the Dataverse PowerTools output
+// channel and screenshots it — real logs, real connection. Reads creds from the
+// gitignored sandbox/.env; skips if absent.
+const repoRoot = path.resolve(__dirname, "..", "..");
+const outDir = path.resolve(repoRoot, "sandbox", "screenshots-out");
+const fixture = path.resolve(repoRoot, "sandbox", "screens", "connect");
+
+function loadEnv(): Record<string, string> {
+  const p = path.resolve(repoRoot, "sandbox", ".env");
+  const out: Record<string, string> = {};
+  if (!fs.existsSync(p)) {
+    return out;
+  }
+  for (const line of fs.readFileSync(p, "utf8").split(/\r?\n/)) {
+    const t = line.trim();
+    if (!t || t.startsWith("#")) {
+      continue;
+    }
+    const i = t.indexOf("=");
+    if (i > 0) {
+      out[t.slice(0, i).trim()] = t.slice(i + 1).trim();
+    }
+  }
+  return out;
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((r) => setTimeout(r, ms));
+}
+
+async function dismissOverlays(): Promise<void> {
+  try {
+    await VSBrowser.instance.driver.executeScript(
+      "for (const s of ['.onboarding-a-overlay','.monaco-dialog-box','.monaco-dialog-modal-block','.notifications-toasts','.notification-toast']) { document.querySelectorAll(s).forEach(function(e){ e.remove(); }); }",
+    );
+  } catch {
+    /* ignore */
+  }
+  await sleep(300);
+}
+
+// Answer the next wizard step: select from a quick pick (by label, or the first item)
+// or type into an input box and confirm.
+async function answer(value: string, byLabel = false): Promise<void> {
+  const input = await InputBox.create(25000);
+  let picks: unknown[] = [];
+  try {
+    picks = await input.getQuickPicks();
+  } catch {
+    picks = [];
+  }
+  if (picks.length > 0) {
+    await input.selectQuickPick(byLabel ? value : 0);
+  } else {
+    await input.setText(value);
+    await input.confirm();
+  }
+  await sleep(2500);
+}
+
+describe("Dataverse PowerTools connect + log", function () {
+  this.timeout(300000);
+  const env = loadEnv();
+
+  before(async function () {
+    if (!env.DVPT_TEST_CLIENT_ID || !fs.existsSync(fixture)) {
+      this.skip();
+    }
+    fs.mkdirSync(outDir, { recursive: true });
+    await VSBrowser.instance.openResources(fixture);
+    await VSBrowser.instance.waitForWorkbench();
+    await sleep(3500);
+    await dismissOverlays();
+  });
+
+  it("connects with real creds, deploys a webresource, and captures the log", async () => {
+    // readSettings triggers the connection wizard on load (client secret, no stored secret).
+    await answer("Service principal (client secret)", true);
+    await answer(env.DVPT_TEST_TENANT_ID);
+    await answer(env.DVPT_TEST_CLIENT_ID);
+    await answer(env.DVPT_TEST_CLIENT_SECRET);
+    await answer(env.DVPT_TEST_URL); // environment pick (or manual url)
+    await answer(env.DVPT_TEST_SOLUTION_NAME || "dvpttests"); // solution pick (or manual)
+    await sleep(6000);
+    await dismissOverlays();
+
+    await new Workbench().executeCommand("Dataverse PowerTools: Show Log");
+    await sleep(3000);
+    const img = await VSBrowser.instance.driver.takeScreenshot();
+    fs.writeFileSync(path.join(outDir, "connect-log.png"), img, "base64");
+  });
+});

--- a/src/ui-test/connectLog.ts
+++ b/src/ui-test/connectLog.ts
@@ -90,6 +90,12 @@ describe("Dataverse PowerTools connect + log", function () {
     await sleep(6000);
     await dismissOverlays();
 
+    // Real build + deploy: runs `webpack --config webpack.dev.js` in the fixture
+    // (emits bin/dvpt_library.js), then upserts it to the live env via the Web API.
+    await new Workbench().executeCommand("Dataverse PowerTools: Build and Deploy Webresources");
+    await sleep(20000); // webpack build + HTTP upsert + publish
+    await dismissOverlays();
+
     await new Workbench().executeCommand("Dataverse PowerTools: Show Log");
     await sleep(3000);
     const img = await VSBrowser.instance.driver.takeScreenshot();

--- a/src/ui-test/screenshots.ts
+++ b/src/ui-test/screenshots.ts
@@ -24,7 +24,7 @@ async function sleep(ms: number): Promise<void> {
 async function dismissOverlays(): Promise<void> {
   try {
     await VSBrowser.instance.driver.executeScript(
-      "for (const s of ['.onboarding-a-overlay','.monaco-dialog-box','.notifications-toasts','.notification-toast']) { document.querySelectorAll(s).forEach(function(e){ e.remove(); }); }",
+      "for (const s of ['.onboarding-a-overlay','.monaco-dialog-box','.monaco-dialog-modal-block','.notifications-toasts','.notification-toast']) { document.querySelectorAll(s).forEach(function(e){ e.remove(); }); }",
     );
   } catch {
     /* ignore */

--- a/src/webresources/generateTypings.ts
+++ b/src/webresources/generateTypings.ts
@@ -1,6 +1,7 @@
 import * as vscode from "vscode";
 import DataversePowerToolsContext from "../context";
 import { workspaceFilePath } from "../general/paths";
+import { parseConnectionString, normalizeOrganizationUrl } from "../general/connectionString";
 
 export async function generateTypings(context: DataversePowerToolsContext) {
   await vscode.window.withProgress(
@@ -18,13 +19,15 @@ export async function generateTypingsExecution(context: DataversePowerToolsConte
   if (vscode.workspace.workspaceFolders !== undefined) {
     const util = require("util");
     const exec = util.promisify(require("child_process").execFile);
+    const parts = parseConnectionString(context.connectionString);
+    const orgUrl = normalizeOrganizationUrl(parts.url);
     const defTypedOptions = [
-      `/url:${context.connectionString.split(";")[2].replace("Url=", "")}/XRMServices/2011/Organization.svc`,
+      `/url:${orgUrl}/XRMServices/2011/Organization.svc`,
       `/out:typings\\XRM`,
       `/ss:${context.projectSettings.solutionName}`,
-      `/mfaAppId:${context.connectionString.split(";")[3].replace("ClientId=", "")}`,
-      `/mfaReturnUrl:${context.connectionString.split(";")[2].replace("Url=", "")}`,
-      `/mfaClientSecret:${context.connectionString.split(";")[4].replace("ClientSecret=", "")}`,
+      `/mfaAppId:${parts.clientId ?? ""}`,
+      `/mfaReturnUrl:${orgUrl}`,
+      `/mfaClientSecret:${parts.clientSecret ?? ""}`,
       `/jsLib:webresources_src\\lib`,
       `/method:ClientSecret`,
       `/w:${context.projectSettings.solutionName}Web`,

--- a/src/webresources/initialiseWebresources.ts
+++ b/src/webresources/initialiseWebresources.ts
@@ -23,7 +23,7 @@ export function initialiseWebresources(context: DataversePowerToolsContext): voi
   if (context.projectSettings.type && context.projectSettings.templateversion && vscode.workspace.workspaceFolders) {
     if (vscode.workspace.workspaceFolders !== undefined && context.projectSettings.templateversion && vscode.workspace.workspaceFolders) {
       var fullFilePath = context.vscode.asAbsolutePath(path.join("templates", context.projectSettings.type));
-      var templates = JSON.parse(fs.readFileSync(fullFilePath + "\\template.json", "utf8")) as Array<PowertoolsTemplate>;
+      var templates = JSON.parse(fs.readFileSync(path.join(fullFilePath, "template.json"), "utf8")) as Array<PowertoolsTemplate>;
       context.template = templates[0];
     }
   }

--- a/test/live/dataverseClient.ts
+++ b/test/live/dataverseClient.ts
@@ -165,6 +165,40 @@ export class LiveDataverseClient {
     return { uniqueName: opts.solutionUniqueName, solutionId };
   }
 
+  /** The id of a table's main form (type 2), for form-event tests. */
+  async findMainFormId(entityLogicalName: string): Promise<string | undefined> {
+    const res = await this.request("GET", `systemforms?$select=formid,name&$filter=objecttypecode eq '${entityLogicalName}' and type eq 2`);
+    if (!res.ok) {
+      throw new Error(`Query systemforms failed: ${res.status} ${await res.text()}`);
+    }
+    return ((await res.json()) as any).value?.[0]?.formid;
+  }
+
+  /** Get a form's raw formxml. */
+  async getFormXml(formId: string): Promise<string> {
+    const res = await this.request("GET", `systemforms(${formId})?$select=formxml`);
+    if (!res.ok) {
+      throw new Error(`Get formxml failed: ${res.status} ${await res.text()}`);
+    }
+    return ((await res.json()) as any).formxml ?? "";
+  }
+
+  /** Publish all customizations (so newly-created webresources become referenceable). */
+  async publishAll(): Promise<void> {
+    const res = await this.request("POST", "PublishAllXml");
+    if (!res.ok) {
+      throw new Error(`PublishAllXml failed: ${res.status} ${await res.text()}`);
+    }
+  }
+
+  /** Overwrite a form's formxml (used to restore a form after a test). */
+  async setFormXml(formId: string, formxml: string): Promise<void> {
+    const res = await this.request("PATCH", `systemforms(${formId})`, { formxml });
+    if (!res.ok) {
+      throw new Error(`Set formxml failed: ${res.status} ${await res.text()}`);
+    }
+  }
+
   /** True if the given component (by objectid) is a member of the solution. */
   async isComponentInSolution(solutionId: string, objectId: string): Promise<boolean> {
     const res = await this.request("GET", `solutioncomponents?$select=solutioncomponentid&$filter=_solutionid_value eq ${solutionId} and objectid eq ${objectId}`);

--- a/test/live/dataverseClient.ts
+++ b/test/live/dataverseClient.ts
@@ -183,6 +183,36 @@ export class LiveDataverseClient {
     return ((await res.json()) as any).formxml ?? "";
   }
 
+  /** Find a plugin package by its unique name. */
+  async findPluginPackageByUniqueName(uniqueName: string): Promise<{ pluginpackageid: string; uniquename: string } | undefined> {
+    const escaped = uniqueName.replace(/'/g, "''");
+    const res = await this.request("GET", `pluginpackages?$select=pluginpackageid,uniquename&$filter=uniquename eq '${escaped}'`);
+    if (!res.ok) {
+      throw new Error(`Query pluginpackage failed: ${res.status} ${await res.text()}`);
+    }
+    return ((await res.json()) as any).value?.[0];
+  }
+
+  /** Get a plugin package by id (to verify a push landed). */
+  async getPluginPackageById(id: string): Promise<{ pluginpackageid: string; uniquename: string } | undefined> {
+    const res = await this.request("GET", `pluginpackages(${id})?$select=pluginpackageid,uniquename`);
+    if (res.status === 404) {
+      return undefined;
+    }
+    if (!res.ok) {
+      throw new Error(`Get pluginpackage failed: ${res.status} ${await res.text()}`);
+    }
+    return (await res.json()) as any;
+  }
+
+  /** Delete a plugin package (and its extracted assemblies) to clean up after a test. */
+  async deletePluginPackage(id: string): Promise<void> {
+    const res = await this.request("DELETE", `pluginpackages(${id})`);
+    if (!res.ok && res.status !== 404) {
+      throw new Error(`Delete pluginpackage failed: ${res.status} ${await res.text()}`);
+    }
+  }
+
   /** Publish all customizations (so newly-created webresources become referenceable). */
   async publishAll(): Promise<void> {
     const res = await this.request("POST", "PublishAllXml");

--- a/test/live/formEventRoundtrip.spec.ts
+++ b/test/live/formEventRoundtrip.spec.ts
@@ -1,0 +1,113 @@
+/* eslint-disable @typescript-eslint/naming-convention */
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import { loadLiveEnv, LiveEnv, testSolutionConfig } from "../liveEnv";
+import { LiveDataverseClient } from "./dataverseClient";
+import { DataverseForm } from "../../src/general/dataverse/DataverseForm";
+import { DataverseWebresource } from "../../src/general/dataverse/DataverseWebresource";
+import DataversePowerToolsContext from "../../src/context";
+
+// Exercises the extension's own form + webresource code against the real environment:
+// a library webresource is created and published (DataverseWebresource), the account
+// main form is loaded and parsed (DataverseForm — also guards the org-url fix), and the
+// form-decoration logic is applied to the parsed form and verified in the object graph.
+//
+// NOTE: it deliberately does NOT PATCH the account form. Dataverse strips custom event
+// handlers when you write formxml to a *system* form via the Web API, so a true
+// push-and-verify-persistence e2e needs a dedicated custom form — a follow-up.
+const env = loadLiveEnv();
+
+it(env ? "live env configured for form/webresource round-trip" : "live env NOT configured — skipping", () => {
+  expect(true).toBe(true);
+});
+
+const live = env ? describe : describe.skip;
+
+/** Minimal stand-in for the context — what DataverseForm and DataverseWebresource read. */
+function fakeContext(url: string, token: string): DataversePowerToolsContext {
+  return {
+    connectionString: `AuthType=OAuth;Url=${url}`,
+    projectSettings: { tenantId: "test" },
+    dataverse: { organizationUrl: url, isValid: true, authorizationToken: token, getAuthorizationToken: async () => token },
+    channel: { appendLine: () => undefined, show: () => undefined },
+  } as unknown as DataversePowerToolsContext;
+}
+
+/** Apply the extension's form-decoration shape (library + onload handler) to a parsed form. */
+function decorate(form: DataverseForm, libraryName: string, functionName: string): void {
+  const root = form.form.form;
+  if (!root.formLibraries) {
+    root.formLibraries = { Library: [] };
+  }
+  if (!root.formLibraries.Library.find((l: any) => l["@_name"] === libraryName)) {
+    root.formLibraries.Library.push({ "@_name": libraryName, "@_libraryUniqueId": "{b2c3d4e5-0000-4000-8000-000000000002}" });
+  }
+  if (!root.events) {
+    root.events = { event: [] };
+  }
+  let onload = root.events.event.find((e: any) => e["@_name"] === "onload");
+  if (!onload) {
+    onload = { "@_name": "onload", "@_active": "true", "@_application": "true", Handlers: { Handler: [] } };
+    root.events.event.push(onload);
+  }
+  if (!onload.Handlers) {
+    onload.Handlers = { Handler: [] };
+  }
+  onload.Handlers.Handler.push({
+    "@_functionName": functionName,
+    "@_libraryName": libraryName,
+    "@_handlerUniqueId": "{a1b2c3d4-0000-4000-8000-000000000001}",
+    "@_enabled": "true",
+    "@_parameters": "",
+    "@_passExecutionContext": "true",
+  });
+}
+
+live("form read + decoration logic + webresource lifecycle (extension code vs real env)", () => {
+  const client = new LiveDataverseClient(env as LiveEnv);
+  const prefix = testSolutionConfig(env as LiveEnv).prefix;
+  const stamp = Date.now();
+  const libraryName = `${prefix}_dvpttestlib_${stamp}.js`;
+  const testFunctionName = `dvpt_test_OnLoad_${stamp}`;
+  let formId = "";
+  let webresourceId: string | undefined;
+
+  beforeAll(async () => {
+    await client.connect();
+    const ctx = fakeContext((env as LiveEnv).url, client.accessToken);
+    const webresource = new DataverseWebresource(libraryName, ctx);
+    await webresource.upsert(Buffer.from("function noop(){}", "utf8").toString("base64"), 3, "dvpt test lib");
+    webresourceId = (await client.findWebresourceByName(libraryName))?.webresourceid;
+    formId = (await client.findMainFormId("account")) ?? "";
+  });
+
+  afterAll(async () => {
+    if (webresourceId) {
+      await client.deleteWebresource(webresourceId);
+    }
+  });
+
+  it("creates a library webresource via the extension's DataverseWebresource and finds the form", () => {
+    expect(webresourceId, "test library webresource was not created").toBeTruthy();
+    expect(formId, "account main form not found").toBeTruthy();
+  });
+
+  it("loads and parses the real form via DataverseForm (guards the org-url fix)", async () => {
+    const form = new DataverseForm(formId, fakeContext((env as LiveEnv).url, client.accessToken));
+    await form.getFormData();
+    expect(form.form?.form, "form xml did not parse").toBeTruthy();
+    expect(form.form.form.tabs, "parsed form has no tabs").toBeTruthy();
+  });
+
+  it("applies the form-decoration logic (library + onload handler) to the parsed form", async () => {
+    const form = new DataverseForm(formId, fakeContext((env as LiveEnv).url, client.accessToken));
+    await form.getFormData();
+    decorate(form, libraryName, testFunctionName);
+
+    const library = form.form.form.formLibraries.Library.find((l: any) => l["@_name"] === libraryName);
+    expect(library, "library was not registered on the form").toBeTruthy();
+    const onload = form.form.form.events.event.find((e: any) => e["@_name"] === "onload");
+    const handler = onload?.Handlers?.Handler?.find((h: any) => h["@_functionName"] === testFunctionName);
+    expect(handler, "onload handler was not registered").toBeTruthy();
+    expect(handler["@_libraryName"]).toBe(libraryName);
+  });
+});

--- a/test/live/liveOperationsLog.spec.ts
+++ b/test/live/liveOperationsLog.spec.ts
@@ -1,0 +1,110 @@
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import * as fs from "fs";
+import * as os from "os";
+import * as path from "path";
+import * as cp from "child_process";
+import { loadLiveEnv, LiveEnv, testSolutionConfig } from "../liveEnv";
+import { LiveDataverseClient } from "./dataverseClient";
+import { DataverseContext } from "../../src/general/dataverse/dataverseContext";
+import { DataverseWebresource } from "../../src/general/dataverse/DataverseWebresource";
+import { upsertDataversePluginPackage } from "../../src/general/dataverse/getDataversePluginPackage";
+
+// Runs real operations against the env through the extension's own code using a REAL
+// DataverseContext (service-principal connect), and captures what the extension writes
+// to its "Dataverse PowerTools" channel — proving the operations succeed AND producing
+// the actual log output. Writes it to sandbox/screenshots-out/live-operations.log.
+const env = loadLiveEnv();
+
+function has(tool: string, args: string[]): boolean {
+  try {
+    cp.execFileSync(tool, args, { stdio: "ignore" });
+    return true;
+  } catch {
+    return false;
+  }
+}
+const toolchain = has("pac", ["help"]) && has("dotnet", ["--version"]);
+
+it(env && toolchain ? "live env + pac/dotnet available for operations log" : "operations log skipped (needs creds + pac + dotnet)", () => {
+  expect(true).toBe(true);
+});
+
+const live = env && toolchain ? describe : describe.skip;
+
+live("live operations log (real connect + webresource push + plugin push, captured channel)", () => {
+  const e = env as LiveEnv;
+  const client = new LiveDataverseClient(e);
+  const cfg = testSolutionConfig(e);
+  const stamp = Date.now();
+  const log: string[] = [];
+  // A real DataverseContext, with just enough surrounding context for it to run.
+  const context: any = {
+    connectionString: `AuthType=ClientSecret;Url=${e.url};ClientId=${e.clientId};ClientSecret=${e.clientSecret}`,
+    projectSettings: { tenantId: e.tenantId },
+    channel: { appendLine: (m: string) => log.push(String(m)), show: () => undefined },
+    setStatusBar: () => undefined,
+  };
+  const wrName = `${cfg.prefix}_dvptlog_${stamp}.js`;
+  const pkgUnique = `${cfg.prefix}_dvptlogpkg${stamp}`;
+  let projectDir = "";
+  let nupkgPath = "";
+  let webresourceId: string | undefined;
+  let packageId: string | undefined;
+
+  beforeAll(async () => {
+    await client.connect();
+    await client.ensureTestSolution(cfg);
+    context.dataverse = new DataverseContext(context);
+
+    projectDir = path.join(os.tmpdir(), `${cfg.prefix}_dvptlogplugin${stamp}`);
+    fs.rmSync(projectDir, { recursive: true, force: true });
+    fs.mkdirSync(projectDir, { recursive: true });
+    cp.execFileSync("pac", ["plugin", "init"], { cwd: projectDir, stdio: "ignore" });
+    cp.execFileSync("dotnet", ["build", "-c", "Release"], { cwd: projectDir, stdio: "ignore" });
+    const releaseDir = path.join(projectDir, "bin", "Release");
+    const nupkg = fs.existsSync(releaseDir) ? fs.readdirSync(releaseDir).find((f) => f.endsWith(".nupkg")) : undefined;
+    nupkgPath = nupkg ? path.join(releaseDir, nupkg) : "";
+  }, 300000);
+
+  afterAll(async () => {
+    const outDir = path.resolve(__dirname, "..", "..", "sandbox", "screenshots-out");
+    fs.mkdirSync(outDir, { recursive: true });
+    const header = [`Dataverse PowerTools — live operations log`, `Environment: ${e.url}`, `Run: ${new Date().toISOString()}`, "".padEnd(60, "-")];
+    fs.writeFileSync(path.join(outDir, "live-operations.log"), header.concat(log).join("\n") + "\n");
+    if (webresourceId) {
+      await client.deleteWebresource(webresourceId);
+    }
+    if (packageId) {
+      await client.deletePluginPackage(packageId);
+    }
+    if (projectDir) {
+      fs.rmSync(projectDir, { recursive: true, force: true });
+    }
+  });
+
+  it("connects to the real environment (logs 'Connected to Dataverse')", async () => {
+    const ok = await context.dataverse.initialize(true);
+    expect(ok, "could not connect to the live environment").toBe(true);
+    expect(log.some((l) => l.includes("Connected to Dataverse"))).toBe(true);
+  });
+
+  it("pushes a webresource and logs the success", async () => {
+    const source = `console.log("dvpt live-log ${stamp}");`;
+    const webresource = new DataverseWebresource(wrName, context);
+    await webresource.upsert(Buffer.from(source, "utf8").toString("base64"), 3, "dvpt live-log test");
+    await webresource.addToSolution(cfg.solutionUniqueName);
+
+    webresourceId = (await client.findWebresourceByName(wrName))?.webresourceid;
+    expect(webresourceId, "webresource not found after push").toBeTruthy();
+    expect(log.some((l) => l.includes(`Webresource '${wrName}' created`))).toBe(true);
+    expect(log.some((l) => l.includes(`Added webresource '${wrName}' to solution`))).toBe(true);
+  });
+
+  it("pushes a plugin package and logs the success", async () => {
+    expect(nupkgPath, "no nupkg built").toBeTruthy();
+    const result = await upsertDataversePluginPackage(context, { name: pkgUnique, uniqueName: pkgUnique, version: "1.0.0" }, nupkgPath);
+    packageId = result.pluginPackageId;
+    expect(packageId, "plugin package not created").toBeTruthy();
+    expect(log.some((l) => l.includes(`Plugin package '${pkgUnique}'`) && l.includes("created"))).toBe(true);
+  });
+});

--- a/test/live/pluginPackageRoundtrip.spec.ts
+++ b/test/live/pluginPackageRoundtrip.spec.ts
@@ -1,0 +1,96 @@
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import * as fs from "fs";
+import * as os from "os";
+import * as path from "path";
+import * as cp from "child_process";
+import { loadLiveEnv, LiveEnv, testSolutionConfig } from "../liveEnv";
+import { LiveDataverseClient } from "./dataverseClient";
+import { upsertDataversePluginPackage, getDataversePluginPackageId } from "../../src/general/dataverse/getDataversePluginPackage";
+import DataversePowerToolsContext from "../../src/context";
+
+// Full plugin e2e the way the extension does it: scaffold a plugin project (pac plugin
+// init), build it to a NuGet package (dotnet build, net462), then push it to the real
+// environment via the extension's own upsertDataversePluginPackage (Web API), verify
+// the package landed via the independent client, and delete it. Needs pac + dotnet, and
+// self-skips (like the rest of the live tier) when either the creds or toolchain are absent.
+const env = loadLiveEnv();
+
+function has(tool: string, args: string[]): boolean {
+  try {
+    cp.execFileSync(tool, args, { stdio: "ignore" });
+    return true;
+  } catch {
+    return false;
+  }
+}
+const toolchain = has("dotnet", ["--version"]) && has("pac", ["help"]);
+
+it(env && toolchain ? "live env + pac/dotnet available for plugin round-trip" : "plugin round-trip skipped (needs creds + pac + dotnet)", () => {
+  expect(true).toBe(true);
+});
+
+const live = env && toolchain ? describe : describe.skip;
+
+function fakeContext(url: string, token: string): DataversePowerToolsContext {
+  return {
+    dataverse: { organizationUrl: url, isValid: true, getAuthorizationToken: async () => token },
+    channel: { appendLine: () => undefined, show: () => undefined },
+  } as unknown as DataversePowerToolsContext;
+}
+
+live("plugin build + package push round-trip (pac init + dotnet build -> extension push -> verify -> delete)", () => {
+  const client = new LiveDataverseClient(env as LiveEnv);
+  const prefix = testSolutionConfig(env as LiveEnv).prefix;
+  const stamp = Date.now();
+  const projectName = `${prefix}_testplugin${stamp}`;
+  const uniqueName = `${prefix}_testpkg${stamp}`;
+  let projectDir = "";
+  let nupkgPath = "";
+  let packageId: string | undefined;
+
+  beforeAll(async () => {
+    await client.connect();
+    projectDir = path.join(os.tmpdir(), projectName);
+    fs.rmSync(projectDir, { recursive: true, force: true });
+    fs.mkdirSync(projectDir, { recursive: true });
+
+    // Scaffold + build the plugin (pac plugin init names the project after the dir).
+    cp.execFileSync("pac", ["plugin", "init"], { cwd: projectDir, stdio: "ignore" });
+    cp.execFileSync("dotnet", ["build", "-c", "Release"], { cwd: projectDir, stdio: "ignore" });
+
+    const releaseDir = path.join(projectDir, "bin", "Release");
+    const nupkg = fs.existsSync(releaseDir) ? fs.readdirSync(releaseDir).find((f) => f.endsWith(".nupkg")) : undefined;
+    nupkgPath = nupkg ? path.join(releaseDir, nupkg) : "";
+  }, 300000);
+
+  afterAll(async () => {
+    if (packageId) {
+      await client.deletePluginPackage(packageId);
+    }
+    if (projectDir) {
+      fs.rmSync(projectDir, { recursive: true, force: true });
+    }
+  });
+
+  it("scaffolds and builds a net462 plugin to a NuGet package", () => {
+    expect(nupkgPath, "no .nupkg produced by dotnet build").toBeTruthy();
+    expect(fs.existsSync(nupkgPath)).toBe(true);
+  });
+
+  it("pushes the package via the extension's upsertDataversePluginPackage and it lands in Dataverse", async () => {
+    const ctx = fakeContext((env as LiveEnv).url, client.accessToken);
+    const result = await upsertDataversePluginPackage(ctx, { name: projectName, uniqueName, version: "1.0.0" }, nupkgPath);
+    packageId = result.pluginPackageId;
+
+    expect(result.pluginPackageId, "no plugin package id returned").toBeTruthy();
+    expect(result.created).toBe(true);
+
+    // Verify the package landed by the id the push returned (robust to any
+    // publisher-prefix normalisation Dataverse applies to the unique name).
+    const found = await client.getPluginPackageById(packageId as string);
+    expect(found, "plugin package not found in Dataverse after push").toBeTruthy();
+
+    // The extension's own lookup should resolve the (possibly normalised) unique name.
+    expect(await getDataversePluginPackageId(ctx, found?.uniquename ?? uniqueName)).toBe(packageId);
+  });
+});

--- a/test/live/solutionPacRoundtrip.spec.ts
+++ b/test/live/solutionPacRoundtrip.spec.ts
@@ -1,0 +1,95 @@
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import * as fs from "fs";
+import * as os from "os";
+import * as path from "path";
+import * as cp from "child_process";
+import { loadLiveEnv, LiveEnv, testSolutionConfig } from "../liveEnv";
+import { pacAuthCreateArgs, pacAuthDeleteArgs, pacSolutionExportArgs, pacSolutionUnpackArgs, pacSolutionPackArgs } from "../../src/solution/pacArgs";
+import { SolutionConfig } from "../../src/solution/solutionConfig";
+
+// Drives the extension's own pac argument builders (pacArgs) against real `pac`:
+// authenticate as the service principal, EXPORT the dedicated test solution from the
+// env, UNPACK the zip to a folder, then PACK it back to a zip — the full solution
+// round-trip. Verifies the artifacts and cleans up. Self-skips without creds or pac.
+const env = loadLiveEnv();
+
+function hasPac(): boolean {
+  try {
+    cp.execFileSync("pac", ["help"], { stdio: "ignore" });
+    return true;
+  } catch {
+    return false;
+  }
+}
+const toolchain = hasPac();
+
+/** Run pac, redacting the client secret from any error surfaced. */
+function runPac(args: string[], cwd: string, secret?: string): void {
+  try {
+    cp.execFileSync("pac", args, { cwd, stdio: ["ignore", "pipe", "pipe"] });
+  } catch (e: any) {
+    const out = `${e.stdout ?? ""}${e.stderr ?? ""} ${e.message ?? ""}`;
+    throw new Error(secret ? out.split(secret).join("***") : out);
+  }
+}
+
+it(env && toolchain ? "live env + pac available for solution round-trip" : "solution round-trip skipped (needs creds + pac)", () => {
+  expect(true).toBe(true);
+});
+
+const live = env && toolchain ? describe : describe.skip;
+
+live("solution export + unpack + pack round-trip (extension pacArgs -> real pac -> env)", () => {
+  const e = env as LiveEnv;
+  const profileName = "dvpttest_soln_e2e";
+  const solutionUniqueName = testSolutionConfig(e).solutionUniqueName;
+  let tmpDir = "";
+  let config: SolutionConfig;
+  let repackedZip = "";
+
+  beforeAll(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "dvpt_soln_"));
+    config = {
+      uniqueName: solutionUniqueName,
+      packagePath: path.join(tmpDir, "unpacked"),
+      zipPath: path.join(tmpDir, `${solutionUniqueName}.zip`),
+      packageType: "Unmanaged",
+    };
+    repackedZip = path.join(tmpDir, `${solutionUniqueName}_repacked.zip`);
+
+    // Fresh auth profile for the test env.
+    try {
+      runPac(pacAuthDeleteArgs(profileName), tmpDir);
+    } catch {
+      /* profile may not exist */
+    }
+    runPac(pacAuthCreateArgs({ profileName, applicationId: e.clientId, clientSecret: e.clientSecret, tenantId: e.tenantId, environmentUrl: e.url }), tmpDir, e.clientSecret);
+
+    runPac(pacSolutionExportArgs(config, { managed: false, environmentUrl: e.url }), tmpDir);
+    runPac(pacSolutionUnpackArgs(config), tmpDir);
+    runPac(pacSolutionPackArgs({ ...config, zipPath: repackedZip }), tmpDir);
+  }, 300000);
+
+  afterAll(() => {
+    try {
+      runPac(pacAuthDeleteArgs(profileName), tmpDir);
+    } catch {
+      /* ignore */
+    }
+    if (tmpDir) {
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    }
+  });
+
+  it("exports the solution zip from the environment", () => {
+    expect(fs.existsSync(config.zipPath), "exported solution zip missing").toBe(true);
+  });
+
+  it("unpacks the zip to a Solution.xml", () => {
+    expect(fs.existsSync(path.join(config.packagePath, "Other", "Solution.xml")), "unpacked Solution.xml missing").toBe(true);
+  });
+
+  it("packs the folder back into a zip", () => {
+    expect(fs.existsSync(repackedZip), "repacked solution zip missing").toBe(true);
+  });
+});


### PR DESCRIPTION
## 0.5.1 — reliability & hardening

A focused hardening release on top of 0.5.0: it fixes real Dataverse API bugs, replaces fragile `pac` output scraping with structured parsing, and makes HTTP error reporting consistent — with new unit coverage and a live end-to-end tier.

### Fixes
- **Plugin package creation (204 handling)** — new plugin packages failed with "Unexpected end of JSON input" because Dataverse returns `204 No Content` on create; the id is now read from the `OData-EntityId` header.
- **Centralised Web API URL/version (#77)** — every Dataverse call now goes through one `dataverseApiUrl` helper (requests were hitting mixed `v9.x` versions). Also fixes the org URL used by form registration and the connection-string parse in typings generation.
- **Cross-platform template paths (#73)** — replaced hard-coded `\` with `path.join` in template generation.
- **Robust `pac` table parsing for portals (#75)** — the portal flow scraped pac's table by whitespace-splitting + index arithmetic, which broke on any spaced value (e.g. an environment display name) or a column-width change. Now parsed by anchoring on the documented column **headers** (pac's `auth list` / `pages list` don't support `--json`). New pure `src/portals/pacOutput.ts` with unit tests, including a **real captured** auth-list sample whose environment cell contains spaces.
- **Consistent HTTP error surfacing (#76)** — shared `logDataverseHttpError` / `logDataverseError` helpers log the operation + status + body across every list/register/form call; one form-listing call that silently swallowed failures (no `response.ok` check) now reports them.

### Additions
- Success logging when webresources and plugin packages are pushed (#76).
- Opt-in **live e2e tier** (form decoration, solution pack/unpack/export via `pac`, plugin scaffold + `dotnet build` + package push) that self-skips without credentials; expanded ExTester UI coverage and hardened overlay handling (#65, #80).
- Backfilled the changelog for **0.4.0 and 0.5.0** (both shipped without changelog entries).

### Validation
- Verify loop green locally: `npm run lint` (0 warnings) · `npm run compile` · `npm run test:unit` **88 passing** · `npm run test:integration` (extension host activates).
- The full **webpack build → deploy of `dvpt_library.js`** was captured end-to-end against a live Dataverse env (real build output + deploy logs), and the deployed webresource verified + cleaned up via an independent Web API client.
- **Parser note:** the pac **auth-list** parser is unit-tested against real captured output; the **pages-list** parser is tested against representative samples + the documented format — the test environment has no Power Pages site to capture a populated live table, so the pages column layout should be confirmed against an env with a site.

### Notes for the reviewer
- **Marketplace publish:** merging to `main` triggers the publish workflow (0.5.1) — intentional on merge.
- **CodeQL:** touches Dataverse HTTP + `pac` output handling; please check the security tab.

🤖 Generated with [Claude Code](https://claude.com/claude-code)