### PR TITLE
test(#80): unit-test the Dataverse HTTP layer + add a CI coverage gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,8 +27,8 @@ jobs:
         run: npm run lint
       - name: Compile (webpack bundle)
         run: npm run compile
-      - name: Unit tests
-        run: npm run test:unit
+      - name: Unit tests (with coverage gate)
+        run: npm run test:coverage
       - name: Integration tests (headless VS Code)
         run: xvfb-run -a npm run test:integration
 

--- a/src/general/dataverse/getDataverseForms.spec.ts
+++ b/src/general/dataverse/getDataverseForms.spec.ts
@@ -1,0 +1,43 @@
+/* eslint-disable @typescript-eslint/naming-convention */ // Dataverse API response fields (LogicalName, msdyn_*) must match the API, not camelCase.
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+vi.mock("node-fetch", () => ({ default: vi.fn() }));
+import fetch from "node-fetch";
+import { getDataverseForms } from "./getDataverseForms";
+import { fakeDataverseContext, okJson, httpError } from "../../../test/dataverseTestUtils";
+
+const fetchMock = fetch as unknown as ReturnType<typeof vi.fn>;
+beforeEach(() => fetchMock.mockReset());
+
+describe("getDataverseForms", () => {
+  it("queries solutioncomponentsummaries filtered by entity and maps records", async () => {
+    fetchMock.mockResolvedValue(okJson({ value: [{ msdyn_objectid: "id-1", msdyn_name: "Main", msdyn_componenttypename: "Main Form" }] }));
+    const { context } = fakeDataverseContext();
+    const forms = await getDataverseForms(context, "account");
+    expect(forms).toEqual([{ formId: "id-1", displayName: "Main", formType: "Main Form" }]);
+    const url = fetchMock.mock.calls[0][0] as string;
+    expect(url).toContain("/api/data/v9.2/msdyn_solutioncomponentsummaries");
+    expect(url).toContain("msdyn_primaryentityname%20eq%20%27account%27");
+  });
+
+  it("initialises the connection first when the context is not yet valid", async () => {
+    fetchMock.mockResolvedValue(okJson({ value: [] }));
+    const { context } = fakeDataverseContext({ isValid: false });
+    await getDataverseForms(context, "contact");
+    expect(context.dataverse.initialize).toHaveBeenCalledOnce();
+  });
+
+  it("returns [] without calling fetch when initialise fails", async () => {
+    const { context } = fakeDataverseContext({ isValid: false });
+    context.dataverse.initialize = vi.fn(async () => false);
+    expect(await getDataverseForms(context, "account")).toEqual([]);
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("returns [] and logs on a non-OK response", async () => {
+    fetchMock.mockResolvedValue(httpError(404, "Not Found"));
+    const { context, lines } = fakeDataverseContext();
+    expect(await getDataverseForms(context, "account")).toEqual([]);
+    expect(lines.join("\n")).toContain("Failed to load forms for 'account': 404 Not Found");
+  });
+});

--- a/src/general/dataverse/getDataverseMessages.spec.ts
+++ b/src/general/dataverse/getDataverseMessages.spec.ts
@@ -1,0 +1,44 @@
+/* eslint-disable @typescript-eslint/naming-convention */ // Dataverse API response fields (name/Name) must match the API, not camelCase.
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+vi.mock("node-fetch", () => ({ default: vi.fn() }));
+import fetch from "node-fetch";
+import { getDataverseMessages } from "./getDataverseMessages";
+import { fakeDataverseContext, okJson, httpError } from "../../../test/dataverseTestUtils";
+
+const fetchMock = fetch as unknown as ReturnType<typeof vi.fn>;
+beforeEach(() => fetchMock.mockReset());
+
+describe("getDataverseMessages", () => {
+  it("requests non-private sdkmessages and returns names sorted ascending", async () => {
+    fetchMock.mockResolvedValue(okJson({ value: [{ name: "Update" }, { name: "Create" }, { name: "Delete" }] }));
+    const { context } = fakeDataverseContext();
+    const result = await getDataverseMessages(context);
+    expect(result).toEqual(["Create", "Delete", "Update"]);
+    expect(fetchMock.mock.calls[0][0]).toBe("https://org.crm.dynamics.com/api/data/v9.2/sdkmessages?$select=name&$filter=isprivate eq false");
+  });
+
+  it("accepts either name or Name casing and drops blanks", async () => {
+    fetchMock.mockResolvedValue(okJson({ value: [{ Name: "Assign" }, { name: " " }, { name: "Book" }, {}] }));
+    const { context } = fakeDataverseContext();
+    expect(await getDataverseMessages(context)).toEqual(["Assign", "Book"]);
+  });
+
+  it("returns [] and logs when the call fails (unparseable body)", async () => {
+    fetchMock.mockResolvedValue({
+      ok: true,
+      json: async () => {
+        throw new Error("network down");
+      },
+    });
+    const { context, lines } = fakeDataverseContext();
+    expect(await getDataverseMessages(context)).toEqual([]);
+    expect(lines.join("\n")).toContain("Error while trying to load messages: network down");
+  });
+
+  it("returns [] on a non-OK response", async () => {
+    fetchMock.mockResolvedValue(httpError(500, "Server Error"));
+    const { context } = fakeDataverseContext();
+    expect(await getDataverseMessages(context)).toEqual([]);
+  });
+});

--- a/src/general/dataverse/getDataverseTableAttributes.spec.ts
+++ b/src/general/dataverse/getDataverseTableAttributes.spec.ts
@@ -1,0 +1,49 @@
+/* eslint-disable @typescript-eslint/naming-convention */ // Dataverse API response fields (LogicalName) must match the API, not camelCase.
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+vi.mock("node-fetch", () => ({ default: vi.fn() }));
+import fetch from "node-fetch";
+import { getDataverseTableAttributes } from "./getDataverseTableAttributes";
+import { fakeDataverseContext, okJson, httpError } from "../../../test/dataverseTestUtils";
+
+const fetchMock = fetch as unknown as ReturnType<typeof vi.fn>;
+beforeEach(() => fetchMock.mockReset());
+
+describe("getDataverseTableAttributes", () => {
+  it("queries the entity's attributes and returns logical names sorted", async () => {
+    fetchMock.mockResolvedValue(okJson({ value: [{ LogicalName: "name" }, { LogicalName: "accountid" }, { LogicalName: "  " }] }));
+    const { context } = fakeDataverseContext();
+    const result = await getDataverseTableAttributes(context, "account");
+    expect(result).toEqual(["accountid", "name"]);
+    const url = fetchMock.mock.calls[0][0] as string;
+    expect(url).toContain("/api/data/v9.2/EntityDefinitions(LogicalName='account')/Attributes");
+    expect(url).toContain("AttributeOf eq null");
+  });
+
+  it("escapes single quotes in the table name to avoid breaking the OData filter", async () => {
+    fetchMock.mockResolvedValue(okJson({ value: [] }));
+    const { context } = fakeDataverseContext();
+    await getDataverseTableAttributes(context, "o'brien");
+    expect(fetchMock.mock.calls[0][0]).toContain("LogicalName='o''brien'");
+  });
+
+  it("returns [] without calling fetch when there is no access token", async () => {
+    const { context } = fakeDataverseContext();
+    context.dataverse.getAuthorizationToken = vi.fn(async () => "");
+    expect(await getDataverseTableAttributes(context, "account")).toEqual([]);
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("returns [] when the response has no value array", async () => {
+    fetchMock.mockResolvedValue(okJson({ notValue: true }));
+    const { context } = fakeDataverseContext();
+    expect(await getDataverseTableAttributes(context, "account")).toEqual([]);
+  });
+
+  it("returns [] and logs on a non-OK response", async () => {
+    fetchMock.mockResolvedValue(httpError(403, "Forbidden"));
+    const { context, lines } = fakeDataverseContext();
+    expect(await getDataverseTableAttributes(context, "account")).toEqual([]);
+    expect(lines.join("\n")).toContain("Failed to load attributes for table 'account': 403 Forbidden");
+  });
+});

--- a/src/general/dataverse/getDataverseTables.spec.ts
+++ b/src/general/dataverse/getDataverseTables.spec.ts
@@ -1,0 +1,46 @@
+/* eslint-disable @typescript-eslint/naming-convention */ // Dataverse API response fields (LogicalName, msdyn_*) must match the API, not camelCase.
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+vi.mock("node-fetch", () => ({ default: vi.fn() }));
+import fetch from "node-fetch";
+import { getDataverseTables } from "./getDataverseTables";
+import { fakeDataverseContext, okJson, httpError } from "../../../test/dataverseTestUtils";
+
+const fetchMock = fetch as unknown as ReturnType<typeof vi.fn>;
+beforeEach(() => fetchMock.mockReset());
+
+describe("getDataverseTables", () => {
+  it("requests EntityDefinitions on the v9.2 API and returns trimmed logical names", async () => {
+    fetchMock.mockResolvedValue(okJson({ value: [{ LogicalName: "account" }, { LogicalName: " contact " }] }));
+    const { context } = fakeDataverseContext({ organizationUrl: "https://org.crm.dynamics.com/" });
+    const result = await getDataverseTables(context);
+    expect(result).toEqual(["account", "contact"]);
+    expect(fetchMock.mock.calls[0][0]).toBe("https://org.crm.dynamics.com/api/data/v9.2/EntityDefinitions?$select=LogicalName");
+    expect(fetchMock.mock.calls[0][1].headers.Authorization).toBe("Bearer tok");
+  });
+
+  it("drops empty, whitespace-only, and missing logical names", async () => {
+    fetchMock.mockResolvedValue(okJson({ value: [{ LogicalName: "account" }, { LogicalName: "" }, { LogicalName: "   " }, {}] }));
+    const { context } = fakeDataverseContext();
+    expect(await getDataverseTables(context)).toEqual(["account"]);
+  });
+
+  it("returns [] and logs a consistent error on a non-OK response", async () => {
+    fetchMock.mockResolvedValue(httpError(401, "Unauthorized", "expired token"));
+    const { context, lines } = fakeDataverseContext();
+    expect(await getDataverseTables(context)).toEqual([]);
+    expect(lines.join("\n")).toContain("Failed to load tables: 401 Unauthorized — expired token");
+  });
+
+  it("returns [] and logs when the call fails (unparseable body)", async () => {
+    fetchMock.mockResolvedValue({
+      ok: true,
+      json: async () => {
+        throw new Error("ECONNRESET");
+      },
+    });
+    const { context, lines } = fakeDataverseContext();
+    expect(await getDataverseTables(context)).toEqual([]);
+    expect(lines.join("\n")).toContain("Error while trying to load tables: ECONNRESET");
+  });
+});

--- a/src/general/dataverse/getSolutions.spec.ts
+++ b/src/general/dataverse/getSolutions.spec.ts
@@ -1,0 +1,57 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+vi.mock("node-fetch", () => ({ default: vi.fn() }));
+import fetch from "node-fetch";
+import { getSolutions } from "./getSolutions";
+import { fakeDataverseContext, okJson, httpError } from "../../../test/dataverseTestUtils";
+
+const fetchMock = fetch as unknown as ReturnType<typeof vi.fn>;
+beforeEach(() => fetchMock.mockReset());
+
+const sampleSolution = {
+  solutionid: "sol-1",
+  friendlyname: "Dataverse PowerTools Tests",
+  uniquename: "dvpttests",
+  publisherid: { friendlyname: "DVPT Publisher", customizationprefix: "dvpt", publisherid: "pub-1" },
+};
+
+describe("getSolutions", () => {
+  it("requests unmanaged solutions with the publisher expanded and maps them", async () => {
+    fetchMock.mockResolvedValue(okJson({ value: [sampleSolution] }));
+    const { context } = fakeDataverseContext();
+    const solutions = await getSolutions(context);
+    expect(solutions).toHaveLength(1);
+    expect(solutions![0]).toMatchObject({
+      id: "sol-1",
+      displayName: "Dataverse PowerTools Tests",
+      uniqueName: "dvpttests",
+      publisherName: "DVPT Publisher",
+      publisherPrefix: "dvpt",
+      publisherId: "pub-1",
+    });
+    const url = fetchMock.mock.calls[0][0] as string;
+    expect(url).toContain("/api/data/v9.2/solutions");
+    expect(url).toContain("ismanaged%20eq%20false");
+    expect(url).toContain("$expand=publisherid");
+  });
+
+  it("returns undefined on a non-OK response", async () => {
+    fetchMock.mockResolvedValue(httpError(403, "Forbidden"));
+    const { context } = fakeDataverseContext();
+    expect(await getSolutions(context)).toBeUndefined();
+  });
+
+  it("returns undefined when the response shape is unexpected", async () => {
+    fetchMock.mockResolvedValue(okJson({ notValue: [] }));
+    const { context, lines } = fakeDataverseContext();
+    expect(await getSolutions(context)).toBeUndefined();
+    expect(lines.join("\n")).toContain("Unexpected solutions response");
+  });
+
+  it("initialises first when the context is not valid", async () => {
+    fetchMock.mockResolvedValue(okJson({ value: [] }));
+    const { context } = fakeDataverseContext({ isValid: false });
+    await getSolutions(context);
+    expect(context.dataverse.initialize).toHaveBeenCalledOnce();
+  });
+});

--- a/test/dataverseTestUtils.ts
+++ b/test/dataverseTestUtils.ts
@@ -1,0 +1,44 @@
+import { vi } from "vitest";
+
+// Shared helpers for unit-testing the Dataverse HTTP fetchers (src/general/dataverse/*).
+// The fetchers are pure (no vscode) but call node-fetch and read context.dataverse +
+// context.channel — so a spec mocks node-fetch and passes one of these fake contexts.
+
+export interface FakeContextOptions {
+  organizationUrl?: string;
+  authorizationToken?: string;
+  isValid?: boolean;
+  /** Token returned by getAuthorizationToken(); defaults to authorizationToken. */
+  token?: string;
+}
+
+/** A minimal fake DataversePowerToolsContext with a captured output channel. */
+export function fakeDataverseContext(opts: FakeContextOptions = {}) {
+  const lines: string[] = [];
+  const organizationUrl = opts.organizationUrl ?? "https://org.crm.dynamics.com";
+  const authorizationToken = opts.authorizationToken ?? "tok";
+  const context = {
+    dataverse: {
+      organizationUrl,
+      authorizationToken,
+      isValid: opts.isValid ?? true,
+      initialize: vi.fn(async () => true),
+      getAuthorizationToken: vi.fn(async () => opts.token ?? authorizationToken),
+    },
+    channel: {
+      appendLine: (m: string) => lines.push(String(m)),
+      show: () => undefined,
+    },
+  };
+  return { context: context as any, lines };
+}
+
+/** A fake node-fetch Response for a successful JSON body. */
+export function okJson(body: unknown) {
+  return { ok: true, status: 200, statusText: "OK", json: async () => body, text: async () => JSON.stringify(body) };
+}
+
+/** A fake node-fetch Response for a failed HTTP call. */
+export function httpError(status: number, statusText = "", body = "") {
+  return { ok: false, status, statusText, json: async () => null, text: async () => body };
+}

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -12,7 +12,18 @@ export default defineConfig({
     coverage: {
       provider: "v8",
       include: ["src/**/*.ts"],
-      exclude: ["src/**/*.spec.ts", "src/test/**", "src/ui-test/**"],
+      exclude: ["src/**/*.spec.ts", "src/test/**", "src/ui-test/**", "src/plugins_old/**"],
+      reporter: ["text", "text-summary"],
+      // A floor that guards against coverage *regressions* (run in CI via test:coverage).
+      // Global unit coverage is low by design: most of src is tangled with the vscode API
+      // and is covered by the integration + ExTester UI suites, not unit tests. Ratchet
+      // these up as vscode-free logic is extracted and unit-tested (see #80).
+      thresholds: {
+        statements: 7,
+        branches: 7,
+        functions: 9,
+        lines: 7,
+      },
     },
   },
   resolve: {


### PR DESCRIPTION
Part of #80 — grow automated test coverage and add a coverage regression gate.

The Dataverse HTTP layer was the largest untested pure-logic surface, so it's the focus here.

## What's in this PR
- **Unit tests for the Dataverse HTTP fetchers** (21 tests): `getDataverseTables`, `getDataverseForms`, `getDataverseMessages`, `getDataverseTableAttributes`, and `getSolutions`. Each asserts:
  - the correct **v9.2** Web API URL is built (via `dataverseApiUrl`),
  - the response is parsed/trimmed/sorted as expected,
  - failure paths (non-OK status, unparseable body) return the empty result and log consistently.
  - Shared fakes in `test/dataverseTestUtils.ts` (fake context + `node-fetch` `Response` builders); `node-fetch` is mocked per spec.
- **Coverage gate**: a threshold floor in `vitest.config.ts` (statements/branches/lines 7, functions 9) and the deprecated `src/plugins_old/**` excluded from the report. CI's unit step now runs `test:coverage`, so coverage can't silently regress.

## Numbers
- Unit suite: **116 passing** (was 95).
- Coverage: **8.29%** statements (was 5.41%); the Dataverse fetchers are now **85–100%** covered.

## Why the global floor is low
Most of `src/` is tangled with the `vscode` API and is covered by the integration + ExTester UI suites, not unit tests. The floor guards against regressions and should ratchet up as vscode-free logic is extracted and unit-tested (the rest of #80).

## Verification
- `npm run lint` clean · `npm run compile` ok · `npm run test:coverage` green (gate passes) · `npm run test:integration` ok
- **Full e2e UI suite run locally on the VM: 7/7 passing** (webresource + plugin lifecycles, both publishing to Dataverse).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
