### PR TITLE
feat: Debug Web Resources — serve local build into the live app with hot reload (#64)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to the "dataverse-powertools" extension will be documented in this file.
 
+## 0.5.4
+
+- New: **Debug Web Resources** — run your local webpack bundle _inside the live model-driven app_ with hot reload and VS Code debugging, instead of republishing on every change. A dedicated Edge/Chrome instance is launched under the DevTools Protocol and its request for the deployed bundle is fulfilled from your local `bin/` build; `webpack --watch` rebuilds on save and the form reloads, and the JS debugger attaches for breakpoints. Nothing is written to Dataverse — the swap is ephemeral and browser-scoped (#64).
+- Fixed Debug Web Resources not taking effect on real forms: model-driven apps serve web resources from a service-worker cache above the network layer, so interception now bypasses that service worker to ensure the live form runs your local code.
+- Security: resolved CodeQL findings in existing code — reworked two ReDoS-prone regexes, spawn a constant `cmd.exe` instead of an environment-provided one, and validate/sanitize the organization URL and plugin project name before they are passed to external tools. No behaviour change for valid input.
+
 ## 0.5.3
 
 - Testing: unit-tested the Dataverse Web API layer (table / form / message / attribute / solution fetchers) — URL construction, response parsing, and error handling — and added a coverage threshold that CI now enforces as a regression gate (#80).

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ one activity bar. Cross-platform, powered by the Power Platform CLI and .NET SDK
 | Plugins | Web Resources | Solutions |
 | :---: | :---: | :---: |
 | <img src="media/plugin-menu.png" width="230" /> | <img src="media/webresource-menu.png" width="230" /> | <img src="media/solution-menu.png" width="230" /> |
-| Create classes & workflows, register steps with CodeLens, generate early-bound types, build with `dotnet`, deploy as a plugin package, unit test with DataverseUnitTest. | Write TypeScript, bundle with webpack, deploy to Dataverse, generate strongly-typed `Xrm` typings, unit test with Jest + xrm-mock. | Export, unpack, pack and import solutions with `pac` — ready for source control and CI/CD. |
+| Create classes & workflows, register steps with CodeLens, generate early-bound types, build with `dotnet`, deploy as a plugin package, unit test with DataverseUnitTest. | Write TypeScript, bundle with webpack, deploy to Dataverse, debug your local bundle live in the real app with hot reload, generate strongly-typed `Xrm` typings, unit test with Jest + xrm-mock. | Export, unpack, pack and import solutions with `pac` — ready for source control and CI/CD. |
 | **[Learn more →](https://github.com/pete-mc/dataverse-powertools/wiki/Plugins)** | **[Learn more →](https://github.com/pete-mc/dataverse-powertools/wiki/Webresources)** | **[Learn more →](https://github.com/pete-mc/dataverse-powertools/wiki/Solutions)** |
 
 ## Get started in minutes

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "dataverse-powertools",
-  "version": "0.5.3",
+  "version": "0.5.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "dataverse-powertools",
-      "version": "0.5.3",
+      "version": "0.5.4",
       "dependencies": {
         "@azure/msal-node": "^5.4.0",
         "adm-zip": "^0.5.18",

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,12 +10,14 @@
       "dependencies": {
         "@azure/msal-node": "^5.4.0",
         "adm-zip": "^0.5.18",
+        "chrome-remote-interface": "^0.34.0",
         "fast-xml-parser": "^5.9.3",
         "fs-extra": "^10.1.0",
         "node-fetch": "^3.2.10"
       },
       "devDependencies": {
         "@types/adm-zip": "^0.5.8",
+        "@types/chrome-remote-interface": "^0.34.0",
         "@types/fs-extra": "^9.0.13",
         "@types/jest": "^30.0.0",
         "@types/mocha": "^10.0.10",
@@ -2633,6 +2635,16 @@
       "dependencies": {
         "@types/deep-eql": "*",
         "assertion-error": "^2.0.1"
+      }
+    },
+    "node_modules/@types/chrome-remote-interface": {
+      "version": "0.34.0",
+      "resolved": "https://registry.npmjs.org/@types/chrome-remote-interface/-/chrome-remote-interface-0.34.0.tgz",
+      "integrity": "sha512-4q8pMUvasrAkB7bejGWw5igboAvBz7vJRZq+295yFONGoeN7X/hfq8Mq4vTxUQKnENbR9tqksP8RZsLxlRtsWQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "devtools-protocol": "0.0.1173815"
       }
     },
     "node_modules/@types/deep-eql": {
@@ -5292,6 +5304,46 @@
       "integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==",
       "dev": true
     },
+    "node_modules/chrome-remote-interface": {
+      "version": "0.34.0",
+      "resolved": "https://registry.npmjs.org/chrome-remote-interface/-/chrome-remote-interface-0.34.0.tgz",
+      "integrity": "sha512-rTTcTZ3zemx8I+nvBii7d8BAF0Ms8LLEroypfvwwZOwSpyNGLE28nStXyCA6VwGp2YSQfmCrQH21F/E+oBFvMw==",
+      "license": "MIT",
+      "dependencies": {
+        "commander": "2.11.x",
+        "ws": "^7.2.0"
+      },
+      "bin": {
+        "chrome-remote-interface": "bin/client.js"
+      }
+    },
+    "node_modules/chrome-remote-interface/node_modules/commander": {
+      "version": "2.11.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.11.0.tgz",
+      "integrity": "sha512-b0553uYA5YAEGgyYIGYROzKQ7X5RAqedkfjiZxwi0kL1g3bOaBNNZfYkzt/CL0umgD5wc9Jec2FbB98CjkMRvQ==",
+      "license": "MIT"
+    },
+    "node_modules/chrome-remote-interface/node_modules/ws": {
+      "version": "7.5.11",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.11.tgz",
+      "integrity": "sha512-zS54Oen9bITtp7kp2XM3AydrCIq1D+HwJOuH+c+e4LfpL/lotP5osijd+UoMnxwAam1GN8R4KtLAyIrIcBNpiA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.3.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": "^5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/chrome-trace-event": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/chrome-trace-event/-/chrome-trace-event-1.0.4.tgz",
@@ -5800,6 +5852,13 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/devtools-protocol": {
+      "version": "0.0.1173815",
+      "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.1173815.tgz",
+      "integrity": "sha512-CmsjkudmgCMeae8FSJB4GV8COZwOk6dJKyE9HS2F/ih/sA8uTdbPKHg5F7DsrOYLEET/QKK00LJCU4YoyG+uHg==",
+      "dev": true,
+      "license": "BSD-3-Clause"
     },
     "node_modules/diff": {
       "version": "7.0.0",

--- a/package.json
+++ b/package.json
@@ -217,12 +217,12 @@
       },
       {
         "view": "dataversePowerToolsMenu",
-        "contents": "Webresource Menu\n[Create New Class](command:dataverse-powertools.createWebResourceClass)\n[Create New Test](command:dataverse-powertools.createWebResourceTest)\n[Build Web Resources](command:dataverse-powertools.buildWebresources)\n[Build & Deploy Web Resources](command:dataverse-powertools.deployWebresources)\n[Generate Typings](command:dataverse-powertools.generateTypings)\n[Add Form Registration](command:dataverse-powertools.addFormDecoration)\n[Register Form Events](command:dataverse-powertools.saveFormData)\n[Upgrade from Spkl](command:dataverse-powertools.upgradeFromSpkl)",
+        "contents": "Webresource Menu\n[Create New Class](command:dataverse-powertools.createWebResourceClass)\n[Create New Test](command:dataverse-powertools.createWebResourceTest)\n[Build Web Resources](command:dataverse-powertools.buildWebresources)\n[Build & Deploy Web Resources](command:dataverse-powertools.deployWebresources)\n[Debug Web Resources (local)](command:dataverse-powertools.debugWebresources)\n[Generate Typings](command:dataverse-powertools.generateTypings)\n[Add Form Registration](command:dataverse-powertools.addFormDecoration)\n[Register Form Events](command:dataverse-powertools.saveFormData)\n[Upgrade from Spkl](command:dataverse-powertools.upgradeFromSpkl)",
         "when": "dataverse-powertools.showLoaded && dataverse-powertools.isWebResource && dataverse-powertools.hasSpkl"
       },
       {
         "view": "dataversePowerToolsMenu",
-        "contents": "Webresource Menu\n[Create New Class](command:dataverse-powertools.createWebResourceClass)\n[Create New Test](command:dataverse-powertools.createWebResourceTest)\n[Build Web Resources](command:dataverse-powertools.buildWebresources)\n[Build & Deploy Web Resources](command:dataverse-powertools.deployWebresources)\n[Generate Typings](command:dataverse-powertools.generateTypings)\n[Add Form Registration](command:dataverse-powertools.addFormDecoration)\n[Register Form Events](command:dataverse-powertools.saveFormData)",
+        "contents": "Webresource Menu\n[Create New Class](command:dataverse-powertools.createWebResourceClass)\n[Create New Test](command:dataverse-powertools.createWebResourceTest)\n[Build Web Resources](command:dataverse-powertools.buildWebresources)\n[Build & Deploy Web Resources](command:dataverse-powertools.deployWebresources)\n[Debug Web Resources (local)](command:dataverse-powertools.debugWebresources)\n[Generate Typings](command:dataverse-powertools.generateTypings)\n[Add Form Registration](command:dataverse-powertools.addFormDecoration)\n[Register Form Events](command:dataverse-powertools.saveFormData)",
         "when": "dataverse-powertools.showLoaded && dataverse-powertools.isWebResource && !dataverse-powertools.hasSpkl"
       },
       {
@@ -501,6 +501,16 @@
         "enablement": "dataverse-powertools.showLoaded && dataverse-powertools.isWebResource"
       },
       {
+        "command": "dataverse-powertools.debugWebresources",
+        "title": "Dataverse PowerTools: Debug Web Resources (serve local build into the live app)",
+        "enablement": "dataverse-powertools.showLoaded && dataverse-powertools.isWebResource"
+      },
+      {
+        "command": "dataverse-powertools.stopDebugWebresources",
+        "title": "Dataverse PowerTools: Stop Debugging Web Resources",
+        "enablement": "dataverse-powertools.showLoaded && dataverse-powertools.isWebResource"
+      },
+      {
         "command": "dataverse-powertools.createPluginClass",
         "title": "Dataverse PowerTools: Create Plugin Class",
         "enablement": "dataverse-powertools.showLoaded && dataverse-powertools.isPlugin"
@@ -609,7 +619,24 @@
         "command": "dataverse-powertools.installRequiredGlobals",
         "title": "Dataverse PowerTools: Add Missing npm Globals"
       }
-    ]
+    ],
+    "configuration": {
+      "title": "Dataverse PowerTools",
+      "properties": {
+        "dataverse-powertools.debugBrowser": {
+          "type": "string",
+          "enum": ["auto", "msedge", "chrome"],
+          "enumDescriptions": ["Prefer Microsoft Edge, fall back to Chrome", "Use Microsoft Edge", "Use Google Chrome"],
+          "default": "auto",
+          "markdownDescription": "Which browser the **Debug Web Resources** command launches under the DevTools Protocol. A persistent profile is used so your Dataverse login is remembered between sessions."
+        },
+        "dataverse-powertools.debugBrowserPath": {
+          "type": "string",
+          "default": "",
+          "markdownDescription": "Optional full path to the Edge/Chrome executable used by **Debug Web Resources**. Leave blank to auto-detect a supported browser."
+        }
+      }
+    }
   },
   "scripts": {
     "vscode:prepublish": "npm run package",
@@ -633,6 +660,7 @@
   },
   "devDependencies": {
     "@types/adm-zip": "^0.5.8",
+    "@types/chrome-remote-interface": "^0.34.0",
     "@types/fs-extra": "^9.0.13",
     "@types/jest": "^30.0.0",
     "@types/mocha": "^10.0.10",
@@ -668,6 +696,7 @@
   "dependencies": {
     "@azure/msal-node": "^5.4.0",
     "adm-zip": "^0.5.18",
+    "chrome-remote-interface": "^0.34.0",
     "fast-xml-parser": "^5.9.3",
     "fs-extra": "^10.1.0",
     "node-fetch": "^3.2.10"

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "type": "git",
     "url": "https://github.com/pete-mc/dataverse-powertools"
   },
-  "version": "0.5.3",
+  "version": "0.5.4",
   "engines": {
     "vscode": "^1.93.0"
   },
@@ -625,8 +625,16 @@
       "properties": {
         "dataverse-powertools.debugBrowser": {
           "type": "string",
-          "enum": ["auto", "msedge", "chrome"],
-          "enumDescriptions": ["Prefer Microsoft Edge, fall back to Chrome", "Use Microsoft Edge", "Use Google Chrome"],
+          "enum": [
+            "auto",
+            "msedge",
+            "chrome"
+          ],
+          "enumDescriptions": [
+            "Prefer Microsoft Edge, fall back to Chrome",
+            "Use Microsoft Edge",
+            "Use Google Chrome"
+          ],
           "default": "auto",
           "markdownDescription": "Which browser the **Debug Web Resources** command launches under the DevTools Protocol. A persistent profile is used so your Dataverse login is remembered between sessions."
         },

--- a/src/general/connectionString.ts
+++ b/src/general/connectionString.ts
@@ -92,13 +92,28 @@ export function normalizeOrganizationUrl(url: string | undefined | null): string
     return "";
   }
   const lower = stripped.toLowerCase();
+  let normalized: string;
   if (lower.startsWith("https://")) {
-    return stripped;
+    normalized = stripped;
+  } else if (lower.startsWith("http://")) {
+    normalized = "https://" + stripped.slice("http://".length);
+  } else {
+    normalized = "https://" + stripped;
   }
-  if (lower.startsWith("http://")) {
-    return "https://" + stripped.slice("http://".length);
+
+  // Defence in depth: this URL is later handed to external tools (e.g. XrmDefinitelyTyped).
+  // Constrain it to a well-formed https URL whose host is a plain hostname — anything else
+  // can't be a real Dataverse org and must not flow downstream where it could carry unexpected
+  // characters. Reject (return "") rather than pass a suspicious value through.
+  try {
+    const parsed = new URL(normalized);
+    if (parsed.protocol !== "https:" || !/^[A-Za-z0-9.-]+$/.test(parsed.hostname)) {
+      return "";
+    }
+  } catch {
+    return "";
   }
-  return "https://" + stripped;
+  return normalized;
 }
 
 /** The organization URL from a connection string, trailing slashes removed. */

--- a/src/general/pac.spec.ts
+++ b/src/general/pac.spec.ts
@@ -24,10 +24,10 @@ describe("pacInvocation", () => {
     expect(pacInvocation(["auth", "list"])).toEqual({ command: "cmd.exe", args: ["/c", "pac", "auth", "list"] });
   });
 
-  it("honours ComSpec when set", () => {
+  it("uses a constant cmd.exe and ignores %ComSpec% so the spawned command can't be redirected by the environment", () => {
     setPlatform("win32");
-    process.env.ComSpec = "C:\\Windows\\System32\\cmd.exe";
-    expect(pacInvocation(["modelbuilder", "build"]).command).toBe("C:\\Windows\\System32\\cmd.exe");
+    process.env.ComSpec = "C:\\attacker\\evil.exe";
+    expect(pacInvocation(["modelbuilder", "build"]).command).toBe("cmd.exe");
   });
 
   it("passes pac arguments through untouched", () => {

--- a/src/general/pac.ts
+++ b/src/general/pac.ts
@@ -11,7 +11,9 @@
 /** The child_process command + args to run `pac` with the given pac arguments. */
 export function pacInvocation(args: string[]): { command: string; args: string[] } {
   if (process.platform === "win32") {
-    return { command: process.env.ComSpec || "cmd.exe", args: ["/c", "pac", ...args] };
+    // A constant executable name (not read from %ComSpec%) so the command being spawned can
+    // never be redirected by the environment; cmd.exe is resolved from the system directory.
+    return { command: "cmd.exe", args: ["/c", "pac", ...args] };
   }
   return { command: "pac", args };
 }

--- a/src/general/restoreDependencies.ts
+++ b/src/general/restoreDependencies.ts
@@ -16,6 +16,16 @@ function isDotnetAddWorkflowPackage(argv: string[]): boolean {
   return argv[0]?.toLowerCase() === "dotnet" && argv[1]?.toLowerCase() === "add" && argv[2]?.toLowerCase() === "package" && argv[3]?.toLowerCase() === "microsoft.crmsdk.workflow";
 }
 
+/**
+ * Constrain a plugin project name to characters valid in a folder/project name before it is
+ * interpolated into a file path and passed to `dotnet` — strips path separators and any shell
+ * metacharacters, so untrusted project settings can't escape the intended directory or command.
+ */
+function sanitizeProjectName(name: string | undefined): string {
+  const cleaned = (name || "").trim().replace(/[^A-Za-z0-9_.-]/g, "");
+  return cleaned || "Plugin";
+}
+
 function resolvePluginCsprojPath(workspacePath: string, projectName: string): string {
   const projectDirectory = path.join(workspacePath, projectName);
   const preferredPath = path.join(projectDirectory, `${projectName}.csproj`);
@@ -55,7 +65,7 @@ function resolveInitCommand(command: string, workspacePath: string, context: Dat
     return command;
   }
 
-  const projectName = (context.projectSettings.pluginProjectName || "Plugin").trim() || "Plugin";
+  const projectName = sanitizeProjectName(context.projectSettings.pluginProjectName);
   const argv = command.split(/\s+/).filter((token) => token.length > 0);
 
   if (isPacPluginInit(argv)) {

--- a/src/plugins/buildAndDeploy.ts
+++ b/src/plugins/buildAndDeploy.ts
@@ -216,15 +216,14 @@ async function findBuiltPackagePath(workspacePath: string, csprojPath: string, p
 function sanitizeUniqueNameSegment(value: string): string {
   return value
     .replace(/[^A-Za-z0-9_]/g, "_")
-    .replace(/_+/g, "_")
-    .replace(/^_+|_+$/g, "");
+    .replace(/_+/g, "_") // collapse runs first, so the trims below only ever see a single underscore (avoids polynomial backtracking)
+    .replace(/^_/, "")
+    .replace(/_$/, "");
 }
 
 function normalizeCustomizationPrefix(prefix: string | undefined): string {
-  const sanitized = (prefix || "")
-    .trim()
-    .replace(/[^A-Za-z0-9]/g, "")
-    .replace(/_+$/g, "");
+  // `[^A-Za-z0-9]` already removes underscores, so no separate trailing-underscore trim is needed.
+  const sanitized = (prefix || "").trim().replace(/[^A-Za-z0-9]/g, "");
 
   if (!sanitized) {
     return "dpt";

--- a/src/webresources/debug/browserArgs.spec.ts
+++ b/src/webresources/debug/browserArgs.spec.ts
@@ -1,0 +1,16 @@
+import { describe, it, expect } from "vitest";
+import { buildBrowserArgs } from "./browserArgs";
+
+describe("buildBrowserArgs", () => {
+  it("builds the CDP + persistent-profile launch args with the url last", () => {
+    const args = buildBrowserArgs({ port: 9333, userDataDir: "C:\\profiles\\dvpt", url: "https://org.crm.dynamics.com" });
+    expect(args).toEqual([
+      "--remote-debugging-port=9333",
+      "--user-data-dir=C:\\profiles\\dvpt",
+      "--no-first-run",
+      "--no-default-browser-check",
+      "--new-window",
+      "https://org.crm.dynamics.com",
+    ]);
+  });
+});

--- a/src/webresources/debug/browserArgs.ts
+++ b/src/webresources/debug/browserArgs.ts
@@ -1,0 +1,20 @@
+// Pure builder for the Chromium launch arguments. Kept separate so the exact flags are
+// unit-tested and reviewable in one place.
+
+export interface BrowserLaunchOptions {
+  /** CDP remote-debugging port (both our interceptor and VS Code's debugger attach here). */
+  port: number;
+  /** Persistent profile dir so the Dataverse login survives between debug sessions. */
+  userDataDir: string;
+  /** Initial URL to open (the org). */
+  url: string;
+}
+
+/**
+ * Build the browser command-line args. A dedicated `--user-data-dir` is required —
+ * Chromium refuses remote debugging on the default profile — and it doubles as the
+ * persistent login profile.
+ */
+export function buildBrowserArgs(options: BrowserLaunchOptions): string[] {
+  return [`--remote-debugging-port=${options.port}`, `--user-data-dir=${options.userDataDir}`, "--no-first-run", "--no-default-browser-check", "--new-window", options.url];
+}

--- a/src/webresources/debug/browserResolver.spec.ts
+++ b/src/webresources/debug/browserResolver.spec.ts
@@ -1,0 +1,60 @@
+/* eslint-disable @typescript-eslint/naming-convention */ // Windows env-var names (ProgramFiles, LOCALAPPDATA) must match the real names.
+import { describe, it, expect } from "vitest";
+import { resolveBrowser, BrowserResolverEnv } from "./browserResolver";
+
+function envWith(platform: NodeJS.Platform, existing: string[], env: Record<string, string | undefined> = {}): BrowserResolverEnv {
+  const set = new Set(existing);
+  return { platform, env, exists: (p) => set.has(p) };
+}
+
+const winEnv = {
+  ProgramFiles: "C:\\Program Files",
+  "ProgramFiles(x86)": "C:\\Program Files (x86)",
+  LOCALAPPDATA: "C:\\Users\\dev\\AppData\\Local",
+};
+const edgeWin = "C:\\Program Files (x86)\\Microsoft\\Edge\\Application\\msedge.exe";
+const chromeWin = "C:\\Program Files\\Google\\Chrome\\Application\\chrome.exe";
+
+describe("resolveBrowser", () => {
+  it("prefers Edge on Windows when both are installed (auto)", () => {
+    const r = resolveBrowser("auto", undefined, envWith("win32", [edgeWin, chromeWin], winEnv));
+    expect(r).toEqual({ kind: "msedge", executablePath: edgeWin });
+  });
+
+  it("falls back to Chrome when Edge is absent", () => {
+    const r = resolveBrowser("auto", undefined, envWith("win32", [chromeWin], winEnv));
+    expect(r).toEqual({ kind: "chrome", executablePath: chromeWin });
+  });
+
+  it("honours a chrome preference when Chrome is installed", () => {
+    const r = resolveBrowser("chrome", undefined, envWith("win32", [edgeWin, chromeWin], winEnv));
+    expect(r.kind).toBe("chrome");
+    expect(r.executablePath).toBe(chromeWin);
+  });
+
+  it("uses an explicit override path when it exists", () => {
+    const custom = "D:\\browsers\\edge.exe";
+    const r = resolveBrowser("auto", custom, envWith("win32", [custom, edgeWin], winEnv));
+    expect(r.executablePath).toBe(custom);
+  });
+
+  it("ignores a missing override path and falls back to a real install", () => {
+    const r = resolveBrowser("auto", "D:\\nope.exe", envWith("win32", [edgeWin], winEnv));
+    expect(r.executablePath).toBe(edgeWin);
+  });
+
+  it("throws an actionable error when no browser is found", () => {
+    expect(() => resolveBrowser("auto", undefined, envWith("win32", [], winEnv))).toThrow(/No supported browser/);
+  });
+
+  it("resolves the macOS Edge path", () => {
+    const mac = "/Applications/Microsoft Edge.app/Contents/MacOS/Microsoft Edge";
+    const r = resolveBrowser("auto", undefined, envWith("darwin", [mac]));
+    expect(r).toEqual({ kind: "msedge", executablePath: mac });
+  });
+
+  it("resolves a Linux Chrome path when Edge is absent", () => {
+    const r = resolveBrowser("auto", undefined, envWith("linux", ["/usr/bin/google-chrome-stable"]));
+    expect(r).toEqual({ kind: "chrome", executablePath: "/usr/bin/google-chrome-stable" });
+  });
+});

--- a/src/webresources/debug/browserResolver.ts
+++ b/src/webresources/debug/browserResolver.ts
@@ -1,0 +1,81 @@
+import * as path from "path";
+
+// Resolve a Chromium-based browser (Edge or Chrome) to drive under CDP for the
+// "Debug Web Resources" flow. Pure and platform-parameterised so it unit-tests on any
+// OS. Edge is preferred (it ships with Windows and is the currently-verified browser);
+// Chrome is supported as a fallback.
+
+export type BrowserKind = "msedge" | "chrome";
+export type BrowserPreference = "auto" | BrowserKind;
+
+export interface ResolvedBrowser {
+  kind: BrowserKind;
+  executablePath: string;
+}
+
+export interface BrowserResolverEnv {
+  platform: NodeJS.Platform;
+  env: Record<string, string | undefined>;
+  /** Whether an executable path exists (injected so this stays pure/testable). */
+  exists: (candidatePath: string) => boolean;
+}
+
+function winProgramDirs(env: Record<string, string | undefined>): string[] {
+  return [env["ProgramFiles(x86)"], env.ProgramFiles, env.LOCALAPPDATA].filter((d): d is string => !!d);
+}
+
+function edgeCandidates(e: BrowserResolverEnv): string[] {
+  switch (e.platform) {
+    case "win32":
+      return winProgramDirs(e.env).map((d) => path.win32.join(d, "Microsoft", "Edge", "Application", "msedge.exe"));
+    case "darwin":
+      return ["/Applications/Microsoft Edge.app/Contents/MacOS/Microsoft Edge"];
+    default:
+      return ["/usr/bin/microsoft-edge", "/usr/bin/microsoft-edge-stable", "/opt/microsoft/msedge/msedge"];
+  }
+}
+
+function chromeCandidates(e: BrowserResolverEnv): string[] {
+  switch (e.platform) {
+    case "win32":
+      return winProgramDirs(e.env).map((d) => path.win32.join(d, "Google", "Chrome", "Application", "chrome.exe"));
+    case "darwin":
+      return ["/Applications/Google Chrome.app/Contents/MacOS/Google Chrome"];
+    default:
+      return ["/usr/bin/google-chrome", "/usr/bin/google-chrome-stable", "/usr/bin/chromium", "/usr/bin/chromium-browser"];
+  }
+}
+
+/** Search order for "auto"/preference: the preferred browser first, then the other. */
+function searchOrder(prefer: BrowserPreference): BrowserKind[] {
+  if (prefer === "chrome") {
+    return ["chrome", "msedge"];
+  }
+  // "auto" and "msedge" both prefer Edge first.
+  return ["msedge", "chrome"];
+}
+
+/**
+ * Resolve the browser to launch. An explicit `overridePath` (from settings) wins when
+ * it exists. Otherwise the first installed browser in preference order is returned.
+ * Throws a clear, actionable error when nothing is found.
+ */
+export function resolveBrowser(prefer: BrowserPreference, overridePath: string | undefined, e: BrowserResolverEnv): ResolvedBrowser {
+  if (overridePath && e.exists(overridePath)) {
+    // Trust the configured preference for how to attach the debugger; default to Edge.
+    return { kind: prefer === "chrome" ? "chrome" : "msedge", executablePath: overridePath };
+  }
+
+  for (const kind of searchOrder(prefer)) {
+    const candidates = kind === "msedge" ? edgeCandidates(e) : chromeCandidates(e);
+    const found = candidates.find((c) => e.exists(c));
+    if (found) {
+      return { kind, executablePath: found };
+    }
+  }
+
+  throw new Error(
+    "No supported browser found for debugging web resources. Install Microsoft Edge (recommended) or Google Chrome, " +
+      "or set 'dataverse-powertools.debugBrowserPath' to the browser executable.",
+  );
+}

--- a/src/webresources/debug/debugConfig.spec.ts
+++ b/src/webresources/debug/debugConfig.spec.ts
@@ -1,0 +1,17 @@
+import { describe, it, expect } from "vitest";
+import { buildAttachDebugConfig } from "./debugConfig";
+
+describe("buildAttachDebugConfig", () => {
+  it("builds an msedge attach config on the given port", () => {
+    const cfg = buildAttachDebugConfig("msedge", 9333);
+    expect(cfg.type).toBe("msedge");
+    expect(cfg.request).toBe("attach");
+    expect(cfg.port).toBe(9333);
+    expect(cfg.webRoot).toBe("${workspaceFolder}");
+    expect(cfg.sourceMapPathOverrides).toBeDefined();
+  });
+
+  it("uses the chrome debug type for chrome", () => {
+    expect(buildAttachDebugConfig("chrome", 1).type).toBe("chrome");
+  });
+});

--- a/src/webresources/debug/debugConfig.ts
+++ b/src/webresources/debug/debugConfig.ts
@@ -1,0 +1,32 @@
+/* eslint-disable @typescript-eslint/naming-convention */ // source-map override keys mirror webpack's path format.
+import type { BrowserKind } from "./browserResolver";
+
+// Pure builder for the VS Code js-debug "attach" configuration. Structurally a
+// vscode.DebugConfiguration, but defined locally so this module stays vscode-free
+// (and unit-testable). VS Code's built-in JS debugger attaches to the same
+// remote-debugging port the browser was launched with, so breakpoints hit the original
+// TypeScript via the bundle's inline source maps.
+
+export interface AttachDebugConfig {
+  type: "msedge" | "chrome";
+  request: "attach";
+  name: string;
+  port: number;
+  webRoot: string;
+  /** Map the served bundle's source-map paths back to the workspace. */
+  sourceMapPathOverrides?: Record<string, string>;
+}
+
+export function buildAttachDebugConfig(browserKind: BrowserKind, port: number): AttachDebugConfig {
+  return {
+    type: browserKind === "chrome" ? "chrome" : "msedge",
+    request: "attach",
+    name: "Dataverse PowerTools: Debug Web Resources",
+    port,
+    webRoot: "${workspaceFolder}",
+    sourceMapPathOverrides: {
+      "webpack://*": "${workspaceFolder}/*",
+      "webpack:///./*": "${workspaceFolder}/*",
+    },
+  };
+}

--- a/src/webresources/debug/debugWebresources.ts
+++ b/src/webresources/debug/debugWebresources.ts
@@ -171,8 +171,17 @@ export async function debugWebResources(context: DataversePowerToolsContext): Pr
 
     // 5. Connect CDP and intercept the bundle request.
     client = await connectCdpWithRetry(port, 20000);
-    const { Fetch, Page } = client;
+    const { Fetch, Page, Network } = client;
     await Page.enable();
+    // Model-driven apps register a service worker (/uclient/sw.js) that serves web-resource
+    // bundles from a "WebResources" Cache Storage keyed by the versioned /%7b..%7d/webresources/
+    // URL. That cache sits ABOVE the network layer, so page-level Fetch interception never sees a
+    // form's bundle request and the deployed copy wins — even with the HTTP cache disabled.
+    // Bypassing the service worker forces every request onto the network, where interception can
+    // fulfil it from local disk. Without this, Debug Web Resources works for a direct web-resource
+    // URL but NOT for real form onload scripts (found via a live Account-form test, #64).
+    await Network.enable();
+    await Network.setBypassServiceWorker({ bypass: true });
     await Fetch.enable({ patterns: [{ urlPattern: bundleCdpPattern(bundleName), requestStage: "Request" }] });
 
     Fetch.requestPaused(async (params) => {
@@ -206,6 +215,10 @@ export async function debugWebResources(context: DataversePowerToolsContext): Pr
     });
 
     client.on("disconnect", () => void stopDebugWebResources());
+
+    // Anything the app loaded between navigation and interception arming came from the service
+    // worker/cache; reload once (bypassing cache) so those resources come back through interception.
+    await Page.reload({ ignoreCache: true });
 
     // 6. Hot refresh: on rebuild, reload the page (debounced).
     fs.mkdirSync(binDir, { recursive: true });

--- a/src/webresources/debug/debugWebresources.ts
+++ b/src/webresources/debug/debugWebresources.ts
@@ -1,0 +1,250 @@
+/* eslint-disable @typescript-eslint/naming-convention */ // CDP domain names (Fetch, Page) are PascalCase by protocol convention.
+import * as vscode from "vscode";
+import * as fs from "fs";
+import * as path from "path";
+import * as net from "net";
+import * as cp from "child_process";
+import CDP = require("chrome-remote-interface");
+import DataversePowerToolsContext from "../../context";
+import { resolveBrowser, BrowserPreference } from "./browserResolver";
+import { buildBrowserArgs } from "./browserArgs";
+import { isWebresourceBundleUrl, bundleCdpPattern, bundleContentType } from "./webresourceUrlMatch";
+import { buildAttachDebugConfig } from "./debugConfig";
+
+// "Debug Web Resources": run the local webpack bundle *inside the real model-driven app*.
+// A dedicated Edge/Chrome instance is launched under the DevTools Protocol; the browser's
+// request for the deployed bundle is intercepted and fulfilled from the local build, so
+// the live form runs your local code. `webpack --watch` rebuilds on save and the page is
+// reloaded. VS Code's JS debugger attaches to the same port for breakpoints in TypeScript.
+//
+// Nothing is written to the server — the interception is ephemeral and browser-scoped
+// (see #64), so there is no prod-promotion or MITM-cert footprint.
+
+interface ActiveDebugSession {
+  dispose(): Promise<void>;
+}
+
+let activeSession: ActiveDebugSession | undefined;
+
+function findFreePort(): Promise<number> {
+  return new Promise((resolve, reject) => {
+    const server = net.createServer();
+    server.once("error", reject);
+    server.listen(0, "127.0.0.1", () => {
+      const address = server.address();
+      const port = typeof address === "object" && address ? address.port : 0;
+      server.close(() => (port ? resolve(port) : reject(new Error("Could not allocate a debugging port."))));
+    });
+  });
+}
+
+async function connectCdpWithRetry(port: number, timeoutMs: number): Promise<CDP.Client> {
+  const deadline = Date.now() + timeoutMs;
+  let lastError: unknown;
+  for (;;) {
+    try {
+      return await CDP({ port });
+    } catch (error) {
+      lastError = error;
+      if (Date.now() > deadline) {
+        throw lastError instanceof Error ? lastError : new Error("Could not connect to the browser's debugging endpoint.");
+      }
+      await new Promise((r) => setTimeout(r, 400));
+    }
+  }
+}
+
+export async function debugWebResources(context: DataversePowerToolsContext): Promise<void> {
+  if (activeSession) {
+    const stop = "Stop current session";
+    const choice = await vscode.window.showInformationMessage("A Web Resources debug session is already running.", stop);
+    if (choice === stop) {
+      await stopDebugWebResources();
+    }
+    return;
+  }
+
+  const folders = vscode.workspace.workspaceFolders;
+  if (!folders || folders.length === 0) {
+    vscode.window.showErrorMessage("Open a Web Resources project folder before debugging.");
+    return;
+  }
+  const workspaceFolder = folders[0];
+  const workspacePath = workspaceFolder.uri.fsPath;
+
+  // Need a live connection to know the org URL to open.
+  if (!context.dataverse || !context.dataverse.isValid) {
+    const initialised = context.dataverse ? await context.dataverse.initialize() : false;
+    if (!initialised) {
+      vscode.window.showErrorMessage("Connect to Dataverse before debugging web resources.");
+      return;
+    }
+  }
+  const orgUrl = context.dataverse.organizationUrl;
+  if (!orgUrl) {
+    vscode.window.showErrorMessage("No Dataverse organisation URL is available. Check the connection and try again.");
+    return;
+  }
+
+  const prefix = context.projectSettings.prefix;
+  if (!prefix) {
+    vscode.window.showErrorMessage("This project has no solution prefix configured, so the bundle name is unknown.");
+    return;
+  }
+  const bundleName = `${prefix}_library.js`;
+  const binDir = path.join(workspacePath, "bin");
+  const bundlePath = path.join(binDir, bundleName);
+
+  const settings = vscode.workspace.getConfiguration("dataverse-powertools");
+  const prefer = (settings.get<string>("debugBrowser") || "auto") as BrowserPreference;
+  const overridePath = settings.get<string>("debugBrowserPath") || undefined;
+
+  let browser;
+  try {
+    browser = resolveBrowser(prefer, overridePath, { platform: process.platform, env: process.env, exists: fs.existsSync });
+  } catch (error: any) {
+    vscode.window.showErrorMessage(error?.message || "Could not find a browser to debug with.");
+    return;
+  }
+
+  // Track everything we start so teardown is total.
+  let webpackProc: cp.ChildProcess | undefined;
+  let browserProc: cp.ChildProcess | undefined;
+  let client: CDP.Client | undefined;
+  let fsWatcher: fs.FSWatcher | undefined;
+  let reloadTimer: NodeJS.Timeout | undefined;
+  let disposed = false;
+
+  const dispose = async () => {
+    if (disposed) {
+      return;
+    }
+    disposed = true;
+    if (reloadTimer) {
+      clearTimeout(reloadTimer);
+    }
+    try {
+      fsWatcher?.close();
+    } catch {
+      /* ignore */
+    }
+    try {
+      await client?.close();
+    } catch {
+      /* ignore */
+    }
+    try {
+      webpackProc?.kill();
+    } catch {
+      /* ignore */
+    }
+    try {
+      browserProc?.kill();
+    } catch {
+      /* ignore */
+    }
+    context.channel.appendLine("Web Resources debug session stopped.");
+  };
+
+  await vscode.window.withProgress({ location: vscode.ProgressLocation.Notification, title: "Starting Web Resources debug session…" }, async () => {
+    // 1. Rebuild-on-save. webpack is a .cmd shim on Windows, so it needs a shell.
+    webpackProc = cp.spawn("webpack", ["--config", "webpack.dev.js", "--watch"], {
+      cwd: workspacePath,
+      shell: process.platform === "win32",
+    });
+    webpackProc.stdout?.on("data", (d) => context.channel.appendLine(`[webpack] ${String(d).trimEnd()}`));
+    webpackProc.stderr?.on("data", (d) => context.channel.appendLine(`[webpack] ${String(d).trimEnd()}`));
+
+    // 2. Persistent profile so the Dataverse login survives between sessions.
+    const userDataDir = path.join(context.vscode.globalStorageUri.fsPath, "webresource-debug-profile");
+    fs.mkdirSync(userDataDir, { recursive: true });
+
+    // 3. One port serves both interception and the VS Code debugger.
+    const port = await findFreePort();
+
+    // 4. Launch the browser at the org.
+    browserProc = cp.spawn(browser.executablePath, buildBrowserArgs({ port, userDataDir, url: orgUrl }), {
+      detached: false,
+      stdio: "ignore",
+    });
+    browserProc.on("exit", () => void stopDebugWebResources());
+
+    // 5. Connect CDP and intercept the bundle request.
+    client = await connectCdpWithRetry(port, 20000);
+    const { Fetch, Page } = client;
+    await Page.enable();
+    await Fetch.enable({ patterns: [{ urlPattern: bundleCdpPattern(bundleName), requestStage: "Request" }] });
+
+    Fetch.requestPaused(async (params) => {
+      const requestId = params.requestId;
+      try {
+        if (isWebresourceBundleUrl(params.request.url, bundleName) && fs.existsSync(bundlePath)) {
+          const body = fs.readFileSync(bundlePath).toString("base64");
+          await Fetch.fulfillRequest({
+            requestId,
+            responseCode: 200,
+
+            responseHeaders: [
+              { name: "Content-Type", value: bundleContentType(bundleName) },
+              { name: "Cache-Control", value: "no-store" },
+            ],
+
+            body,
+          });
+          context.channel.appendLine(`[debug] served local ${bundleName} into the live app`);
+        } else {
+          await Fetch.continueRequest({ requestId });
+        }
+      } catch (error: any) {
+        context.channel.appendLine(`[debug] interception error: ${error?.message || error}`);
+        try {
+          await Fetch.continueRequest({ requestId });
+        } catch {
+          /* the request may already be gone */
+        }
+      }
+    });
+
+    client.on("disconnect", () => void stopDebugWebResources());
+
+    // 6. Hot refresh: on rebuild, reload the page (debounced).
+    fs.mkdirSync(binDir, { recursive: true });
+    fsWatcher = fs.watch(binDir, (_event, filename) => {
+      if (filename !== bundleName) {
+        return;
+      }
+      if (reloadTimer) {
+        clearTimeout(reloadTimer);
+      }
+      reloadTimer = setTimeout(() => {
+        context.channel.appendLine("[debug] bundle rebuilt — reloading");
+        Page.reload({ ignoreCache: true }).catch(() => undefined);
+      }, 400);
+    });
+
+    // 7. Attach the VS Code JS debugger (best-effort — interception + hot reload work
+    //    regardless of whether the debugger attaches).
+    try {
+      await vscode.debug.startDebugging(workspaceFolder, buildAttachDebugConfig(browser.kind, port) as vscode.DebugConfiguration);
+    } catch (error: any) {
+      context.channel.appendLine(`[debug] could not attach the VS Code debugger (interception still active): ${error?.message || error}`);
+    }
+
+    activeSession = { dispose };
+    context.channel.appendLine(
+      `Web Resources debug session started with ${browser.kind === "chrome" ? "Chrome" : "Edge"}. Log in, open your form, and edits will hot-reload the local ${bundleName}.`,
+    );
+    context.channel.show();
+    vscode.window.showInformationMessage("Web Resources debug session started — the live app is now running your local bundle.");
+  });
+}
+
+/** Stop the running debug session (browser, webpack --watch, CDP, watchers). Safe to call when none is active. */
+export async function stopDebugWebResources(): Promise<void> {
+  const session = activeSession;
+  if (!session) {
+    return;
+  }
+  activeSession = undefined;
+  await session.dispose();
+}

--- a/src/webresources/debug/webresourceUrlMatch.spec.ts
+++ b/src/webresources/debug/webresourceUrlMatch.spec.ts
@@ -1,0 +1,51 @@
+import { describe, it, expect } from "vitest";
+import { isWebresourceBundleUrl, bundleCdpPattern, bundleContentType } from "./webresourceUrlMatch";
+
+const bundle = "dvpt_library.js";
+const org = "https://org.crm.dynamics.com";
+
+describe("isWebresourceBundleUrl", () => {
+  it("matches the plain /WebResources/<name> path", () => {
+    expect(isWebresourceBundleUrl(`${org}/WebResources/dvpt_library.js`, bundle)).toBe(true);
+  });
+
+  it("matches a cache-busting version-brace segment (percent-encoded, lowercase path)", () => {
+    expect(isWebresourceBundleUrl(`${org}/%7B638500000000000000%7D/webresources/dvpt_library.js`, bundle)).toBe(true);
+  });
+
+  it("matches regardless of case and with a ?ver query", () => {
+    expect(isWebresourceBundleUrl(`${org}/WEBRESOURCES/DVPT_LIBRARY.JS?ver=1699999999`, bundle)).toBe(true);
+  });
+
+  it("does not match the source map for the same bundle", () => {
+    expect(isWebresourceBundleUrl(`${org}/WebResources/dvpt_library.js.map`, bundle)).toBe(false);
+  });
+
+  it("does not match a different web resource", () => {
+    expect(isWebresourceBundleUrl(`${org}/WebResources/other_library.js`, bundle)).toBe(false);
+  });
+
+  it("does not match a same-named file outside /webresources/", () => {
+    expect(isWebresourceBundleUrl(`${org}/scripts/dvpt_library.js`, bundle)).toBe(false);
+  });
+
+  it("returns false for an empty bundle name", () => {
+    expect(isWebresourceBundleUrl(`${org}/WebResources/dvpt_library.js`, "")).toBe(false);
+  });
+});
+
+describe("bundleCdpPattern", () => {
+  it("wraps the bundle name in wildcards", () => {
+    expect(bundleCdpPattern(bundle)).toBe("*/dvpt_library.js*");
+  });
+});
+
+describe("bundleContentType", () => {
+  it("defaults to application/javascript", () => {
+    expect(bundleContentType("dvpt_library.js")).toBe("application/javascript");
+  });
+  it("maps css and html", () => {
+    expect(bundleContentType("styles.css")).toBe("text/css");
+    expect(bundleContentType("page.html")).toBe("text/html");
+  });
+});

--- a/src/webresources/debug/webresourceUrlMatch.ts
+++ b/src/webresources/debug/webresourceUrlMatch.ts
@@ -1,0 +1,65 @@
+// Pure helpers for matching the browser's request for a web-resource bundle and for
+// building the response we fulfil it with. Dataverse serves web resources under a
+// "/WebResources/<name>" path, often with a cache-busting version segment
+// ("/%7B<version>%7D/webresources/<name>"), varying case, and/or a "?ver=" query — so
+// matching keys on the "/webresources/<name>" tail rather than an exact URL.
+
+function safeDecode(value: string): string {
+  try {
+    return decodeURIComponent(value);
+  } catch {
+    return value;
+  }
+}
+
+function pathnameOf(url: string): string {
+  try {
+    return new URL(url).pathname;
+  } catch {
+    // Not an absolute URL — strip any query/hash and use as-is.
+    return url.split(/[?#]/)[0];
+  }
+}
+
+const WEBRESOURCES_SEGMENT = "/webresources/";
+
+/**
+ * True when `url` is the Dataverse request for the web-resource named `bundleName`,
+ * across the path/casing/version variants the platform uses. Keys on the final
+ * "/webresources/<name>" segment so a source-map or differently-named resource is not
+ * matched.
+ */
+export function isWebresourceBundleUrl(url: string, bundleName: string): boolean {
+  if (!bundleName) {
+    return false;
+  }
+  const decodedPath = safeDecode(pathnameOf(url)).toLowerCase();
+  const name = bundleName.toLowerCase();
+  const idx = decodedPath.lastIndexOf(WEBRESOURCES_SEGMENT);
+  if (idx === -1) {
+    return false;
+  }
+  const tail = decodedPath.slice(idx + WEBRESOURCES_SEGMENT.length);
+  return tail === name;
+}
+
+/**
+ * A broad CDP `Fetch.enable` urlPattern that pauses candidate requests for this bundle.
+ * It over-matches on purpose (the precise decision is `isWebresourceBundleUrl`) so we
+ * don't intercept unrelated traffic while still catching every path variant.
+ */
+export function bundleCdpPattern(bundleName: string): string {
+  return `*/${bundleName}*`;
+}
+
+/** Content type to serve a locally-fulfilled web-resource bundle with. */
+export function bundleContentType(bundleName: string): string {
+  const lower = bundleName.toLowerCase();
+  if (lower.endsWith(".css")) {
+    return "text/css";
+  }
+  if (lower.endsWith(".html") || lower.endsWith(".htm")) {
+    return "text/html";
+  }
+  return "application/javascript";
+}

--- a/src/webresources/initialiseWebresources.ts
+++ b/src/webresources/initialiseWebresources.ts
@@ -10,6 +10,7 @@ import { generateTypings } from "./generateTypings";
 import { saveFormData } from "./saveFormData";
 import { formIntersectSelector } from "./tableIntersects/tableIntersects";
 import { upgradeFromSpkl } from "./upgradeFromSpkl";
+import { debugWebResources, stopDebugWebResources } from "./debug/debugWebresources";
 
 export function initialiseWebresources(context: DataversePowerToolsContext): void {
   vscode.commands.executeCommand("setContext", "dataverse-powertools.isPlugin", false);
@@ -36,4 +37,9 @@ export function initialiseWebresources(context: DataversePowerToolsContext): voi
   context.vscode.subscriptions.push(vscode.commands.registerCommand("dataverse-powertools.addFormDecoration", () => addFormDecoration(context)));
   context.vscode.subscriptions.push(vscode.commands.registerCommand("dataverse-powertools.saveFormData", () => saveFormData(context)));
   context.vscode.subscriptions.push(vscode.commands.registerCommand("dataverse-powertools.upgradeFromSpkl", () => upgradeFromSpkl(context)));
+  context.vscode.subscriptions.push(vscode.commands.registerCommand("dataverse-powertools.debugWebresources", () => debugWebResources(context)));
+  context.vscode.subscriptions.push(vscode.commands.registerCommand("dataverse-powertools.stopDebugWebresources", () => stopDebugWebResources()));
+  // Ensure a running debug session (browser, webpack --watch, CDP) is torn down if the
+  // extension deactivates or the workspace reloads.
+  context.vscode.subscriptions.push({ dispose: () => void stopDebugWebResources() });
 }

--- a/test/live/browserAutoLogin.ts
+++ b/test/live/browserAutoLogin.ts
@@ -151,7 +151,14 @@ export async function autoLoginBrowser(port: number, opts: AutoLoginOptions): Pr
   // targets and the default pick isn't always the login tab.
   const targets = await CDP.List({ port });
   const pages = targets.filter((t) => t.type === "page");
-  const target = pages.find((t) => t.url.includes("login.microsoftonline.com") || t.url.includes(opts.orgHost)) || pages.find((t) => t.url.startsWith("http")) || pages[0];
+  const hostOf = (u: string): string => {
+    try {
+      return new URL(u).hostname;
+    } catch {
+      return "";
+    }
+  };
+  const target = pages.find((t) => hostOf(t.url) === "login.microsoftonline.com" || hostOf(t.url) === opts.orgHost) || pages.find((t) => t.url.startsWith("http")) || pages[0];
   const client = await CDP({ port, target });
   try {
     await client.Runtime.enable();

--- a/test/live/browserAutoLogin.ts
+++ b/test/live/browserAutoLogin.ts
@@ -1,0 +1,247 @@
+/* eslint-disable @typescript-eslint/naming-convention */
+import * as fs from "fs";
+import * as path from "path";
+import * as net from "net";
+import * as cp from "child_process";
+import CDP = require("chrome-remote-interface");
+
+// Unattended Azure AD sign-in for the test browser, driven over the DevTools Protocol.
+// Lets the live/e2e harness exercise the interactive ("Authenticated") user path — and
+// run Edge and Chrome with the same test account — without a human typing credentials.
+//
+// The account MUST be excluded from MFA/conditional access: this fills the managed AAD
+// sign-in form (email → password → "stay signed in") and cannot satisfy an MFA challenge.
+// Credentials come from DVPT_TEST_USERNAME / DVPT_TEST_PASSWORD via loadInteractiveTestUser().
+
+const sleep = (ms: number): Promise<void> => new Promise((r) => setTimeout(r, ms));
+
+function freePort(): Promise<number> {
+  return new Promise((resolve, reject) => {
+    const srv = net.createServer();
+    srv.once("error", reject);
+    srv.listen(0, "127.0.0.1", () => {
+      const a = srv.address();
+      const p = typeof a === "object" && a ? a.port : 0;
+      srv.close(() => (p ? resolve(p) : reject(new Error("could not allocate a port"))));
+    });
+  });
+}
+
+/**
+ * Read the CDP port a Chromium browser wrote to `<profileDir>/DevToolsActivePort`.
+ * Chromium writes this file once its debugging endpoint is listening, so it's the
+ * reliable way to learn the port when the launcher (e.g. Debug Web Resources) picked a
+ * free one internally. First line is the port.
+ */
+export async function readDevToolsPort(profileDir: string, timeoutMs = 25000): Promise<number> {
+  const file = path.join(profileDir, "DevToolsActivePort");
+  const deadline = Date.now() + timeoutMs;
+  for (;;) {
+    try {
+      const first = fs.readFileSync(file, "utf8").split(/\r?\n/)[0]?.trim();
+      const port = Number(first);
+      if (port > 0) {
+        return port;
+      }
+    } catch {
+      /* not written yet */
+    }
+    if (Date.now() > deadline) {
+      throw new Error(`DevToolsActivePort not found under ${profileDir} within ${timeoutMs}ms`);
+    }
+    await sleep(300);
+  }
+}
+
+/**
+ * Discover the remote-debugging port of the browser launched with `--user-data-dir=profileDir`.
+ * Chromium only writes `DevToolsActivePort` when the port is 0 (auto-picked); when a launcher
+ * passes an explicit port (as Debug Web Resources does), read it from the process command line.
+ * Windows-only (this harness runs on the Windows VM), via PowerShell/CIM.
+ */
+export async function findDebugPortByProfile(profileDir: string, timeoutMs = 25000): Promise<number> {
+  const script =
+    `$p=$env:DVPT_PROFILE; ` +
+    `$proc = Get-CimInstance Win32_Process -Filter "Name='msedge.exe' OR Name='chrome.exe'" | ` +
+    `Where-Object { $_.CommandLine -like "*$p*" -and $_.CommandLine -like '*remote-debugging-port=*' } | Select-Object -First 1; ` +
+    `if ($proc -and $proc.CommandLine -match 'remote-debugging-port=(\\d+)') { $matches[1] }`;
+  const deadline = Date.now() + timeoutMs;
+  for (;;) {
+    try {
+      const out = cp.execFileSync("powershell", ["-NoProfile", "-NonInteractive", "-Command", script], { env: { ...process.env, DVPT_PROFILE: profileDir }, encoding: "utf8" }).trim();
+      const port = Number(out);
+      if (port > 0) {
+        return port;
+      }
+    } catch {
+      /* process not up yet */
+    }
+    if (Date.now() > deadline) {
+      throw new Error(`Could not find a debug port for a browser using profile ${profileDir}`);
+    }
+    await sleep(400);
+  }
+}
+
+export interface AutoLoginOptions {
+  username: string;
+  password: string;
+  /** Host of the org (e.g. "org1234.crm11.dynamics.com") — sign-in is done once we land here. */
+  orgHost: string;
+  timeoutMs?: number;
+  log?: (message: string) => void;
+}
+
+interface PageState {
+  host: string;
+  email: boolean;
+  pass: boolean;
+  kmsi: boolean;
+  err: string | null;
+}
+
+async function evalOn(client: CDP.Client, expression: string, awaitPromise = false): Promise<unknown> {
+  const { result } = await client.Runtime.evaluate({ expression, awaitPromise, returnByValue: true });
+  return result.value;
+}
+
+async function probe(client: CDP.Client): Promise<PageState> {
+  const json = (await evalOn(
+    client,
+    `JSON.stringify((() => { const q=s=>document.querySelector(s); const vis=e=>!!(e&&e.offsetParent!==null&&!e.disabled); const t=document.body?document.body.innerText:''; return {
+      host: location.host,
+      email: vis(q('input[name=loginfmt]')), pass: vis(q('input[name=passwd]')),
+      kmsi: /stay signed in\\?/i.test(t)||!!q('#KmsiCheckboxField'),
+      err: (q('#usernameError')||q('#passwordError')||q('.alert-error')||{}).innerText||null }; })())`,
+  )) as string;
+  return JSON.parse(json) as PageState;
+}
+
+/**
+ * Fill a React-controlled input the way AAD's sign-in form expects: set the value through
+ * the native HTMLInputElement setter (so React's value tracker sees the change) and fire
+ * input+change. A bare `.value =` or CDP Input.insertText can be silently reverted by React.
+ */
+async function typeInto(client: CDP.Client, selector: string, text: string): Promise<boolean> {
+  const val = await evalOn(
+    client,
+    `(() => { const e=document.querySelector(${JSON.stringify(selector)}); if(!e) return null;
+      e.focus();
+      const setter=Object.getOwnPropertyDescriptor(window.HTMLInputElement.prototype,'value').set;
+      setter.call(e, ${JSON.stringify(text)});
+      e.dispatchEvent(new Event('input',{bubbles:true}));
+      e.dispatchEvent(new Event('change',{bubbles:true}));
+      return e.value; })()`,
+  );
+  return val === text;
+}
+
+async function click(client: CDP.Client, selector: string): Promise<void> {
+  await evalOn(client, `(() => { const e=document.querySelector(${JSON.stringify(selector)}); if(e){e.click();return true;} return false; })()`);
+}
+
+/**
+ * Drive the managed AAD sign-in on the browser at `port` until it reaches the org.
+ * Returns true on success (including when the profile is already signed in). Never
+ * throws on a login mis-step — it retries within the timeout and returns false if stuck.
+ */
+export async function autoLoginBrowser(port: number, opts: AutoLoginOptions): Promise<boolean> {
+  const log = opts.log ?? (() => undefined);
+  // Explicitly attach to the sign-in (or org) page — the browser may have several page
+  // targets and the default pick isn't always the login tab.
+  const targets = await CDP.List({ port });
+  const pages = targets.filter((t) => t.type === "page");
+  const target = pages.find((t) => t.url.includes("login.microsoftonline.com") || t.url.includes(opts.orgHost)) || pages.find((t) => t.url.startsWith("http")) || pages[0];
+  const client = await CDP({ port, target });
+  try {
+    await client.Runtime.enable();
+    const deadline = Date.now() + (opts.timeoutMs ?? 90000);
+    let lastSig = "";
+    // Visibility-driven, not a fixed stage machine: whichever step is on screen, do it —
+    // and keep re-doing it until the screen actually changes. A "Next"/"Sign in" click can
+    // land before the button is armed, so retrying (rather than optimistically advancing) is
+    // what makes this reliable across Edge and Chrome.
+    while (Date.now() < deadline) {
+      const s = await probe(client);
+      const sig = `${s.host}|e${s.email ? 1 : 0}|p${s.pass ? 1 : 0}|k${s.kmsi ? 1 : 0}`;
+      if (sig !== lastSig) {
+        log(`[auto-login] ${sig}${s.err ? ` err="${s.err.replace(/\s+/g, " ").slice(0, 40)}"` : ""}`);
+        lastSig = sig;
+      }
+      if (s.host.includes(opts.orgHost)) {
+        return true;
+      }
+      if (s.pass) {
+        if (await typeInto(client, "input[name=passwd]", opts.password)) {
+          await click(client, "#idSIButton9");
+        }
+        await sleep(2500);
+        continue;
+      }
+      if (s.email) {
+        if (await typeInto(client, "input[name=loginfmt]", opts.username)) {
+          await click(client, "#idSIButton9");
+        }
+        await sleep(2500);
+        continue;
+      }
+      if (s.kmsi) {
+        await click(client, "#idSIButton9"); // "Stay signed in?" → Yes (persist the profile)
+        await sleep(2500);
+        continue;
+      }
+      await sleep(1500);
+    }
+    return false;
+  } finally {
+    await client.close();
+  }
+}
+
+export interface PreAuthOptions {
+  username: string;
+  password: string;
+  orgHost: string;
+  log?: (message: string) => void;
+}
+
+/**
+ * Sign a Chromium profile in ahead of time so a later Debug Web Resources session starts
+ * already authenticated — the same state a real developer's persistent profile is in.
+ * Launches its own clean browser (no interception attached), drives the AAD sign-in, lets
+ * cookies flush, and closes it so the profile dir is free to reopen. Returns true on success.
+ */
+export async function preAuthenticateProfile(exePath: string, profileDir: string, orgUrl: string, opts: PreAuthOptions): Promise<boolean> {
+  const log = opts.log ?? (() => undefined);
+  fs.mkdirSync(profileDir, { recursive: true });
+  const port = await freePort();
+  const child = cp.spawn(exePath, [`--remote-debugging-port=${port}`, `--user-data-dir=${profileDir}`, "--no-first-run", "--no-default-browser-check", "--new-window", orgUrl], { stdio: "ignore" });
+  try {
+    const deadline = Date.now() + 25000;
+    let up = false;
+    while (Date.now() < deadline) {
+      try {
+        const c = await CDP({ port });
+        await c.close();
+        up = true;
+        break;
+      } catch {
+        await sleep(400);
+      }
+    }
+    if (!up) {
+      log("[pre-auth] browser CDP endpoint never came up");
+      return false;
+    }
+    const ok = await autoLoginBrowser(port, { username: opts.username, password: opts.password, orgHost: opts.orgHost, log });
+    await sleep(3000); // let auth cookies flush to disk before we close
+    return ok;
+  } finally {
+    try {
+      child.kill();
+    } catch {
+      /* ignore */
+    }
+    await sleep(2000); // release the profile lock so the debug session can reopen it
+  }
+}

--- a/test/live/debugBrowsersMatrix.spec.ts
+++ b/test/live/debugBrowsersMatrix.spec.ts
@@ -184,7 +184,7 @@ suite("Debug Web Resources — Edge + Chrome unattended (#64)", () => {
         // Sign the profile in first (clean browser, no interception attached) so the debug
         // session opens already authenticated — like a real developer's persistent profile.
         const resolved = resolveBrowser(browser, undefined, { platform: process.platform, env: process.env, exists: fs.existsSync });
-        log(`[${browser}] pre-authenticating profile as ${u.username}`);
+        log(`[${browser}] pre-authenticating the debug profile with the interactive test user`);
         const authed = await preAuthenticateProfile(resolved.executablePath, profileDir, e.url, { username: u.username, password: u.password, orgHost, log });
         expect(authed, `pre-auth failed on ${browser}`).toBe(true);
 

--- a/test/live/debugBrowsersMatrix.spec.ts
+++ b/test/live/debugBrowsersMatrix.spec.ts
@@ -1,0 +1,210 @@
+/* eslint-disable @typescript-eslint/naming-convention */
+import { describe, it, beforeAll, afterAll, afterEach, expect } from "vitest";
+import * as os from "os";
+import * as fs from "fs";
+import * as path from "path";
+import * as vscode from "vscode"; // aliased to test/vscode.mock.ts
+import CDP = require("chrome-remote-interface");
+import { loadLiveEnv, loadInteractiveTestUser, LiveEnv, testSolutionConfig } from "../liveEnv";
+import { LiveDataverseClient } from "./dataverseClient";
+import { DataverseWebresource } from "../../src/general/dataverse/DataverseWebresource";
+import { DataverseForm } from "../../src/general/dataverse/DataverseForm";
+import { debugWebResources, stopDebugWebResources } from "../../src/webresources/debug/debugWebresources";
+import { preAuthenticateProfile, findDebugPortByProfile } from "./browserAutoLogin";
+import { resolveBrowser } from "../../src/webresources/debug/browserResolver";
+import DataversePowerToolsContext from "../../src/context";
+
+// Unattended #64 coverage across BOTH browsers using the interactive test user.
+// For each of Edge and Chrome: launch Debug Web Resources (real command) → auto-login →
+// open a real Account form → assert the LOCAL onload banner is served (not the deployed
+// one) → edit the bundle → assert the form hot-reloads to v2. No human interaction.
+//
+//   DVPT_DEBUG_DEMO=1 npm run test:live -- test/live/debugBrowsersMatrix.spec.ts
+const env = loadLiveEnv();
+const user = loadInteractiveTestUser();
+const enabled = !!env && !!user && process.env.DVPT_DEBUG_DEMO === "1";
+const suite = enabled ? describe : describe.skip;
+
+const BUNDLE = "dvpt_library.js";
+const FORM_ID = "8448b78f-8f42-454e-8e2a-f8196b0419af"; // account "Account" main form
+const APP_ID = "a6d7419d-7477-f111-ab0d-70a8a54b2854";
+const TRIGGER = "{a1b2c3d4-0000-4000-8000-0000000000aa}";
+const LIB_UID = "{b2c3d4e5-0000-4000-8000-0000000000bb}";
+const FN = "dvpt.DemoForm.onLoad";
+
+const bundleJs = (banner: string): string =>
+  `var dvpt=(function(){return{DemoForm:{onLoad:function(ec){try{ec.getFormContext().ui.setFormNotification(${JSON.stringify(banner)},"INFO","dvpt-debug-demo");}catch(e){console.error(e);}}}};})();\n`;
+const DEPLOYED = bundleJs(">>> DEPLOYED — banner from the SERVER copy <<<");
+const localV1 = (b: string): string => bundleJs(`>>> LOCAL v1 on ${b} — served from disk <<<`);
+const localV2 = (b: string): string => bundleJs(`>>> LOCAL v2 on ${b} — HOT-RELOADED <<<`);
+
+function log(m: string): void {
+  // eslint-disable-next-line no-console
+  console.log(m);
+}
+
+function makeContext(url: string, token: string, workspacePath: string, globalStorage: string, browser: string): DataversePowerToolsContext {
+  return {
+    projectSettings: { prefix: "dvpt", tenantId: (env as LiveEnv).tenantId },
+    dataverse: { organizationUrl: url, isValid: true, authorizationToken: token, getAuthorizationToken: async () => token, initialize: async () => true },
+    channel: { appendLine: (m: string) => log(`[${browser}] ${m}`), show: () => undefined },
+    vscode: { globalStorageUri: { fsPath: globalStorage }, subscriptions: [] as unknown[] },
+  } as unknown as DataversePowerToolsContext;
+}
+
+/** Register library + onload handler on the Account form via the extension's DataverseForm. */
+async function registerHandler(ctx: DataversePowerToolsContext): Promise<void> {
+  const form = new DataverseForm(FORM_ID, ctx);
+  await form.getFormData();
+  const root = form.form.form;
+  if (!root.formLibraries) root.formLibraries = { Library: [] };
+  if (!root.formLibraries.Library.find((l: any) => l["@_name"] === BUNDLE)) root.formLibraries.Library.push({ "@_name": BUNDLE, "@_libraryUniqueId": LIB_UID });
+  if (!root.events) root.events = { event: [] };
+  let onload = root.events.event.find((e: any) => e["@_name"] === "onload");
+  if (!onload) {
+    onload = { "@_name": "onload", "@_active": "true", "@_application": "true", Handlers: { Handler: [] } };
+    root.events.event.push(onload);
+  }
+  if (!onload.Handlers) onload.Handlers = { Handler: [] };
+  if (!onload.Handlers.Handler.find((h: any) => h["@_handlerUniqueId"] === TRIGGER)) {
+    onload.Handlers.Handler.push({ "@_functionName": FN, "@_libraryName": BUNDLE, "@_handlerUniqueId": TRIGGER, "@_enabled": "true", "@_parameters": "", "@_passExecutionContext": "true" });
+  }
+  await form.saveForm();
+}
+
+async function unregisterHandler(ctx: DataversePowerToolsContext): Promise<void> {
+  const form = new DataverseForm(FORM_ID, ctx);
+  await form.getFormData();
+  const root = form.form.form;
+  if (root.formLibraries?.Library) {
+    root.formLibraries.Library = root.formLibraries.Library.filter((l: any) => l["@_name"] !== BUNDLE);
+    if (root.formLibraries.Library.length === 0) delete root.formLibraries;
+  }
+  if (root.events?.event) {
+    for (const e of root.events.event) if (e.Handlers?.Handler) e.Handlers.Handler = e.Handlers.Handler.filter((h: any) => h["@_libraryName"] !== BUNDLE);
+    root.events.event = root.events.event.filter((e: any) => e.Handlers?.Handler?.length > 0);
+    if (root.events.event.length === 0) delete root.events;
+  }
+  await form.saveForm();
+}
+
+async function bannerOnForm(port: number, recordUrl: string): Promise<string> {
+  const targets = await CDP.List({ port });
+  const page = targets.find((t) => t.type === "page");
+  const client = await CDP({ port, target: page });
+  try {
+    await client.Page.enable();
+    await client.Runtime.enable();
+    await client.Page.navigate({ url: recordUrl });
+    await new Promise((r) => setTimeout(r, 18000));
+    return (await client.Runtime.evaluate({
+      expression: `(document.body.innerText.match(/LOCAL v2[^<]*|LOCAL v1[^<]*|DEPLOYED — banner from the SERVER copy/)||['(none)'])[0]`,
+      returnByValue: true,
+    })).result.value as string;
+  } finally {
+    await client.close();
+  }
+}
+
+async function reloadedBanner(port: number): Promise<string> {
+  await new Promise((r) => setTimeout(r, 9000)); // let the feature's debounced hot-reload happen
+  const targets = await CDP.List({ port });
+  const page = targets.find((t) => t.type === "page");
+  const client = await CDP({ port, target: page });
+  try {
+    await client.Runtime.enable();
+    return (await client.Runtime.evaluate({
+      expression: `(document.body.innerText.match(/LOCAL v2[^<]*|LOCAL v1[^<]*|DEPLOYED — banner from the SERVER copy/)||['(none)'])[0]`,
+      returnByValue: true,
+    })).result.value as string;
+  } finally {
+    await client.close();
+  }
+}
+
+suite("Debug Web Resources — Edge + Chrome unattended (#64)", () => {
+  const e = env as LiveEnv;
+  const u = user!;
+  const client = new LiveDataverseClient(e);
+  const orgHost = new URL(e.url).host;
+  const tmpRoot = path.join(os.tmpdir(), "dvpt-debug-matrix");
+  let recordUrl = "";
+
+  beforeAll(async () => {
+    await client.connect();
+    await client.ensureTestSolution(testSolutionConfig(e));
+    const setupCtx = makeContext(e.url, client.accessToken, tmpRoot, tmpRoot, "setup");
+    const wr = new DataverseWebresource(BUNDLE, setupCtx);
+    await wr.upsert(Buffer.from(DEPLOYED, "utf8").toString("base64"), 3, "dvpt library (debug demo)");
+    await client.publishAll();
+    await registerHandler(setupCtx);
+    await client.publishAll();
+    // Any existing account record (a create form triggers a beforeunload dialog on reload).
+    const res: any = await (await fetch(`${e.url}/api/data/v9.2/accounts?$select=accountid&$top=1`, { headers: { Authorization: `Bearer ${client.accessToken}`, Accept: "application/json" } })).json();
+    const accountId = res.value?.[0]?.accountid;
+    recordUrl = `${e.url}/main.aspx?appid=${APP_ID}&pagetype=entityrecord&etn=account${accountId ? `&id=${accountId}` : ""}`;
+    log(`Setup complete. Account form registered; record: ${accountId ?? "(new)"}`);
+  }, 180000);
+
+  afterEach(async () => {
+    // Always tear down the session, even when an assertion failed mid-test, so the next
+    // browser isn't blocked by a lingering activeSession.
+    await stopDebugWebResources();
+  });
+
+  afterAll(async () => {
+    await stopDebugWebResources();
+    try {
+      await unregisterHandler(makeContext(e.url, client.accessToken, tmpRoot, tmpRoot, "cleanup"));
+      await client.publishAll(); // publish the form revert so the WR dependency clears before delete
+      const found = await client.findWebresourceByName(BUNDLE);
+      if (found) await client.deleteWebresource(found.webresourceid);
+      await client.publishAll();
+      log("Cleaned up: form reverted, webresource deleted.");
+    } catch (err) {
+      log(`cleanup error: ${(err as Error).message}`);
+    }
+  }, 120000);
+
+  for (const browser of ["msedge", "chrome"] as const) {
+    it(
+      `serves LOCAL into a real form and hot-reloads on ${browser}`,
+      async () => {
+        (vscode.workspace as unknown as { getConfiguration: () => unknown }).getConfiguration = () => ({ get: (k: string) => (k === "debugBrowser" ? browser : undefined), update: () => undefined });
+        const workspacePath = path.join(tmpRoot, browser, "workspace");
+        const binDir = path.join(workspacePath, "bin");
+        const bundlePath = path.join(binDir, BUNDLE);
+        const globalStorage = path.join(tmpRoot, browser, "globalStorage");
+        const profileDir = path.join(globalStorage, "webresource-debug-profile");
+        fs.mkdirSync(binDir, { recursive: true });
+        fs.mkdirSync(globalStorage, { recursive: true });
+        fs.writeFileSync(bundlePath, localV1(browser));
+        (vscode.workspace as unknown as { workspaceFolders: unknown[] }).workspaceFolders = [{ uri: { fsPath: workspacePath }, name: "webresource", index: 0 }];
+
+        // Sign the profile in first (clean browser, no interception attached) so the debug
+        // session opens already authenticated — like a real developer's persistent profile.
+        const resolved = resolveBrowser(browser, undefined, { platform: process.platform, env: process.env, exists: fs.existsSync });
+        log(`[${browser}] pre-authenticating profile as ${u.username}`);
+        const authed = await preAuthenticateProfile(resolved.executablePath, profileDir, e.url, { username: u.username, password: u.password, orgHost, log });
+        expect(authed, `pre-auth failed on ${browser}`).toBe(true);
+
+        const ctx = makeContext(e.url, client.accessToken, workspacePath, globalStorage, browser);
+        await debugWebResources(ctx);
+        const port = await findDebugPortByProfile(profileDir);
+        log(`[${browser}] debug session on port ${port}`);
+
+        const first = await bannerOnForm(port, recordUrl);
+        log(`[${browser}] banner on first load: ${first}`);
+        expect(first, `expected LOCAL served on ${browser}, got: ${first}`).toContain("LOCAL v1");
+
+        fs.writeFileSync(bundlePath, localV2(browser));
+        const after = await reloadedBanner(port);
+        log(`[${browser}] banner after edit: ${after}`);
+        expect(after, `expected hot reload to v2 on ${browser}, got: ${after}`).toContain("LOCAL v2");
+
+        await stopDebugWebResources();
+      },
+      6 * 60 * 1000,
+    );
+  }
+});

--- a/test/liveEnv.ts
+++ b/test/liveEnv.ts
@@ -63,6 +63,28 @@ export function loadLiveEnv(): LiveEnv | undefined {
   };
 }
 
+export interface InteractiveTestUser {
+  username: string;
+  password: string;
+}
+
+/**
+ * The MFA-exempt interactive ("Authenticated") test user (DVPT_TEST_USERNAME /
+ * DVPT_TEST_PASSWORD), used to exercise the OAuth/interactive auth path — both the
+ * extension's connection and unattended browser sign-in for Edge/Chrome. Returns
+ * undefined when not configured, so tests that need it self-skip rather than fail.
+ * The account must be excluded from MFA/conditional access (headless ROPC can't
+ * satisfy an MFA challenge) and hold a Dataverse System Customizer/Administrator role.
+ */
+export function loadInteractiveTestUser(): InteractiveTestUser | undefined {
+  const username = process.env.DVPT_TEST_USERNAME?.trim();
+  const password = process.env.DVPT_TEST_PASSWORD;
+  if (!username || !password) {
+    return undefined;
+  }
+  return { username, password };
+}
+
 export interface TestSolutionConfig {
   solutionUniqueName: string;
   solutionFriendlyName: string;

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -20,8 +20,13 @@ const extensionConfig = {
     libraryTarget: 'commonjs2'
   },
   externals: {
-    vscode: 'commonjs vscode' // the vscode-module is created on-the-fly and must be excluded. Add other modules that cannot be webpack'ed, 📖 -> https://webpack.js.org/configuration/externals/
+    vscode: 'commonjs vscode', // the vscode-module is created on-the-fly and must be excluded. Add other modules that cannot be webpack'ed, 📖 -> https://webpack.js.org/configuration/externals/
     // modules added here also need to be added in the .vscodeignore file
+    // Optional native speedups for `ws` (pulled in by chrome-remote-interface). They are
+    // not installed and `ws` falls back to pure JS when they're absent; externalise them
+    // so webpack doesn't warn about the unresolved optional require.
+    bufferutil: 'commonjs bufferutil',
+    'utf-8-validate': 'commonjs utf-8-validate'
   },
   resolve: {
     // support reading TypeScript and JavaScript files, 📖 -> https://github.com/TypeStrong/ts-loader


### PR DESCRIPTION
Closes #64.

Adds a **Debug Web Resources** command that runs your **local** webpack bundle **inside the real model-driven app** — so you can debug it in VS Code and hot-reload on save instead of republishing every change. The app, forms, and `Xrm` are all real; only the web-resource *code* is served locally (this is **not** an `xrm-mock` harness).

## How it works — CDP request interception
Launches a dedicated Edge/Chrome instance under the DevTools Protocol with a **persistent profile** (login is remembered), intercepts the browser's request for the deployed bundle, and **fulfils it from `bin/<prefix>_library.js`** before it hits the network. Per #64 this is the low-footprint approach:
- **No server artifact** — nothing is written to Dataverse, so there's zero prod-promotion risk. It's ephemeral (gone when the browser closes).
- **No MITM cert** — interception happens inside the browser at the request level, so there's no root CA to install and no other traffic touched.
- **No mixed-content/CSP issues** — the existing same-origin HTTPS request is fulfilled; nothing new is added to the page.

`webpack --watch` rebuilds on save → the page reloads. VS Code's JS debugger attaches to the same `--remote-debugging-port`, so breakpoints hit the original TypeScript via the bundle's inline source maps.

## What's included
- `src/webresources/debug/` — pure, unit-tested helpers:
  - `browserResolver.ts` — Edge-first, Chrome fallback, override path; cross-platform (Win/mac/Linux).
  - `webresourceUrlMatch.ts` — matches the bundle request across Dataverse's `/WebResources/`, version-brace, case, and `?ver=` variants; keys on the `/webresources/<name>` tail (so source maps / other resources aren't matched).
  - `browserArgs.ts`, `debugConfig.ts` — launch args + js-debug attach config.
  - `debugWebresources.ts` — runtime orchestration (launch → CDP intercept → watch → reload → attach → teardown).
- Commands `debugWebresources` / `stopDebugWebresources`, webresource-menu buttons, and settings `dataverse-powertools.debugBrowser` (`auto`|`msedge`|`chrome`) + `debugBrowserPath`.
- Teardown on stop, browser close, or extension deactivate.
- Deps: `chrome-remote-interface` (+ `@types`); `ws`'s optional native speedups externalised in webpack.

## Verification (local)
- **21 unit tests** for the pure logic (browser resolution, URL matching, args, debug config).
- **CDP smoke test** against Edge: confirmed a `/WebResources/<bundle>` request is intercepted and fulfilled with local JS that then **executes in the page** (`intercepted=true`, value `4242`).
- lint clean · tsc clean · `webpack` compile clean · unit suite **137 passing**.
- **Full e2e UI suite 7/7** (webresource + plugin lifecycles) — regression check that the new command/deps don't affect existing flows.

## Live validation against a real org — and a fix it surfaced
Ran the real command against a live Dataverse org, logged in, on a real **Account form** with an onload script registered to `<prefix>_library.js`:
- ✅ Local `onLoad` banner served into the live form; edit-on-save **hot-reloaded** the banner (LOCAL v1 → v2), independently confirmed via CDP.

This uncovered a real gap the earlier direct-URL smoke test missed: **model-driven apps register a service worker (`/uclient/sw.js`) that serves web-resource bundles from a `WebResources` Cache Storage above the network layer**, so page-level Fetch interception never saw a *form's* bundle request — direct `/WebResources/<name>` worked but real form scripts silently ran the deployed copy. Fixed in `debugWebresources.ts` by enabling the `Network` domain and calling `Network.setBypassServiceWorker` (+ one reload after arming). Re-verified: fresh session → open Account form → **LOCAL** on first load, hot reload to v2. Fix commit included in this PR.

## Reviewer notes (merge-ready)
- Validated end-to-end on **both Edge and Chrome**, fully unattended, via a new interactive-login test harness (`test/live/browserAutoLogin.ts` + `debugBrowsersMatrix.spec.ts`): sign in → open a real Account form → LOCAL onload banner served → edit → hot reload to v2, on each browser.
- **Version bumped to `0.5.4`** — merging to `main` will publish this to the Marketplace.
- Also includes CodeQL security fixes for pre-existing alerts surfaced on this PR (ReDoS, env-sourced executable, tainted shell inputs) — none introduced by #64.
- v1 intercepts the primary page target and attaches js-debug best-effort (interception + hot reload work even if the debugger doesn't attach). Multi-target/tab handling can be a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


