### PR TITLE
0.7.3 (pre-release) — Power Pages first-class: shared pac auth, upload round-trip, remembered site (#74)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to the "dataverse-powertools" extension will be documented in this file.
 
+## 0.7.3 (pre-release)
+
+- **Power Pages as a first-class project type (#74).** The portal flow now runs on the shared `dataverse-powertools` pac auth profile (service principal or OAuth — no more ad-hoc `pac auth` juggling), with pure unit-tested `pac pages` argument builders and structured error reporting. **Upload is new**: round-trip a site with *Download from \<org\>* / *Upload* on the portal card. *Select site* remembers your Power Pages site (`portalWebsiteId`) so download/upload target it without re-picking; the download folder is configurable via `portalDownloadPath` (default `portalpublish`).
+
 ## 0.7.2 (pre-release)
 
 - **Reliable live web-resource debugging (#96).** Re-running **Debug Web Resources** now stops the previous session and starts fresh (no more reload-VS-Code-between-runs); stopping the debugger from VS Code's toolbar tears down the whole stack (browser, webpack watch, CDP interception); breakpoints bind reliably to your TypeScript — the debug watch build forces `inline-source-map` even for projects whose `webpack.dev.js` still says `eval-source-map` (new projects scaffold with inline maps).

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "dataverse-powertools",
-  "version": "0.7.2",
+  "version": "0.7.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "dataverse-powertools",
-      "version": "0.7.2",
+      "version": "0.7.3",
       "hasInstallScript": true,
       "dependencies": {
         "@azure/msal-node": "^5.4.0",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "type": "git",
     "url": "https://github.com/pete-mc/dataverse-powertools"
   },
-  "version": "0.7.2",
+  "version": "0.7.3",
   "engines": {
     "vscode": "^1.93.0"
   },
@@ -529,6 +529,11 @@
         "command": "dataverse-powertools.viewPluginTraceLogs",
         "title": "Dataverse PowerTools: View Plugin Trace Logs",
         "enablement": "dataverse-powertools.showLoaded && dataverse-powertools.isPlugin"
+      },
+      {
+        "command": "dataverse-powertools.uploadPortal",
+        "title": "Dataverse PowerTools: Upload Portal",
+        "enablement": "dataverse-powertools.showLoaded && dataverse-powertools.isPortal"
       },
       {
         "command": "dataverse-powertools.showLog",

--- a/src/context.ts
+++ b/src/context.ts
@@ -153,6 +153,10 @@ interface ProjectSettings {
   pluginModelBuilder?: PluginModelBuilderSettings;
   controlName?: string;
   formIntersect?: FormIntersect[];
+  /** Power Pages (#74): the remembered site + download folder for this component. */
+  portalWebsiteId?: string;
+  portalWebsiteName?: string;
+  portalDownloadPath?: string;
 }
 
 export interface PluginModelBuilderSettings {

--- a/src/portals/connectPortal.ts
+++ b/src/portals/connectPortal.ts
@@ -1,151 +1,132 @@
 import * as vscode from "vscode";
-import * as cp from "child_process";
+import * as fs from "fs";
 import DataversePowerToolsContext from "../context";
-import { window } from "vscode";
-import { getOrganizationUrl } from "../general/connectionString";
-import { pacInvocation } from "../general/pac";
-import { parsePacAuthList, findAuthProfileForUrl, parsePacPagesList } from "./pacOutput";
-import path = require("path");
+import { parsePacPagesList, PacPage } from "./pacOutput";
+import { pacPagesListArgs, pacPagesDownloadArgs, pacPagesUploadArgs } from "./pacPagesArgs";
+import { ensurePacAuthForCurrentConnection, runPacLogged, runPacResult } from "../general/pacAuth";
 import { activeComponentRoot } from "../components/componentDiscovery";
+import path = require("path");
 
-export async function connectPortal(context: DataversePowerToolsContext, command: string) {
+// Power Pages round-trip on pac (#74): list/download/upload against the shared
+// dataverse-powertools pac auth profile (same model as solutions/modelbuilder),
+// pure arg builders, tolerant list parsing, and the selected site + download
+// folder remembered in dataverse-powertools.json.
+
+export type PortalMode = "connect" | "download" | "upload";
+
+function portalDownloadDirectory(context: DataversePowerToolsContext, workspacePath: string): string {
+  return path.join(workspacePath, (context.projectSettings.portalDownloadPath as string) || "portalpublish");
+}
+
+async function pickSite(context: DataversePowerToolsContext, workspacePath: string): Promise<PacPage | undefined> {
+  const list = await runPacResult(pacPagesListArgs(), workspacePath);
+  if (list.stdout) {
+    context.channel.appendLine(list.stdout);
+  }
+  if (list.code !== 0) {
+    if (list.stderr) {
+      context.channel.appendLine(list.stderr);
+    }
+    context.channel.show();
+    vscode.window.showErrorMessage("pac pages list failed. See the Dataverse PowerTools output.");
+    return undefined;
+  }
+  const sites = parsePacPagesList(list.stdout);
+  if (sites.length === 0) {
+    vscode.window.showErrorMessage("No Power Pages websites were found in this environment.");
+    return undefined;
+  }
+  const remembered = context.projectSettings.portalWebsiteId as string | undefined;
+  const pick = await vscode.window.showQuickPick(
+    sites.map((site) => ({
+      label: (site.websiteId === remembered ? "$(star-full) " : "") + (site.friendlyName || site.websiteId),
+      description: site.websiteId,
+      target: site,
+    })),
+    { placeHolder: "Select a Power Pages website" },
+  );
+  if (!pick) {
+    return undefined;
+  }
+  // Remember the site so download/upload target it without re-picking.
+  context.projectSettings.portalWebsiteId = pick.target.websiteId;
+  context.projectSettings.portalWebsiteName = pick.target.friendlyName;
+  await context.writeSettings();
+  context.refreshPanel?.();
+  return pick.target;
+}
+
+export async function connectPortal(context: DataversePowerToolsContext, mode: PortalMode): Promise<void> {
+  const workspacePath = activeComponentRoot(context);
+  if (!workspacePath) {
+    vscode.window.showErrorMessage("Open a workspace folder first.");
+    return;
+  }
+
   await vscode.window.withProgress(
     {
       location: vscode.ProgressLocation.Notification,
-      title: "Connecting Portal...",
+      title: mode === "upload" ? "Uploading Power Pages site..." : mode === "download" ? "Downloading Power Pages site..." : "Connecting to Power Pages...",
     },
     async () => {
-      await getPACLocation(context, command);
+      // Shared pac auth: service principals (re)create the extension's profile;
+      // OAuth creates one interactively when none exists (#103 behaviour).
+      if (!(await ensurePacAuthForCurrentConnection(context, workspacePath))) {
+        return;
+      }
+
+      if (mode === "connect") {
+        const site = await pickSite(context, workspacePath);
+        if (site) {
+          vscode.window.showInformationMessage(`Connected to ${site.friendlyName || site.websiteId} — Download / Upload now target this site.`);
+        }
+        return;
+      }
+
+      if (mode === "download") {
+        let websiteId = context.projectSettings.portalWebsiteId as string | undefined;
+        if (!websiteId) {
+          websiteId = (await pickSite(context, workspacePath))?.websiteId;
+        }
+        if (!websiteId) {
+          return;
+        }
+        const downloadPath = portalDownloadDirectory(context, workspacePath);
+        const ok = await runPacLogged(context, pacPagesDownloadArgs({ websiteId, path: downloadPath, overwrite: true }), workspacePath);
+        if (ok) {
+          vscode.window.showInformationMessage(`Power Pages site downloaded to ${path.basename(downloadPath)}.`);
+        } else {
+          vscode.window.showErrorMessage("pac pages download failed. See the Dataverse PowerTools output.");
+        }
+        return;
+      }
+
+      // upload
+      const uploadRoot = portalDownloadDirectory(context, workspacePath);
+      // pac pages download nests the site in a subfolder of the target path;
+      // upload wants the folder containing website.yml. Use it directly when
+      // present, else the single site subfolder.
+      let uploadPath = uploadRoot;
+      if (!fs.existsSync(path.join(uploadRoot, "website.yml"))) {
+        const subfolders = fs.existsSync(uploadRoot) ? fs.readdirSync(uploadRoot, { withFileTypes: true }).filter((entry) => entry.isDirectory()) : [];
+        const siteFolder = subfolders.find((entry) => fs.existsSync(path.join(uploadRoot, entry.name, "website.yml")));
+        if (!siteFolder) {
+          vscode.window.showErrorMessage(`No downloaded site found under ${uploadRoot} — run Download Portal first.`);
+          return;
+        }
+        uploadPath = path.join(uploadRoot, siteFolder.name);
+      }
+      const ok = await runPacLogged(context, pacPagesUploadArgs({ path: uploadPath }), workspacePath);
+      if (ok) {
+        vscode.window.showInformationMessage("Power Pages site uploaded.");
+      } else {
+        vscode.window.showErrorMessage("pac pages upload failed. See the Dataverse PowerTools output.");
+      }
     },
   );
 }
 
-async function execFileAsync(file: string, args: string[], cwd?: string): Promise<{ stdout: string; stderr: string }> {
-  return new Promise((resolve, reject) => {
-    cp.execFile(file, args, { cwd }, (error, stdout, stderr) => {
-      if (error) {
-        reject({ error, stdout, stderr });
-        return;
-      }
-
-      resolve({ stdout, stderr });
-    });
-  });
-}
-
-// Run a pac command and return stdout; pac.ts handles the Windows .cmd invocation.
-async function runPac(context: DataversePowerToolsContext, args: string[]) {
-  const workspacePath = activeComponentRoot(context);
-  const { command, args: invocationArgs } = pacInvocation(args);
-  const { stdout, stderr } = await execFileAsync(command, invocationArgs, workspacePath);
-  if (stderr) {
-    context.channel.appendLine(stderr);
-  }
-  return stdout;
-}
-
-export async function getPACLocation(context: DataversePowerToolsContext, command: string) {
-  if (vscode.workspace.workspaceFolders !== undefined) {
-    await connectPortalExec(context, command);
-  }
-}
-
-export async function createPACConnection(context: DataversePowerToolsContext, url: string) {
-  if (vscode.workspace.workspaceFolders !== undefined) {
-    try {
-      const stdout = await runPac(context, ["auth", "create", "--url", url]);
-      if (stdout !== null && stdout !== "") {
-        context.channel.appendLine(stdout);
-        context.channel.show();
-      }
-    } catch (error: any) {
-      vscode.window.showErrorMessage("Error creating auth.");
-      context.channel.appendLine(error?.error?.message || error?.message || JSON.stringify(error));
-      context.channel.show();
-    }
-  }
-}
-
-export async function connectPortalExec(context: DataversePowerToolsContext, _command: string) {
-  if (vscode.workspace.workspaceFolders !== undefined) {
-    try {
-      const stdout = await runPac(context, ["auth", "list"]);
-      if (stdout !== null && stdout !== "") {
-        context.channel.appendLine(stdout);
-        const targetUrl = getOrganizationUrl(context.connectionString);
-        const profile = findAuthProfileForUrl(parsePacAuthList(stdout), targetUrl);
-        if (!profile) {
-          vscode.window.showErrorMessage("Error finding matching portal.");
-          await createPACConnection(context, targetUrl);
-        } else {
-          // Prefer selecting by profile name; fall back to its index when unnamed.
-          const selector = profile.name ? ["-n", profile.name] : profile.index !== undefined ? ["--index", String(profile.index)] : undefined;
-          if (!selector) {
-            vscode.window.showErrorMessage("Error finding matching portal.");
-            return;
-          }
-          context.channel.appendLine(`Selecting auth profile: ${profile.name || `#${profile.index}`}`);
-          context.channel.show();
-          await selectEnvironment(context, selector);
-        }
-      }
-    } catch (error: any) {
-      vscode.window.showErrorMessage("Error finding Portals.");
-      context.channel.appendLine(error?.error?.message || error?.message || JSON.stringify(error));
-      context.channel.show();
-    }
-  }
-}
-
-export async function selectEnvironment(context: DataversePowerToolsContext, selector: string[]) {
-  if (vscode.workspace.workspaceFolders !== undefined) {
-    try {
-      const stdout = await runPac(context, ["auth", "select", ...selector]);
-      if (stdout !== null && stdout !== "") {
-        context.channel.appendLine(stdout);
-        context.channel.show();
-      }
-      await downloadPortal(context);
-    } catch (error: any) {
-      vscode.window.showErrorMessage("Error finding Portals.");
-      context.channel.appendLine(error?.error?.message || error?.message || JSON.stringify(error));
-      context.channel.show();
-    }
-  }
-}
-
-export async function downloadPortal(context: DataversePowerToolsContext) {
-  if (vscode.workspace.workspaceFolders !== undefined) {
-    const workspacePath = activeComponentRoot(context) ?? vscode.workspace.workspaceFolders[0].uri.fsPath;
-    try {
-      const stdout = await runPac(context, ["pages", "list"]);
-      if (stdout !== null && stdout !== "") {
-        context.channel.appendLine(stdout);
-        const pages = parsePacPagesList(stdout);
-        if (pages.length === 0) {
-          vscode.window.showErrorMessage("No Power Pages websites were found in this environment.");
-          context.channel.show();
-          return;
-        }
-        const quickPickArray = pages.map((page) => ({ label: page.friendlyName || page.websiteId, target: page.websiteId }));
-
-        const result = await window.showQuickPick(quickPickArray, { placeHolder: "Select a Power Pages website." });
-        if (!result?.target) {
-          return;
-        }
-
-        context.channel.appendLine(`${result.label}, ${result.target}`);
-        const downloadPath = path.join(workspacePath, "portalpublish");
-        const downloadOutput = await runPac(context, ["pages", "download", "-id", result.target, "-p", downloadPath]);
-        if (downloadOutput !== null && downloadOutput !== "") {
-          context.channel.appendLine(downloadOutput);
-        }
-        context.channel.show();
-      }
-    } catch (error: any) {
-      vscode.window.showErrorMessage("Error finding Portals.");
-      context.channel.appendLine(error?.error?.message || error?.message || JSON.stringify(error));
-      context.channel.show();
-    }
-  }
+/** Back-compat wrapper: the old signature took "connect" | "download". */
+export async function downloadPortal(context: DataversePowerToolsContext): Promise<void> {
+  await connectPortal(context, "download");
 }

--- a/src/portals/pacPagesArgs.spec.ts
+++ b/src/portals/pacPagesArgs.spec.ts
@@ -1,0 +1,31 @@
+import { describe, it, expect } from "vitest";
+import { pacPagesListArgs, pacPagesDownloadArgs, pacPagesUploadArgs } from "./pacPagesArgs";
+
+describe("pac pages args", () => {
+  it("lists sites", () => {
+    expect(pacPagesListArgs()).toEqual(["pages", "list"]);
+  });
+
+  it("downloads a site by id into a path", () => {
+    expect(pacPagesDownloadArgs({ websiteId: "site-1", path: "C:/repo/portalpublish" })).toEqual(["pages", "download", "--webSiteId", "site-1", "--path", "C:/repo/portalpublish"]);
+  });
+
+  it("passes the enhanced data model and overwrite when requested", () => {
+    expect(pacPagesDownloadArgs({ websiteId: "s", path: "p", modelVersion: 2, overwrite: true })).toEqual([
+      "pages",
+      "download",
+      "--webSiteId",
+      "s",
+      "--path",
+      "p",
+      "--modelVersion",
+      "2",
+      "--overwrite",
+    ]);
+  });
+
+  it("uploads from a path with optional model version", () => {
+    expect(pacPagesUploadArgs({ path: "p" })).toEqual(["pages", "upload", "--path", "p"]);
+    expect(pacPagesUploadArgs({ path: "p", modelVersion: 2 })).toEqual(["pages", "upload", "--path", "p", "--modelVersion", "2"]);
+  });
+});

--- a/src/portals/pacPagesArgs.ts
+++ b/src/portals/pacPagesArgs.ts
@@ -1,0 +1,38 @@
+// Pure builders for `pac pages` argument arrays (#74). No vscode import — keep
+// the exact flags visible and unit-tested, like src/solution/pacArgs.ts.
+
+export function pacPagesListArgs(): string[] {
+  return ["pages", "list"];
+}
+
+export interface PagesDownloadOptions {
+  websiteId: string;
+  path: string;
+  /** Power Pages data model: "Standard" | "Enhanced" (pac --modelVersion 1|2). */
+  modelVersion?: 1 | 2;
+  overwrite?: boolean;
+}
+
+export function pacPagesDownloadArgs(options: PagesDownloadOptions): string[] {
+  const args = ["pages", "download", "--webSiteId", options.websiteId, "--path", options.path];
+  if (options.modelVersion) {
+    args.push("--modelVersion", String(options.modelVersion));
+  }
+  if (options.overwrite) {
+    args.push("--overwrite");
+  }
+  return args;
+}
+
+export interface PagesUploadOptions {
+  path: string;
+  modelVersion?: 1 | 2;
+}
+
+export function pacPagesUploadArgs(options: PagesUploadOptions): string[] {
+  const args = ["pages", "upload", "--path", options.path];
+  if (options.modelVersion) {
+    args.push("--modelVersion", String(options.modelVersion));
+  }
+  return args;
+}

--- a/src/projectTypes/activation.ts
+++ b/src/projectTypes/activation.ts
@@ -204,6 +204,7 @@ export const projectTypeActivations: Record<ProjectTypes, ProjectTypeActivation>
     commands: {
       "dataverse-powertools.connectPortal": tracked("Connect portal", (context) => connectPortal(context, "connect")),
       "dataverse-powertools.downloadPortal": tracked("Download portal", (context) => connectPortal(context, "download")),
+      "dataverse-powertools.uploadPortal": tracked("Upload portal", (context) => connectPortal(context, "upload")),
     },
   },
 };

--- a/src/projectTypes/registry.ts
+++ b/src/projectTypes/registry.ts
@@ -181,11 +181,14 @@ export const projectTypeRegistry: readonly ProjectTypeDescriptor[] = [
     templateFolder: "portal",
     defaultTemplateVersion: 1,
     contextKey: "isPortal",
-    commandIds: [`${prefix}connectPortal`, `${prefix}downloadPortal`],
+    commandIds: [`${prefix}connectPortal`, `${prefix}downloadPortal`, `${prefix}uploadPortal`],
     menu() {
       return {
-        primary: { command: `${prefix}connectPortal`, label: "Connect to {environment}" },
-        secondary: [{ command: `${prefix}downloadPortal`, label: "Download" }],
+        primary: { command: `${prefix}downloadPortal`, label: "Download from {environment}" },
+        secondary: [
+          { command: `${prefix}uploadPortal`, label: "Upload" },
+          { command: `${prefix}connectPortal`, label: "Select site" },
+        ],
         overflow: [],
       };
     },


### PR DESCRIPTION
Closes #74.

- Portal flow rebuilt on the shared `dataverse-powertools` pac auth profile (`ensurePacAuthForCurrentConnection` — SP or OAuth), replacing the ad-hoc `pac auth list/select/create` parsing dance.
- Pure unit-tested `pac pages` arg builders (`pacPagesArgs.ts`); tolerant list parsing retained; structured error reporting via `runPacLogged`.
- **Upload** added (`pac pages upload`), with `website.yml` detection inside the download folder; **Select site** remembers `portalWebsiteId`/`portalWebsiteName` so Download/Upload target it without re-picking; `portalDownloadPath` configurable (default `portalpublish`).
- Portal card: *Download from \<org\>* (primary) / *Upload* / *Select site*.

Verification: lint / 229 unit tests / compile / integration green; core e2e regression suites **14/14 green** (plugin, webresource, both interactive). Portals have no live e2e — the test environment hosts no Power Pages site; flows verified against `pac pages` reference + unit-tested builders. Comprehensive step-8 env flake tracked in #106.

Published as a **pre-release**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)