### PR TITLE
0.5.3 — Dataverse API-layer tests + CI coverage gate (#80), API-version centralisation cleanup (#77)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,8 +27,8 @@ jobs:
         run: npm run lint
       - name: Compile (webpack bundle)
         run: npm run compile
-      - name: Unit tests
-        run: npm run test:unit
+      - name: Unit tests (with coverage gate)
+        run: npm run test:coverage
       - name: Integration tests (headless VS Code)
         run: xvfb-run -a npm run test:integration
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to the "dataverse-powertools" extension will be documented in this file.
 
+## 0.5.3
+
+- Testing: unit-tested the Dataverse Web API layer (table / form / message / attribute / solution fetchers) — URL construction, response parsing, and error handling — and added a coverage threshold that CI now enforces as a regression gate (#80).
+- Internal: removed the now-redundant per-file `toApiUrl` wrappers so all Dataverse Web API calls go through the single `dataverseApiUrl` helper directly — one API-version source of truth (finishes #77). No behaviour change.
+
 ## 0.5.2
 
 - Fixed early-bound generation failing with `spawn EINVAL`: on Windows `pac` is a `.cmd` shim that recent Node versions refuse to spawn directly, so all `pac` calls (early-bound/model builder, portals, solutions) now run through `cmd.exe /c pac …`.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "dataverse-powertools",
-  "version": "0.5.2",
+  "version": "0.5.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "dataverse-powertools",
-      "version": "0.5.2",
+      "version": "0.5.3",
       "dependencies": {
         "@azure/msal-node": "^5.4.0",
         "adm-zip": "^0.5.18",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "type": "git",
     "url": "https://github.com/pete-mc/dataverse-powertools"
   },
-  "version": "0.5.2",
+  "version": "0.5.3",
   "engines": {
     "vscode": "^1.93.0"
   },

--- a/src/general/dataverse/getDataverseForms.spec.ts
+++ b/src/general/dataverse/getDataverseForms.spec.ts
@@ -1,0 +1,43 @@
+/* eslint-disable @typescript-eslint/naming-convention */ // Dataverse API response fields (LogicalName, msdyn_*) must match the API, not camelCase.
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+vi.mock("node-fetch", () => ({ default: vi.fn() }));
+import fetch from "node-fetch";
+import { getDataverseForms } from "./getDataverseForms";
+import { fakeDataverseContext, okJson, httpError } from "../../../test/dataverseTestUtils";
+
+const fetchMock = fetch as unknown as ReturnType<typeof vi.fn>;
+beforeEach(() => fetchMock.mockReset());
+
+describe("getDataverseForms", () => {
+  it("queries solutioncomponentsummaries filtered by entity and maps records", async () => {
+    fetchMock.mockResolvedValue(okJson({ value: [{ msdyn_objectid: "id-1", msdyn_name: "Main", msdyn_componenttypename: "Main Form" }] }));
+    const { context } = fakeDataverseContext();
+    const forms = await getDataverseForms(context, "account");
+    expect(forms).toEqual([{ formId: "id-1", displayName: "Main", formType: "Main Form" }]);
+    const url = fetchMock.mock.calls[0][0] as string;
+    expect(url).toContain("/api/data/v9.2/msdyn_solutioncomponentsummaries");
+    expect(url).toContain("msdyn_primaryentityname%20eq%20%27account%27");
+  });
+
+  it("initialises the connection first when the context is not yet valid", async () => {
+    fetchMock.mockResolvedValue(okJson({ value: [] }));
+    const { context } = fakeDataverseContext({ isValid: false });
+    await getDataverseForms(context, "contact");
+    expect(context.dataverse.initialize).toHaveBeenCalledOnce();
+  });
+
+  it("returns [] without calling fetch when initialise fails", async () => {
+    const { context } = fakeDataverseContext({ isValid: false });
+    context.dataverse.initialize = vi.fn(async () => false);
+    expect(await getDataverseForms(context, "account")).toEqual([]);
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("returns [] and logs on a non-OK response", async () => {
+    fetchMock.mockResolvedValue(httpError(404, "Not Found"));
+    const { context, lines } = fakeDataverseContext();
+    expect(await getDataverseForms(context, "account")).toEqual([]);
+    expect(lines.join("\n")).toContain("Failed to load forms for 'account': 404 Not Found");
+  });
+});

--- a/src/general/dataverse/getDataverseMessages.spec.ts
+++ b/src/general/dataverse/getDataverseMessages.spec.ts
@@ -1,0 +1,44 @@
+/* eslint-disable @typescript-eslint/naming-convention */ // Dataverse API response fields (name/Name) must match the API, not camelCase.
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+vi.mock("node-fetch", () => ({ default: vi.fn() }));
+import fetch from "node-fetch";
+import { getDataverseMessages } from "./getDataverseMessages";
+import { fakeDataverseContext, okJson, httpError } from "../../../test/dataverseTestUtils";
+
+const fetchMock = fetch as unknown as ReturnType<typeof vi.fn>;
+beforeEach(() => fetchMock.mockReset());
+
+describe("getDataverseMessages", () => {
+  it("requests non-private sdkmessages and returns names sorted ascending", async () => {
+    fetchMock.mockResolvedValue(okJson({ value: [{ name: "Update" }, { name: "Create" }, { name: "Delete" }] }));
+    const { context } = fakeDataverseContext();
+    const result = await getDataverseMessages(context);
+    expect(result).toEqual(["Create", "Delete", "Update"]);
+    expect(fetchMock.mock.calls[0][0]).toBe("https://org.crm.dynamics.com/api/data/v9.2/sdkmessages?$select=name&$filter=isprivate eq false");
+  });
+
+  it("accepts either name or Name casing and drops blanks", async () => {
+    fetchMock.mockResolvedValue(okJson({ value: [{ Name: "Assign" }, { name: " " }, { name: "Book" }, {}] }));
+    const { context } = fakeDataverseContext();
+    expect(await getDataverseMessages(context)).toEqual(["Assign", "Book"]);
+  });
+
+  it("returns [] and logs when the call fails (unparseable body)", async () => {
+    fetchMock.mockResolvedValue({
+      ok: true,
+      json: async () => {
+        throw new Error("network down");
+      },
+    });
+    const { context, lines } = fakeDataverseContext();
+    expect(await getDataverseMessages(context)).toEqual([]);
+    expect(lines.join("\n")).toContain("Error while trying to load messages: network down");
+  });
+
+  it("returns [] on a non-OK response", async () => {
+    fetchMock.mockResolvedValue(httpError(500, "Server Error"));
+    const { context } = fakeDataverseContext();
+    expect(await getDataverseMessages(context)).toEqual([]);
+  });
+});

--- a/src/general/dataverse/getDataverseTableAttributes.spec.ts
+++ b/src/general/dataverse/getDataverseTableAttributes.spec.ts
@@ -1,0 +1,49 @@
+/* eslint-disable @typescript-eslint/naming-convention */ // Dataverse API response fields (LogicalName) must match the API, not camelCase.
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+vi.mock("node-fetch", () => ({ default: vi.fn() }));
+import fetch from "node-fetch";
+import { getDataverseTableAttributes } from "./getDataverseTableAttributes";
+import { fakeDataverseContext, okJson, httpError } from "../../../test/dataverseTestUtils";
+
+const fetchMock = fetch as unknown as ReturnType<typeof vi.fn>;
+beforeEach(() => fetchMock.mockReset());
+
+describe("getDataverseTableAttributes", () => {
+  it("queries the entity's attributes and returns logical names sorted", async () => {
+    fetchMock.mockResolvedValue(okJson({ value: [{ LogicalName: "name" }, { LogicalName: "accountid" }, { LogicalName: "  " }] }));
+    const { context } = fakeDataverseContext();
+    const result = await getDataverseTableAttributes(context, "account");
+    expect(result).toEqual(["accountid", "name"]);
+    const url = fetchMock.mock.calls[0][0] as string;
+    expect(url).toContain("/api/data/v9.2/EntityDefinitions(LogicalName='account')/Attributes");
+    expect(url).toContain("AttributeOf eq null");
+  });
+
+  it("escapes single quotes in the table name to avoid breaking the OData filter", async () => {
+    fetchMock.mockResolvedValue(okJson({ value: [] }));
+    const { context } = fakeDataverseContext();
+    await getDataverseTableAttributes(context, "o'brien");
+    expect(fetchMock.mock.calls[0][0]).toContain("LogicalName='o''brien'");
+  });
+
+  it("returns [] without calling fetch when there is no access token", async () => {
+    const { context } = fakeDataverseContext();
+    context.dataverse.getAuthorizationToken = vi.fn(async () => "");
+    expect(await getDataverseTableAttributes(context, "account")).toEqual([]);
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("returns [] when the response has no value array", async () => {
+    fetchMock.mockResolvedValue(okJson({ notValue: true }));
+    const { context } = fakeDataverseContext();
+    expect(await getDataverseTableAttributes(context, "account")).toEqual([]);
+  });
+
+  it("returns [] and logs on a non-OK response", async () => {
+    fetchMock.mockResolvedValue(httpError(403, "Forbidden"));
+    const { context, lines } = fakeDataverseContext();
+    expect(await getDataverseTableAttributes(context, "account")).toEqual([]);
+    expect(lines.join("\n")).toContain("Failed to load attributes for table 'account': 403 Forbidden");
+  });
+});

--- a/src/general/dataverse/getDataverseTables.spec.ts
+++ b/src/general/dataverse/getDataverseTables.spec.ts
@@ -1,0 +1,46 @@
+/* eslint-disable @typescript-eslint/naming-convention */ // Dataverse API response fields (LogicalName, msdyn_*) must match the API, not camelCase.
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+vi.mock("node-fetch", () => ({ default: vi.fn() }));
+import fetch from "node-fetch";
+import { getDataverseTables } from "./getDataverseTables";
+import { fakeDataverseContext, okJson, httpError } from "../../../test/dataverseTestUtils";
+
+const fetchMock = fetch as unknown as ReturnType<typeof vi.fn>;
+beforeEach(() => fetchMock.mockReset());
+
+describe("getDataverseTables", () => {
+  it("requests EntityDefinitions on the v9.2 API and returns trimmed logical names", async () => {
+    fetchMock.mockResolvedValue(okJson({ value: [{ LogicalName: "account" }, { LogicalName: " contact " }] }));
+    const { context } = fakeDataverseContext({ organizationUrl: "https://org.crm.dynamics.com/" });
+    const result = await getDataverseTables(context);
+    expect(result).toEqual(["account", "contact"]);
+    expect(fetchMock.mock.calls[0][0]).toBe("https://org.crm.dynamics.com/api/data/v9.2/EntityDefinitions?$select=LogicalName");
+    expect(fetchMock.mock.calls[0][1].headers.Authorization).toBe("Bearer tok");
+  });
+
+  it("drops empty, whitespace-only, and missing logical names", async () => {
+    fetchMock.mockResolvedValue(okJson({ value: [{ LogicalName: "account" }, { LogicalName: "" }, { LogicalName: "   " }, {}] }));
+    const { context } = fakeDataverseContext();
+    expect(await getDataverseTables(context)).toEqual(["account"]);
+  });
+
+  it("returns [] and logs a consistent error on a non-OK response", async () => {
+    fetchMock.mockResolvedValue(httpError(401, "Unauthorized", "expired token"));
+    const { context, lines } = fakeDataverseContext();
+    expect(await getDataverseTables(context)).toEqual([]);
+    expect(lines.join("\n")).toContain("Failed to load tables: 401 Unauthorized — expired token");
+  });
+
+  it("returns [] and logs when the call fails (unparseable body)", async () => {
+    fetchMock.mockResolvedValue({
+      ok: true,
+      json: async () => {
+        throw new Error("ECONNRESET");
+      },
+    });
+    const { context, lines } = fakeDataverseContext();
+    expect(await getDataverseTables(context)).toEqual([]);
+    expect(lines.join("\n")).toContain("Error while trying to load tables: ECONNRESET");
+  });
+});

--- a/src/general/dataverse/getSolutions.spec.ts
+++ b/src/general/dataverse/getSolutions.spec.ts
@@ -1,0 +1,57 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+vi.mock("node-fetch", () => ({ default: vi.fn() }));
+import fetch from "node-fetch";
+import { getSolutions } from "./getSolutions";
+import { fakeDataverseContext, okJson, httpError } from "../../../test/dataverseTestUtils";
+
+const fetchMock = fetch as unknown as ReturnType<typeof vi.fn>;
+beforeEach(() => fetchMock.mockReset());
+
+const sampleSolution = {
+  solutionid: "sol-1",
+  friendlyname: "Dataverse PowerTools Tests",
+  uniquename: "dvpttests",
+  publisherid: { friendlyname: "DVPT Publisher", customizationprefix: "dvpt", publisherid: "pub-1" },
+};
+
+describe("getSolutions", () => {
+  it("requests unmanaged solutions with the publisher expanded and maps them", async () => {
+    fetchMock.mockResolvedValue(okJson({ value: [sampleSolution] }));
+    const { context } = fakeDataverseContext();
+    const solutions = await getSolutions(context);
+    expect(solutions).toHaveLength(1);
+    expect(solutions![0]).toMatchObject({
+      id: "sol-1",
+      displayName: "Dataverse PowerTools Tests",
+      uniqueName: "dvpttests",
+      publisherName: "DVPT Publisher",
+      publisherPrefix: "dvpt",
+      publisherId: "pub-1",
+    });
+    const url = fetchMock.mock.calls[0][0] as string;
+    expect(url).toContain("/api/data/v9.2/solutions");
+    expect(url).toContain("ismanaged%20eq%20false");
+    expect(url).toContain("$expand=publisherid");
+  });
+
+  it("returns undefined on a non-OK response", async () => {
+    fetchMock.mockResolvedValue(httpError(403, "Forbidden"));
+    const { context } = fakeDataverseContext();
+    expect(await getSolutions(context)).toBeUndefined();
+  });
+
+  it("returns undefined when the response shape is unexpected", async () => {
+    fetchMock.mockResolvedValue(okJson({ notValue: [] }));
+    const { context, lines } = fakeDataverseContext();
+    expect(await getSolutions(context)).toBeUndefined();
+    expect(lines.join("\n")).toContain("Unexpected solutions response");
+  });
+
+  it("initialises first when the context is not valid", async () => {
+    fetchMock.mockResolvedValue(okJson({ value: [] }));
+    const { context } = fakeDataverseContext({ isValid: false });
+    await getSolutions(context);
+    expect(context.dataverse.initialize).toHaveBeenCalledOnce();
+  });
+});

--- a/src/general/dataverse/registerPluginSteps.ts
+++ b/src/general/dataverse/registerPluginSteps.ts
@@ -4,12 +4,6 @@ import { addDataverseSolutionComponent } from "./addDataverseSolutionComponent";
 import { DataverseContext, Options } from "./dataverseContext";
 import { dataverseApiUrl, logDataverseHttpError } from "./webApi";
 
-// The helpers below take "/api/data/v9.x/<resource>" relative urls; strip the version
-// segment and rebuild via the central helper so every request targets one API version.
-function toApiUrl(baseUrl: string, relativeUrl: string): string {
-  return dataverseApiUrl(baseUrl, relativeUrl.replace(/^\/?api\/data\/v9\.[0-9]\//, ""));
-}
-
 export interface PluginStepRegistration {
   className: string;
   fullTypeName: string;
@@ -61,7 +55,7 @@ async function getJson(context: DataversePowerToolsContext, relativeUrl: string)
   } as Options;
   /* eslint-enable @typescript-eslint/naming-convention */
 
-  const response = await fetch(toApiUrl(baseUrl, relativeUrl), options);
+  const response = await fetch(dataverseApiUrl(baseUrl, relativeUrl), options);
   if (!response.ok) {
     await logDataverseHttpError(context.channel, `GET ${relativeUrl}`, response);
     return undefined;
@@ -93,7 +87,7 @@ async function sendJson(context: DataversePowerToolsContext, method: "POST" | "P
   } as Options;
   /* eslint-enable @typescript-eslint/naming-convention */
 
-  const response = await fetch(toApiUrl(baseUrl, relativeUrl), options);
+  const response = await fetch(dataverseApiUrl(baseUrl, relativeUrl), options);
   if (!response.ok) {
     await logDataverseHttpError(context.channel, `${method} ${relativeUrl}`, response);
     return undefined;
@@ -108,10 +102,7 @@ async function sendJson(context: DataversePowerToolsContext, method: "POST" | "P
 
 async function resolvePluginTypeId(context: DataversePowerToolsContext, assemblyId: string, fullTypeName: string): Promise<string | undefined> {
   const escapedTypeName = escapeODataString(fullTypeName);
-  const data = await getJson(
-    context,
-    `/api/data/v9.1/plugintypes?$select=plugintypeid,typename&$filter=_pluginassemblyid_value eq ${assemblyId} and typename eq '${escapedTypeName}'`,
-  );
+  const data = await getJson(context, `plugintypes?$select=plugintypeid,typename&$filter=_pluginassemblyid_value eq ${assemblyId} and typename eq '${escapedTypeName}'`);
 
   if (!data?.value || !Array.isArray(data.value) || data.value.length === 0) {
     return undefined;
@@ -122,7 +113,7 @@ async function resolvePluginTypeId(context: DataversePowerToolsContext, assembly
 
 async function resolveSdkMessageId(context: DataversePowerToolsContext, messageName: string): Promise<string | undefined> {
   const escapedMessageName = escapeODataString(messageName);
-  const data = await getJson(context, `/api/data/v9.1/sdkmessages?$select=sdkmessageid,name&$filter=name eq '${escapedMessageName}'`);
+  const data = await getJson(context, `sdkmessages?$select=sdkmessageid,name&$filter=name eq '${escapedMessageName}'`);
   if (!data?.value || !Array.isArray(data.value) || data.value.length === 0) {
     return undefined;
   }
@@ -138,7 +129,7 @@ async function resolveSdkMessageFilterId(context: DataversePowerToolsContext, sd
   const escapedEntityName = escapeODataString(entityLogicalName);
   const data = await getJson(
     context,
-    `/api/data/v9.1/sdkmessagefilters?$select=sdkmessagefilterid,primaryobjecttypecode&$filter=_sdkmessageid_value eq ${sdkMessageId} and primaryobjecttypecode eq '${escapedEntityName}'`,
+    `sdkmessagefilters?$select=sdkmessagefilterid,primaryobjecttypecode&$filter=_sdkmessageid_value eq ${sdkMessageId} and primaryobjecttypecode eq '${escapedEntityName}'`,
   );
 
   if (!data?.value || !Array.isArray(data.value) || data.value.length === 0) {
@@ -159,7 +150,7 @@ async function resolveExistingStepId(context: DataversePowerToolsContext, step: 
   const escapedStepName = escapeODataString(step.stepName);
   const data = await getJson(
     context,
-    `/api/data/v9.1/sdkmessageprocessingsteps?$select=sdkmessageprocessingstepid,name&$filter=_plugintypeid_value eq ${pluginTypeId} and _sdkmessageid_value eq ${sdkMessageId} and name eq '${escapedStepName}'`,
+    `sdkmessageprocessingsteps?$select=sdkmessageprocessingstepid,name&$filter=_plugintypeid_value eq ${pluginTypeId} and _sdkmessageid_value eq ${sdkMessageId} and name eq '${escapedStepName}'`,
   );
 
   if (!data?.value || !Array.isArray(data.value) || data.value.length === 0) {
@@ -191,7 +182,7 @@ async function doesStepExistById(context: DataversePowerToolsContext, stepId: st
   } as Options;
   /* eslint-enable @typescript-eslint/naming-convention */
 
-  const response = await fetch(toApiUrl(baseUrl, `/api/data/v9.1/sdkmessageprocessingsteps(${stepId})?$select=sdkmessageprocessingstepid`), options);
+  const response = await fetch(dataverseApiUrl(baseUrl, `sdkmessageprocessingsteps(${stepId})?$select=sdkmessageprocessingstepid`), options);
   if (response.ok) {
     return true;
   }
@@ -215,10 +206,7 @@ interface ExistingStepSnapshot {
 }
 
 async function getExistingStepSnapshot(context: DataversePowerToolsContext, stepId: string): Promise<ExistingStepSnapshot | undefined> {
-  const data = await getJson(
-    context,
-    `/api/data/v9.1/sdkmessageprocessingsteps(${stepId})?$select=sdkmessageprocessingstepid,name,rank,stage,mode,filteringattributes,_sdkmessagefilterid_value`,
-  );
+  const data = await getJson(context, `sdkmessageprocessingsteps(${stepId})?$select=sdkmessageprocessingstepid,name,rank,stage,mode,filteringattributes,_sdkmessagefilterid_value`);
 
   if (!data) {
     return undefined;
@@ -345,7 +333,7 @@ export async function registerPluginSteps(
       const requiresUpdate = existingSnapshot ? stepNeedsUpdate(existingSnapshot, step, sdkMessageFilterId) : true;
 
       if (requiresUpdate) {
-        const updateResponse = await sendJson(context, "PATCH", `/api/data/v9.1/sdkmessageprocessingsteps(${existingStepId})`, stepPayload);
+        const updateResponse = await sendJson(context, "PATCH", `sdkmessageprocessingsteps(${existingStepId})`, stepPayload);
         if (updateResponse !== undefined) {
           updated++;
         } else {
@@ -366,7 +354,7 @@ export async function registerPluginSteps(
       continue;
     }
 
-    const createResponse = await sendJson(context, "POST", "/api/data/v9.1/sdkmessageprocessingsteps", stepPayload);
+    const createResponse = await sendJson(context, "POST", "sdkmessageprocessingsteps", stepPayload);
     const createdStepId = createResponse?.sdkmessageprocessingstepid;
     if (createResponse !== undefined && createdStepId) {
       created++;

--- a/src/general/dataverse/registerWorkflowActivities.ts
+++ b/src/general/dataverse/registerWorkflowActivities.ts
@@ -4,12 +4,6 @@ import { addDataverseSolutionComponent } from "./addDataverseSolutionComponent";
 import { DataverseContext, Options } from "./dataverseContext";
 import { dataverseApiUrl, logDataverseHttpError } from "./webApi";
 
-// Callers pass "/api/data/v9.x/<resource>" relative urls; strip the version segment
-// and rebuild via the central helper so every request targets one API version.
-function toApiUrl(baseUrl: string, relativeUrl: string): string {
-  return dataverseApiUrl(baseUrl, relativeUrl.replace(/^\/?api\/data\/v9\.[0-9]\//, ""));
-}
-
 export interface WorkflowActivityRegistration {
   className: string;
   fullTypeName: string;
@@ -79,7 +73,7 @@ async function getJson(context: DataversePowerToolsContext, relativeUrl: string)
   } as Options;
   /* eslint-enable @typescript-eslint/naming-convention */
 
-  const response = await fetch(toApiUrl(baseUrl, relativeUrl), options);
+  const response = await fetch(dataverseApiUrl(baseUrl, relativeUrl), options);
   if (!response.ok) {
     await logDataverseHttpError(context.channel, `GET ${relativeUrl}`, response);
     return undefined;
@@ -111,7 +105,7 @@ async function patchJson(context: DataversePowerToolsContext, relativeUrl: strin
   } as Options;
   /* eslint-enable @typescript-eslint/naming-convention */
 
-  const response = await fetch(toApiUrl(baseUrl, relativeUrl), options);
+  const response = await fetch(dataverseApiUrl(baseUrl, relativeUrl), options);
   if (response.ok) {
     return true;
   }
@@ -124,7 +118,7 @@ async function resolveWorkflowPluginType(context: DataversePowerToolsContext, as
   const escapedTypeName = escapeODataString(fullTypeName);
   const data = await getJson(
     context,
-    `/api/data/v9.1/plugintypes?$select=plugintypeid,typename,name,friendlyname,description,workflowactivitygroupname&$filter=_pluginassemblyid_value eq ${assemblyId} and typename eq '${escapedTypeName}'`,
+    `plugintypes?$select=plugintypeid,typename,name,friendlyname,description,workflowactivitygroupname&$filter=_pluginassemblyid_value eq ${assemblyId} and typename eq '${escapedTypeName}'`,
   );
 
   const records = Array.isArray(data?.value) ? data.value : [];
@@ -179,7 +173,7 @@ async function resolveWorkflowPluginTypeFromAssembly(
 ): Promise<ResolvedWorkflowPluginType | undefined> {
   const data = await getJson(
     context,
-    `/api/data/v9.1/plugintypes?$select=plugintypeid,typename,name,friendlyname,description,workflowactivitygroupname&$filter=_pluginassemblyid_value eq ${assemblyId}`,
+    `plugintypes?$select=plugintypeid,typename,name,friendlyname,description,workflowactivitygroupname&$filter=_pluginassemblyid_value eq ${assemblyId}`,
   );
 
   const records: any[] = Array.isArray(data?.value) ? data.value : [];
@@ -258,7 +252,7 @@ export async function registerWorkflowActivities(
 
     const payload = getWorkflowPatchPayload(resolved.snapshot, workflow);
     if (Object.keys(payload).length > 0) {
-      const patched = await patchJson(context, `/api/data/v9.1/plugintypes(${resolved.plugintypeid})`, payload);
+      const patched = await patchJson(context, `plugintypes(${resolved.plugintypeid})`, payload);
       if (patched) {
         updated++;
         context.channel.appendLine(`Updated workflow activity '${workflowLabel}' (${workflow.className}).`);

--- a/test/dataverseTestUtils.ts
+++ b/test/dataverseTestUtils.ts
@@ -1,0 +1,44 @@
+import { vi } from "vitest";
+
+// Shared helpers for unit-testing the Dataverse HTTP fetchers (src/general/dataverse/*).
+// The fetchers are pure (no vscode) but call node-fetch and read context.dataverse +
+// context.channel — so a spec mocks node-fetch and passes one of these fake contexts.
+
+export interface FakeContextOptions {
+  organizationUrl?: string;
+  authorizationToken?: string;
+  isValid?: boolean;
+  /** Token returned by getAuthorizationToken(); defaults to authorizationToken. */
+  token?: string;
+}
+
+/** A minimal fake DataversePowerToolsContext with a captured output channel. */
+export function fakeDataverseContext(opts: FakeContextOptions = {}) {
+  const lines: string[] = [];
+  const organizationUrl = opts.organizationUrl ?? "https://org.crm.dynamics.com";
+  const authorizationToken = opts.authorizationToken ?? "tok";
+  const context = {
+    dataverse: {
+      organizationUrl,
+      authorizationToken,
+      isValid: opts.isValid ?? true,
+      initialize: vi.fn(async () => true),
+      getAuthorizationToken: vi.fn(async () => opts.token ?? authorizationToken),
+    },
+    channel: {
+      appendLine: (m: string) => lines.push(String(m)),
+      show: () => undefined,
+    },
+  };
+  return { context: context as any, lines };
+}
+
+/** A fake node-fetch Response for a successful JSON body. */
+export function okJson(body: unknown) {
+  return { ok: true, status: 200, statusText: "OK", json: async () => body, text: async () => JSON.stringify(body) };
+}
+
+/** A fake node-fetch Response for a failed HTTP call. */
+export function httpError(status: number, statusText = "", body = "") {
+  return { ok: false, status, statusText, json: async () => null, text: async () => body };
+}

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -12,7 +12,18 @@ export default defineConfig({
     coverage: {
       provider: "v8",
       include: ["src/**/*.ts"],
-      exclude: ["src/**/*.spec.ts", "src/test/**", "src/ui-test/**"],
+      exclude: ["src/**/*.spec.ts", "src/test/**", "src/ui-test/**", "src/plugins_old/**"],
+      reporter: ["text", "text-summary"],
+      // A floor that guards against coverage *regressions* (run in CI via test:coverage).
+      // Global unit coverage is low by design: most of src is tangled with the vscode API
+      // and is covered by the integration + ExTester UI suites, not unit tests. Ratchet
+      // these up as vscode-free logic is extracted and unit-tested (see #80).
+      thresholds: {
+        statements: 7,
+        branches: 7,
+        functions: 9,
+        lines: 7,
+      },
     },
   },
   resolve: {


### PR DESCRIPTION
Maintenance/quality release. **No user-facing behaviour change** — the shipped extension behaves identically to 0.5.2; this lands internal cleanup + a CI regression gate.

## Contents
- **#80** — unit-test the Dataverse Web API layer (`getDataverseTables/Forms/Messages/TableAttributes` + `getSolutions`, 21 tests: URL construction, parsing, error paths) and add a **coverage threshold** that CI now enforces via `test:coverage`. Unit suite 95 → **116**; coverage 5.41% → **8.29%** statements (fetchers 85–100%).
- **#77** — finishes the Dataverse API-version centralisation started in 0.5.1: removed the now-redundant per-file `toApiUrl` wrappers so all calls go through the single `dataverseApiUrl` helper directly (one version source of truth). Behaviour-preserving.
- Version bump to **0.5.3** + changelog.

Closes #77. Substantial progress on #80 (the remaining scope — broader coverage via vscode-free extraction — stays open).

## Verification
- `npm run lint` clean · `npm run compile` ok · `npm run test:coverage` green (gate passes) · `npm run test:integration` ok
- **Full e2e UI suite on the VM: 7/7 passing** (webresource + plugin lifecycles, both publishing to Dataverse) — run against this branch with the #77 change compiled in.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
