### PR TITLE
test: interactive-auth coverage (wizard + browser) + harden the Edge/Chrome matrix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to the "dataverse-powertools" extension will be documented in this file.
 
+## 0.5.5
+
+- Internal/testing: added end-to-end coverage for the interactive (OAuth) sign-in path — including a full wizard run that scaffolds and deploys a plugin under interactive auth — and hardened the live Edge/Chrome debug-web-resources test harness. A guarded, test-only MSAL cache seam (active only when `DVPT_TEST_MSAL_CACHE_FILE` is set) makes the interactive connect silent during automated tests; it is inert in normal use. No user-facing change.
+
 ## 0.5.4
 
 - New: **Debug Web Resources** — run your local webpack bundle _inside the live model-driven app_ with hot reload and VS Code debugging, instead of republishing on every change. A dedicated Edge/Chrome instance is launched under the DevTools Protocol and its request for the deployed bundle is fulfilled from your local `bin/` build; `webpack --watch` rebuilds on save and the form reloads, and the JS debugger attaches for breakpoints. Nothing is written to Dataverse — the swap is ephemeral and browser-scoped (#64).

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "dataverse-powertools",
-  "version": "0.5.4",
+  "version": "0.5.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "dataverse-powertools",
-      "version": "0.5.4",
+      "version": "0.5.5",
       "dependencies": {
         "@azure/msal-node": "^5.4.0",
         "adm-zip": "^0.5.18",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "type": "git",
     "url": "https://github.com/pete-mc/dataverse-powertools"
   },
-  "version": "0.5.4",
+  "version": "0.5.5",
   "engines": {
     "vscode": "^1.93.0"
   },

--- a/src/general/dataverse/tokenAcquisition.ts
+++ b/src/general/dataverse/tokenAcquisition.ts
@@ -3,6 +3,7 @@
 // scope logic it relies on is in authTypes.ts and is unit-tested there.
 
 import fetch from "node-fetch";
+import * as fs from "fs";
 import * as vscode from "vscode";
 import { PublicClientApplication, AccountInfo, ICachePlugin, TokenCacheContext } from "@azure/msal-node";
 import { buildDataverseScopes } from "./authTypes";
@@ -53,8 +54,27 @@ export function initInteractiveTokenCache(secrets: vscode.SecretStorage, channel
   cacheChannel = channel;
 }
 
+// Test-only seam: when DVPT_TEST_MSAL_CACHE_FILE points at a file, the MSAL cache is read/written
+// there instead of VS Code secret storage. This lets automated e2e tests pre-seed an
+// interactive-user sign-in (acquired headlessly beforehand) so the connect wizard authenticates
+// silently, with no browser to drive. It is inert unless that env var is explicitly set, so it
+// never affects real users.
+const testCacheFile = (): string | undefined => process.env.DVPT_TEST_MSAL_CACHE_FILE || undefined;
+
 const cachePlugin: ICachePlugin = {
   beforeCacheAccess: async (cacheContext: TokenCacheContext) => {
+    const file = testCacheFile();
+    if (file) {
+      try {
+        const data = fs.readFileSync(file, "utf8");
+        if (data) {
+          cacheContext.tokenCache.deserialize(data);
+        }
+      } catch {
+        /* no seeded cache yet */
+      }
+      return;
+    }
     if (!cacheSecrets) {
       return;
     }
@@ -64,7 +84,19 @@ const cachePlugin: ICachePlugin = {
     }
   },
   afterCacheAccess: async (cacheContext: TokenCacheContext) => {
-    if (!cacheSecrets || !cacheContext.cacheHasChanged) {
+    if (!cacheContext.cacheHasChanged) {
+      return;
+    }
+    const file = testCacheFile();
+    if (file) {
+      try {
+        fs.writeFileSync(file, cacheContext.tokenCache.serialize());
+      } catch {
+        /* best effort */
+      }
+      return;
+    }
+    if (!cacheSecrets) {
       return;
     }
     await cacheSecrets.store(MSAL_CACHE_SECRET_KEY, cacheContext.tokenCache.serialize());

--- a/src/ui-test/e2e/pluginInteractiveLifecycle.e2e.ts
+++ b/src/ui-test/e2e/pluginInteractiveLifecycle.e2e.ts
@@ -1,0 +1,123 @@
+import * as path from "path";
+import * as fs from "fs";
+import { expect } from "chai";
+import { VSBrowser } from "vscode-extension-tester";
+import { loadE2EEnv, freshWorkspace, answerText, answerFlexible, pickByLabel, runCommand, waitForFile, dismissOverlays, sleep, E2EClient } from "./lib";
+
+// End-to-end: create a Plugins project via the real wizard using INTERACTIVE (OAuth) sign-in —
+// then Build Package & Deploy it to the live environment and verify it landed. The interactive
+// connect is silent because DVPT_TEST_MSAL_CACHE_FILE points at a cache pre-seeded by
+// preAcquireInteractiveCache.mjs (so there is no browser to drive inside ExTester). Proves the
+// interactive-auth wizard path end-to-end for plugins (which deploy via the Dataverse Web API +
+// token, not pac). Self-skips without sandbox/.env or a seeded cache.
+describe("Plugin lifecycle — interactive auth (e2e)", function () {
+  this.timeout(1200000);
+  const env = loadE2EEnv();
+  const hasCache = !!process.env.DVPT_TEST_MSAL_CACHE_FILE && fs.existsSync(process.env.DVPT_TEST_MSAL_CACHE_FILE || "");
+  const projectName = "E2EPluginInt";
+  const packageName = "E2EPluginIntPkg";
+  let workspace: string;
+  let solutionFriendlyName: string;
+
+  function pluginPackageUniqueName(): string {
+    try {
+      const settings = JSON.parse(fs.readFileSync(path.join(workspace, "dataverse-powertools.json"), "utf8"));
+      return `${settings.prefix}_${packageName}`;
+    } catch {
+      return `${env?.prefix}_${packageName}`;
+    }
+  }
+
+  afterEach(async function () {
+    if (this.currentTest?.state === "failed") {
+      try {
+        const dir = path.resolve(__dirname, "..", "..", "..", "sandbox", "screenshots-out");
+        fs.mkdirSync(dir, { recursive: true });
+        const img = await VSBrowser.instance.driver.takeScreenshot();
+        const name = (this.currentTest?.title || "step").replace(/[^a-z0-9]+/gi, "-").slice(0, 40);
+        fs.writeFileSync(path.join(dir, `e2e-plugin-int-fail-${name}.png`), img, "base64");
+      } catch {
+        /* ignore */
+      }
+    }
+  });
+
+  before(async function () {
+    if (!env || !hasCache) {
+      this.skip();
+    }
+    const client = new E2EClient(env!);
+    await client.connect();
+    solutionFriendlyName = (await client.getSolutionFriendlyName(env!.solutionName)) ?? env!.solutionName;
+
+    workspace = freshWorkspace("plugin-interactive");
+    await VSBrowser.instance.openResources(workspace);
+    await VSBrowser.instance.waitForWorkbench();
+    await sleep(3500);
+    await dismissOverlays();
+    try {
+      await runCommand("Dataverse PowerTools: Show Log");
+    } catch {
+      /* the command may not be registered until the extension activates */
+    }
+  });
+
+  it("creates a Plugins project via the wizard using interactive sign-in", async () => {
+    const log = (m: string) => console.log(`    [e2e] ${m}`);
+    log("running Initialise Project");
+    await runCommand("Dataverse PowerTools: Initialise Project");
+    log("project type");
+    await pickByLabel("Plugins");
+    log("auth type: Interactive sign-in");
+    await pickByLabel("Interactive sign-in");
+    // Interactive signs in silently from the pre-seeded cache, then lists environments via Global
+    // Discovery — no tenant/clientId/clientSecret prompts. Pick the environment by its URL.
+    log("environment (silent sign-in + discovery)");
+    await answerFlexible(env!.url, 120000);
+    log(`solution (${solutionFriendlyName})`);
+    await pickByLabel(solutionFriendlyName);
+    log("plugin project name");
+    await answerText(projectName);
+    log("plugin package name");
+    await answerText(packageName);
+    log("plugin package version");
+    await answerText("1.0.0");
+    log("waiting for restores + setup-unit-testing prompt");
+    await pickByLabel("No", 600000);
+    await sleep(4000);
+    await dismissOverlays();
+
+    expect(await waitForFile(path.join(workspace, "dataverse-powertools.json"), 60000), "dataverse-powertools.json").to.equal(true);
+    expect(await waitForFile(path.join(workspace, projectName, `${projectName}.csproj`), 300000), `${projectName}/${projectName}.csproj`).to.equal(true);
+  });
+
+  it("builds and deploys the plugin package to Dataverse (interactive token)", async () => {
+    await runCommand("Dataverse PowerTools: Build Package & Deploy");
+
+    const client = new E2EClient(env!);
+    await client.connect();
+    let id: string | undefined;
+    const deadline = Date.now() + 240000;
+    do {
+      try {
+        id = await client.findPluginPackageId(pluginPackageUniqueName());
+      } catch {
+        id = undefined;
+      }
+      if (id) {
+        break;
+      }
+      await sleep(7000);
+    } while (Date.now() < deadline);
+    expect(id, `${pluginPackageUniqueName()} exists in Dataverse`).to.not.equal(undefined);
+  });
+
+  after(async function () {
+    if (!env || !hasCache) {
+      return;
+    }
+    const client = new E2EClient(env);
+    await client.connect();
+    await client.deletePluginPackage(pluginPackageUniqueName());
+  });
+});

--- a/test/live/debugBrowsersMatrix.spec.ts
+++ b/test/live/debugBrowsersMatrix.spec.ts
@@ -10,7 +10,7 @@ import { LiveDataverseClient } from "./dataverseClient";
 import { DataverseWebresource } from "../../src/general/dataverse/DataverseWebresource";
 import { DataverseForm } from "../../src/general/dataverse/DataverseForm";
 import { debugWebResources, stopDebugWebResources } from "../../src/webresources/debug/debugWebresources";
-import { preAuthenticateProfile, findDebugPortByProfile } from "./browserAutoLogin";
+import { preAuthenticateProfile, autoLoginBrowser, findDebugPortByProfile } from "./browserAutoLogin";
 import { resolveBrowser } from "../../src/webresources/debug/browserResolver";
 import DataversePowerToolsContext from "../../src/context";
 
@@ -88,35 +88,74 @@ async function unregisterHandler(ctx: DataversePowerToolsContext): Promise<void>
   await form.saveForm();
 }
 
-async function bannerOnForm(port: number, recordUrl: string): Promise<string> {
+const BANNER_RE = `document.body.innerText.match(/LOCAL v2[^<\\n]*|LOCAL v1[^<\\n]*|DEPLOYED — banner from the SERVER copy/)`;
+
+/** Open a persistent CDP client on the page, with the service worker bypassed so the form's bundle
+ *  request goes to the network where the feature's interception sees it (otherwise the SW cache
+ *  serves it and no banner reflects the local build). The client stays open so the bypass persists
+ *  through the load — closing it would revert the override mid-navigation. */
+async function openPageClient(port: number): Promise<CDP.Client> {
   const targets = await CDP.List({ port });
-  const page = targets.find((t) => t.type === "page");
+  const pages = targets.filter((t) => t.type === "page");
+  const page = pages.find((t) => /dynamics|crm|main\.aspx/i.test(t.url)) || pages.find((t) => t.url.startsWith("http")) || pages[0];
   const client = await CDP({ port, target: page });
+  await client.Page.enable();
+  await client.Network.enable();
+  await client.Runtime.enable();
+  await client.Network.setBypassServiceWorker({ bypass: true });
+  return client;
+}
+
+async function pollBannerOn(client: CDP.Client, timeoutMs: number, want?: string): Promise<string> {
+  const deadline = Date.now() + timeoutMs;
+  let last = "(none)";
+  while (Date.now() < deadline) {
+    const v = (await client.Runtime.evaluate({ expression: `(${BANNER_RE}||['(none)'])[0]`, returnByValue: true })).result.value as string;
+    if (v && v !== "(none)") {
+      last = v;
+      if (!want || v.includes(want)) {
+        return v;
+      }
+    }
+    await new Promise((r) => setTimeout(r, 3000));
+  }
+  return last;
+}
+
+async function bannerOnForm(port: number, recordUrl: string): Promise<string> {
+  const client = await openPageClient(port);
   try {
-    await client.Page.enable();
-    await client.Runtime.enable();
     await client.Page.navigate({ url: recordUrl });
-    await new Promise((r) => setTimeout(r, 18000));
-    return (await client.Runtime.evaluate({
-      expression: `(document.body.innerText.match(/LOCAL v2[^<]*|LOCAL v1[^<]*|DEPLOYED — banner from the SERVER copy/)||['(none)'])[0]`,
-      returnByValue: true,
-    })).result.value as string;
+    const banner = await pollBannerOn(client, 60000); // form + onload notification can lag a cold load
+    if (banner === "(none)") {
+      // Diagnose why no banner rendered (form/library/onload state).
+      const d = (
+        await client.Runtime.evaluate({
+          expression: `JSON.stringify((()=>{const perf=performance.getEntriesByType('resource').map(e=>e.name).filter(n=>/dvpt_library/i.test(n));return{url:location.href.slice(0,90),title:document.title,bundle:perf,hasXrm:typeof Xrm!=='undefined',bodyLen:(document.body?document.body.innerText.length:0)};})())`,
+          returnByValue: true,
+        })
+      ).result.value as string;
+      log(`no-banner diag: ${d}`);
+    }
+    return banner;
   } finally {
     await client.close();
   }
 }
 
 async function reloadedBanner(port: number): Promise<string> {
-  await new Promise((r) => setTimeout(r, 9000)); // let the feature's debounced hot-reload happen
+  // Let the feature's debounced fs.watch reload fire + settle first. Do NOT open a
+  // bypass-toggling client while the feature is reloading — on Chrome that races the feature's
+  // CDP session and can drop it (tearing down the debug session). Read-only client, no bypass.
+  await new Promise((r) => setTimeout(r, 9000));
   const targets = await CDP.List({ port });
-  const page = targets.find((t) => t.type === "page");
+  const pages = targets.filter((t) => t.type === "page");
+  const page = pages.find((t) => /dynamics|crm|main\.aspx/i.test(t.url)) || pages[0];
+  if (!page) return "(none)";
   const client = await CDP({ port, target: page });
   try {
     await client.Runtime.enable();
-    return (await client.Runtime.evaluate({
-      expression: `(document.body.innerText.match(/LOCAL v2[^<]*|LOCAL v1[^<]*|DEPLOYED — banner from the SERVER copy/)||['(none)'])[0]`,
-      returnByValue: true,
-    })).result.value as string;
+    return await pollBannerOn(client, 45000, "LOCAL v2");
   } finally {
     await client.close();
   }
@@ -139,10 +178,16 @@ suite("Debug Web Resources — Edge + Chrome unattended (#64)", () => {
     await client.publishAll();
     await registerHandler(setupCtx);
     await client.publishAll();
+    // PublishAllXml returns before the published form/web-resource are fully served by the app,
+    // so let the customisations settle before a browser opens the form (otherwise the onload
+    // handler/library may not yet be live and no banner renders).
+    await new Promise((r) => setTimeout(r, 15000));
     // Any existing account record (a create form triggers a beforeunload dialog on reload).
     const res: any = await (await fetch(`${e.url}/api/data/v9.2/accounts?$select=accountid&$top=1`, { headers: { Authorization: `Bearer ${client.accessToken}`, Accept: "application/json" } })).json();
     const accountId = res.value?.[0]?.accountid;
-    recordUrl = `${e.url}/main.aspx?appid=${APP_ID}&pagetype=entityrecord&etn=account${accountId ? `&id=${accountId}` : ""}`;
+    // Force the specific form we registered the handler on (&formid=) — Dynamics otherwise opens
+    // the user's last-used account form, which may not be FORM_ID.
+    recordUrl = `${e.url}/main.aspx?appid=${APP_ID}&pagetype=entityrecord&etn=account&formid=${FORM_ID}${accountId ? `&id=${accountId}` : ""}`;
     log(`Setup complete. Account form registered; record: ${accountId ?? "(new)"}`);
   }, 180000);
 
@@ -192,6 +237,12 @@ suite("Debug Web Resources — Edge + Chrome unattended (#64)", () => {
         await debugWebResources(ctx);
         const port = await findDebugPortByProfile(profileDir);
         log(`[${browser}] debug session on port ${port}`);
+
+        // Belt-and-braces: the pre-auth session cookie doesn't always persist into the reopened
+        // profile, so make sure the feature's browser is actually signed in (returns immediately if
+        // it already is) before we open the form — otherwise it sits on the AAD sign-in page.
+        const signedIn = await autoLoginBrowser(port, { username: u.username, password: u.password, orgHost, log, timeoutMs: 90000 });
+        expect(signedIn, `feature browser did not reach the org on ${browser}`).toBe(true);
 
         const first = await bannerOnForm(port, recordUrl);
         log(`[${browser}] banner on first load: ${first}`);

--- a/test/live/interactiveConnect.spec.ts
+++ b/test/live/interactiveConnect.spec.ts
@@ -158,7 +158,7 @@ suite("Interactive (OAuth) auth → real Dataverse", () => {
   it(
     "acquires an interactive user token and writes to Dataverse with it",
     async () => {
-      log(`acquiring interactive token as ${u.username} …`);
+      log(`acquiring an interactive-user token …`);
       const res = await acquireInteractiveToken(e.url, undefined, true);
       expect(res?.accessToken, "interactive token acquisition returned nothing").toBeTruthy();
       token = res!.accessToken;

--- a/test/live/interactiveConnect.spec.ts
+++ b/test/live/interactiveConnect.spec.ts
@@ -1,0 +1,183 @@
+/* eslint-disable @typescript-eslint/naming-convention */
+import { describe, it, beforeAll, afterAll, expect } from "vitest";
+import * as os from "os";
+import * as fs from "fs";
+import * as path from "path";
+import * as net from "net";
+import * as cp from "child_process";
+import * as vscode from "vscode"; // aliased to test/vscode.mock.ts
+import CDP = require("chrome-remote-interface");
+import { loadLiveEnv, loadInteractiveTestUser, LiveEnv } from "../liveEnv";
+import { LiveDataverseClient } from "./dataverseClient";
+import { DataverseWebresource } from "../../src/general/dataverse/DataverseWebresource";
+import { acquireInteractiveToken } from "../../src/general/dataverse/tokenAcquisition";
+import DataversePowerToolsContext from "../../src/context";
+
+// Verifies the extension's real INTERACTIVE (OAuth/MSAL loopback) auth path end-to-end against a
+// live org: acquire a token as the interactive user by auto-driving the MSAL sign-in browser,
+// then do a real Dataverse write (deploy a web resource) with that token. Proves interactive-user
+// auth works cross-platform (complements the service-principal e2e).
+//
+//   DVPT_DEBUG_DEMO=1 npm run test:live -- test/live/interactiveConnect.spec.ts
+const env = loadLiveEnv();
+const user = loadInteractiveTestUser();
+const enabled = !!env && !!user && process.env.DVPT_DEBUG_DEMO === "1";
+const suite = enabled ? describe : describe.skip;
+
+const EDGE = "C:\\Program Files (x86)\\Microsoft\\Edge\\Application\\msedge.exe";
+const sleep = (ms: number): Promise<void> => new Promise((r) => setTimeout(r, ms));
+const log = (m: string): void => {
+  // eslint-disable-next-line no-console
+  console.log(`[interactive] ${m}`);
+};
+
+function freePort(): Promise<number> {
+  return new Promise((resolve, reject) => {
+    const s = net.createServer();
+    s.once("error", reject);
+    s.listen(0, "127.0.0.1", () => {
+      const a = s.address();
+      const p = typeof a === "object" && a ? a.port : 0;
+      s.close(() => (p ? resolve(p) : reject(new Error("no port"))));
+    });
+  });
+}
+
+async function evalJs(client: CDP.Client, expr: string): Promise<unknown> {
+  return (await client.Runtime.evaluate({ expression: expr, awaitPromise: true, returnByValue: true })).result.value;
+}
+async function typeInto(client: CDP.Client, sel: string, text: string): Promise<boolean> {
+  const v = await evalJs(
+    client,
+    `(() => { const e=document.querySelector(${JSON.stringify(sel)}); if(!e) return null; e.focus();
+      const s=Object.getOwnPropertyDescriptor(window.HTMLInputElement.prototype,'value').set; s.call(e, ${JSON.stringify(text)});
+      e.dispatchEvent(new Event('input',{bubbles:true})); e.dispatchEvent(new Event('change',{bubbles:true})); return e.value; })()`,
+  );
+  return v === text;
+}
+const clickBtn = (client: CDP.Client): Promise<unknown> => evalJs(client, `(() => { const b=document.querySelector('#idSIButton9'); if(b){b.click();return true;} return false; })()`);
+
+/** Drive the MSAL loopback sign-in: fill email/password, accept KMSI/consent, until the browser
+ *  redirects to the localhost loopback (where MSAL captures the auth code). */
+async function driveMsalLogin(authUrl: string, u: { username: string; password: string }): Promise<void> {
+  const profile = path.join(os.tmpdir(), "dvpt-msal-login");
+  fs.rmSync(profile, { recursive: true, force: true });
+  fs.mkdirSync(profile, { recursive: true });
+  const port = await freePort();
+  const child = cp.spawn(EDGE, [`--remote-debugging-port=${port}`, `--user-data-dir=${profile}`, "--no-first-run", "--no-default-browser-check", "--new-window", authUrl], { stdio: "ignore" });
+  try {
+    let client: CDP.Client | undefined;
+    for (let i = 0; i < 40 && !client; i++) {
+      try {
+        client = await CDP({ port });
+      } catch {
+        await sleep(400);
+      }
+    }
+    if (!client) throw new Error("no CDP for MSAL login browser");
+    await client.Runtime.enable();
+    const deadline = Date.now() + 90000;
+    let lastSig = "";
+    while (Date.now() < deadline) {
+      const s = JSON.parse(
+        (await evalJs(
+          client,
+          `JSON.stringify((()=>{const q=s=>document.querySelector(s);const vis=e=>!!(e&&e.offsetParent!==null&&!e.disabled);const t=document.body?document.body.innerText:'';return{
+            host:location.host, email:vis(q('input[name=loginfmt]')), pass:vis(q('input[name=passwd]')),
+            consent:/permissions requested|consent|let this app|accepting these permissions/i.test(t),
+            kmsi:/stay signed in\\?/i.test(t)||!!q('#KmsiCheckboxField'), btn:!!q('#idSIButton9') };})())`,
+        )) as string,
+      );
+      const sig = `${s.host}|e${+s.email}|p${+s.pass}|c${+s.consent}|k${+s.kmsi}`;
+      if (sig !== lastSig) {
+        log(`sign-in ${sig}`);
+        lastSig = sig;
+      }
+      if (s.host === "localhost" || s.host.startsWith("localhost:")) {
+        log("reached loopback redirect");
+        await sleep(1500);
+        return;
+      }
+      if (s.pass) {
+        if (await typeInto(client, "input[name=passwd]", u.password)) await clickBtn(client);
+        await sleep(2500);
+      } else if (s.email) {
+        if (await typeInto(client, "input[name=loginfmt]", u.username)) await clickBtn(client);
+        await sleep(2500);
+      } else if (s.consent || s.kmsi) {
+        await clickBtn(client); // Accept / Yes
+        await sleep(2000);
+      } else {
+        await sleep(1500);
+      }
+    }
+    log("WARNING: sign-in did not reach the loopback within timeout");
+  } finally {
+    // give MSAL a moment to capture the code before the browser dies
+    await sleep(500);
+    try {
+      child.kill();
+    } catch {
+      /* ignore */
+    }
+  }
+}
+
+suite("Interactive (OAuth) auth → real Dataverse", () => {
+  const e = env as LiveEnv;
+  const u = user!;
+  const client = new LiveDataverseClient(e);
+  const BUNDLE = "dvpt_interactive_probe.js";
+  let token = "";
+
+  beforeAll(async () => {
+    await client.connect();
+    // The extension's interactive flow calls vscode.env.openExternal(uri) with the MSAL auth URL.
+    (vscode as unknown as { env: unknown }).env = {
+      openExternal: async (uri: { fsPath?: string; toString?: () => string }) => {
+        const url = (uri.fsPath && uri.fsPath.startsWith("http") ? uri.fsPath : undefined) ?? (uri.toString ? uri.toString() : String(uri));
+        await driveMsalLogin(url, u);
+        return true;
+      },
+    };
+  }, 120000);
+
+  afterAll(async () => {
+    try {
+      const found = await client.findWebresourceByName(BUNDLE);
+      if (found) {
+        await client.deleteWebresource(found.webresourceid);
+        await client.publishAll();
+        log("cleaned up interactive probe webresource");
+      }
+    } catch (err) {
+      log(`cleanup error: ${(err as Error).message}`);
+    }
+  }, 60000);
+
+  it(
+    "acquires an interactive user token and writes to Dataverse with it",
+    async () => {
+      log(`acquiring interactive token as ${u.username} …`);
+      const res = await acquireInteractiveToken(e.url, undefined, true);
+      expect(res?.accessToken, "interactive token acquisition returned nothing").toBeTruthy();
+      token = res!.accessToken;
+      log(`got interactive token (len ${token.length}); deploying a web resource with it`);
+
+      const ctx = {
+        projectSettings: { prefix: "dvpt", tenantId: e.tenantId },
+        dataverse: { organizationUrl: e.url, isValid: true, authorizationToken: token, getAuthorizationToken: async () => token },
+        channel: { appendLine: log, show: () => undefined },
+      } as unknown as DataversePowerToolsContext;
+
+      const wr = new DataverseWebresource(BUNDLE, ctx);
+      await wr.upsert(Buffer.from("// deployed via interactive-user auth\n", "utf8").toString("base64"), 3, "dvpt interactive probe");
+      await client.publishAll();
+
+      const found = await client.findWebresourceByName(BUNDLE);
+      expect(found, "web resource was not created using the interactive-user token").toBeTruthy();
+      log("verified: web resource created in Dataverse using the interactive-user token ✓");
+    },
+    5 * 60 * 1000,
+  );
+});

--- a/test/live/interactiveSilent.spec.ts
+++ b/test/live/interactiveSilent.spec.ts
@@ -1,0 +1,32 @@
+/* eslint-disable @typescript-eslint/naming-convention */
+import { describe, it, beforeAll, expect } from "vitest";
+import * as fs from "fs";
+import * as vscode from "vscode"; // aliased to test/vscode.mock.ts
+import { loadLiveEnv, LiveEnv } from "../liveEnv";
+import { acquireInteractiveToken } from "../../src/general/dataverse/tokenAcquisition";
+
+// Validates the DVPT_TEST_MSAL_CACHE_FILE seam: with a pre-seeded interactive cache (written by
+// preAcquireInteractiveCache.mjs in a prior process), the extension's interactive auth resolves a
+// token SILENTLY — no browser. This is what lets the ExTester wizard connect interactively.
+const env = loadLiveEnv();
+const cacheFile = process.env.DVPT_TEST_MSAL_CACHE_FILE;
+const enabled = !!env && !!cacheFile && fs.existsSync(cacheFile || "") && process.env.DVPT_DEBUG_DEMO === "1";
+const suite = enabled ? describe : describe.skip;
+
+suite("Interactive connect is silent from a pre-seeded cache", () => {
+  const e = env as LiveEnv;
+
+  beforeAll(() => {
+    // If the interactive flow tries to open a browser, that means it wasn't silent — fail loudly.
+    (vscode as unknown as { env: unknown }).env = {
+      openExternal: async () => {
+        throw new Error("openExternal called — interactive connect was NOT silent");
+      },
+    };
+  });
+
+  it("acquires an interactive token without opening a browser", async () => {
+    const res = await acquireInteractiveToken(e.url, undefined, /* promptIfNeeded */ false);
+    expect(res?.accessToken, "no silent token — the pre-seeded cache was not used").toBeTruthy();
+  });
+});

--- a/test/live/preAcquireInteractiveCache.mjs
+++ b/test/live/preAcquireInteractiveCache.mjs
@@ -1,0 +1,73 @@
+// Pre-acquire an interactive (OAuth) MSAL token cache for the interactive test user and write it
+// to DVPT_TEST_MSAL_CACHE_FILE, using the SAME public-client app id + authority the extension uses.
+// The extension (with that env var set) then reads this cache and connects SILENTLY — no browser
+// to drive during the ExTester wizard. Run before `extest`.
+//
+//   DVPT_TEST_MSAL_CACHE_FILE=... node test/live/preAcquireInteractiveCache.mjs
+import * as fs from "fs";
+import * as os from "os";
+import * as path from "path";
+import * as net from "net";
+import * as cp from "child_process";
+import { createRequire } from "module";
+const require = createRequire("file:///C:/Users/Peter/sources/repos/dataverse-powertools/index.js");
+const { PublicClientApplication } = require("@azure/msal-node");
+const CDP = require("chrome-remote-interface");
+
+const CLIENT_ID = "51f81489-12ee-4a9e-aaae-a2591f45987d"; // == DEFAULT_INTERACTIVE_CLIENT_ID
+const AUTHORITY = "https://login.microsoftonline.com/organizations";
+const EDGE = "C:\\Program Files (x86)\\Microsoft\\Edge\\Application\\msedge.exe";
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+
+function env() {
+  const t = fs.readFileSync("C:/Users/Peter/sources/repos/dataverse-powertools/sandbox/.env", "utf8");
+  const e = {};
+  for (const l of t.split(/\r?\n/)) { const m = l.match(/^\s*([A-Z0-9_]+)\s*=\s*(.*)\s*$/); if (m) e[m[1]] = m[2]; }
+  return e;
+}
+function freePort() {
+  return new Promise((res, rej) => { const s = net.createServer(); s.once("error", rej); s.listen(0, "127.0.0.1", () => { const p = s.address().port; s.close(() => res(p)); }); });
+}
+async function driveMsalLogin(authUrl, USER, PASS) {
+  const profile = path.join(os.tmpdir(), "dvpt-preacquire-login");
+  fs.rmSync(profile, { recursive: true, force: true }); fs.mkdirSync(profile, { recursive: true });
+  const port = await freePort();
+  const child = cp.spawn(EDGE, [`--remote-debugging-port=${port}`, `--user-data-dir=${profile}`, "--no-first-run", "--no-default-browser-check", "--new-window", authUrl], { stdio: "ignore" });
+  try {
+    let client; for (let i = 0; i < 40 && !client; i++) { try { client = await CDP({ port }); } catch { await sleep(400); } }
+    const { Runtime } = client; await Runtime.enable();
+    const ev = async (e) => (await Runtime.evaluate({ expression: e, awaitPromise: true, returnByValue: true })).result.value;
+    const setV = (sel, v) => ev(`(()=>{const e=document.querySelector(${JSON.stringify(sel)});if(!e)return false;e.focus();const s=Object.getOwnPropertyDescriptor(window.HTMLInputElement.prototype,'value').set;s.call(e,${JSON.stringify(v)});e.dispatchEvent(new Event('input',{bubbles:true}));e.dispatchEvent(new Event('change',{bubbles:true}));return true;})()`);
+    const clickBtn = () => ev(`(()=>{const b=document.querySelector('#idSIButton9');if(b){b.click();return true;}return false;})()`);
+    const deadline = Date.now() + 90000;
+    while (Date.now() < deadline) {
+      const s = JSON.parse(await ev(`JSON.stringify((()=>{const q=s=>document.querySelector(s);const vis=e=>!!(e&&e.offsetParent!==null&&!e.disabled);const t=document.body?document.body.innerText:'';return{host:location.host,email:vis(q('input[name=loginfmt]')),pass:vis(q('input[name=passwd]')),consent:/permissions requested|consent|accepting these permissions/i.test(t),kmsi:/stay signed in\\?/i.test(t)||!!q('#KmsiCheckboxField')};})())`));
+      if (s.host === "localhost" || s.host.startsWith("localhost:")) { await sleep(1500); break; }
+      if (s.pass) { await setV("input[name=passwd]", PASS); await clickBtn(); await sleep(2500); }
+      else if (s.email) { await setV("input[name=loginfmt]", USER); await clickBtn(); await sleep(2500); }
+      else if (s.consent || s.kmsi) { await clickBtn(); await sleep(2000); }
+      else await sleep(1500);
+    }
+    await client.close();
+  } finally { await sleep(500); try { child.kill(); } catch {} }
+}
+
+const e = env();
+const ORG = e.DVPT_TEST_URL.replace(/\/+$/, "");
+const USER = e.DVPT_TEST_USERNAME.trim(), PASS = e.DVPT_TEST_PASSWORD;
+const cacheFile = process.env.DVPT_TEST_MSAL_CACHE_FILE;
+if (!cacheFile) { console.error("DVPT_TEST_MSAL_CACHE_FILE is required"); process.exit(1); }
+fs.rmSync(cacheFile, { force: true });
+
+const cachePlugin = {
+  beforeCacheAccess: async (ctx) => { try { const d = fs.readFileSync(cacheFile, "utf8"); if (d) ctx.tokenCache.deserialize(d); } catch {} },
+  afterCacheAccess: async (ctx) => { if (ctx.cacheHasChanged) fs.writeFileSync(cacheFile, ctx.tokenCache.serialize()); },
+};
+const pca = new PublicClientApplication({ auth: { clientId: CLIENT_ID, authority: AUTHORITY }, cache: { cachePlugin } });
+const res = await pca.acquireTokenInteractive({
+  scopes: [`${ORG}/.default`],
+  openBrowser: async (url) => driveMsalLogin(url, USER, PASS),
+  successTemplate: "<html><body>Signed in. You can close this window.</body></html>",
+});
+console.log("pre-acquired interactive token for", res?.account?.username, "| cache file bytes:", fs.existsSync(cacheFile) ? fs.statSync(cacheFile).size : 0);
+process.exit(res?.accessToken ? 0 : 1);


### PR DESCRIPTION
Adds real-Dataverse coverage for the **interactive-user** auth path and hardens the Edge/Chrome Debug Web Resources matrix, after a full cross-matrix test run.

## New: `test/live/interactiveConnect.spec.ts`
Drives the extension's real **MSAL interactive (OAuth loopback)** sign-in with an auto-logged-in browser, acquires an interactive-user token, and **deploys a web resource to a live org with it** — verifying interactive auth end-to-end (complements the service-principal e2e). Gated behind `DVPT_DEBUG_DEMO`.

## Hardened: `test/live/debugBrowsersMatrix.spec.ts`
A full run surfaced several real-Dataverse timing/state races (thanks to the "don't race publish / check state each step" insight):
- Force the registered form via `&formid=` — Dynamics otherwise opens the user's last-used account form, which may not carry the handler.
- Let `PublishAllXml` settle before opening the browser (it returns before the app serves the published form/web resource).
- Poll for the onload banner instead of a single fixed wait.
- Keep one persistent CDP client with the service worker bypassed **through** the form navigation (a client that closes mid-load reverts the bypass; the SW cache then serves the bundle and interception never sees it).
- **Ensure the feature's browser is actually signed in** before opening the form — the pre-auth session cookie doesn't always persist into the reopened profile.
- Don't open a bypass-toggling read client while the feature is mid hot-reload — on Chrome that races and drops the feature's CDP session; wait for the reload to settle and read read-only.

## Verified (full cross-matrix, real Dataverse)
- **e2e (service principal):** plugins + web resources scaffold → deploy → verify — **7 passing**
- **Interactive auth:** MSAL loopback sign-in → web-resource deploy — **1 passing**
- **Debug Web Resources (Edge + Chrome):** LOCAL served into a real Account form + hot reload to v2 — **2 passing**

Unit suite: 137 passing. These specs are gated (`DVPT_DEBUG_DEMO`) and don't run in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)