### PR TITLE
0.7.4 (pre-release) — per-file web resource output (#88), settings schema version + migrations (#71)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to the "dataverse-powertools" extension will be documented in this file.
 
+## 0.7.4 (pre-release)
+
+- **Per-file web resource output (#88).** New projects choose at creation: the classic single bundled library (default) or **one JS web resource per TypeScript file** (`webresourceOutput: "perFile"` in `dataverse-powertools.json`). Per-file mode maps 1:1 with form libraries — each `webresources_src/*.ts` builds to `bin/<prefix>_<name>.js`, exports merged onto the `<prefix>` global so forms still call `<prefix>.Class.Function`; deploy pushes every built file. Known limitation: local debug interception currently targets the bundled library.
+- **Settings schema version + central migrations (#71).** `dataverse-powertools.json` now carries an explicit integer `settingsVersion`; an ordered, idempotent migration runner upgrades settings on load (root AND subfolder components identically), and files written by a newer extension are detected with a warning instead of silently mis-handled. Legacy plugin (<v3) auto-upgrade remains tracked on #71.
+
 ## 0.7.3 (pre-release)
 
 - **Power Pages as a first-class project type (#74).** The portal flow now runs on the shared `dataverse-powertools` pac auth profile (service principal or OAuth — no more ad-hoc `pac auth` juggling), with pure unit-tested `pac pages` argument builders and structured error reporting. **Upload is new**: round-trip a site with *Download from \<org\>* / *Upload* on the portal card. *Select site* remembers your Power Pages site (`portalWebsiteId`) so download/upload target it without re-picking; the download folder is configurable via `portalDownloadPath` (default `portalpublish`).

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "dataverse-powertools",
-  "version": "0.7.3",
+  "version": "0.7.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "dataverse-powertools",
-      "version": "0.7.3",
+      "version": "0.7.4",
       "hasInstallScript": true,
       "dependencies": {
         "@azure/msal-node": "^5.4.0",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "type": "git",
     "url": "https://github.com/pete-mc/dataverse-powertools"
   },
-  "version": "0.7.3",
+  "version": "0.7.4",
   "engines": {
     "vscode": "^1.93.0"
   },

--- a/src/components/discovery.ts
+++ b/src/components/discovery.ts
@@ -7,6 +7,8 @@
 // resolves them into components with root-file inheritance and provides
 // path→component resolution. Unit-tested in discovery.spec.ts.
 
+import { migrateSettings } from "../general/settingsMigrations";
+
 /** The parsed shape of a component's dataverse-powertools.json (loosely typed —
  * the full ProjectSettings interface lives in context.ts, which imports vscode). */
 export interface ComponentSettings {
@@ -107,12 +109,10 @@ export function resolveComponents(workspaceRoot: string, settingsFiles: { path: 
     }
   }
 
-  // Mirror readSettings' back-fill so subfolder web-resource components behave
-  // like the root one (context.ts applies this only to the root settings file).
+  // Run the central settings migrations (#71) so subfolder components behave
+  // exactly like the root one (context.readSettings migrates the root file).
   for (const component of components) {
-    if (!component.settings["webresourceSolutionName"] && component.settings.solutionName) {
-      component.settings["webresourceSolutionName"] = component.settings.solutionName;
-    }
+    component.settings = migrateSettings(component.settings).settings as ComponentSettings;
   }
 
   return { components, malformed };

--- a/src/context.ts
+++ b/src/context.ts
@@ -8,6 +8,7 @@ import { parseConnectionString, buildConnectionString, getOrganizationUrl, merge
 import { parseAuthType, DataverseAuthType } from "./general/dataverse/authTypes";
 import { ProjectTypes } from "./projectTypes/registry";
 import type { DiscoveredComponent } from "./components/discovery";
+import { migrateSettings } from "./general/settingsMigrations";
 
 // The enum now lives in the project-type registry (single source of truth,
 // #47/#100); re-exported here so existing imports keep working.
@@ -94,10 +95,16 @@ export default class DataversePowerToolsContext {
     if (filePath !== undefined) {
       await this.readFileAsync(filePath)
         .then(async (data: any) => {
-          this.projectSettings = JSON.parse(data);
-          if (!this.projectSettings.webresourceSolutionName && this.projectSettings.solutionName) {
-            this.projectSettings.webresourceSolutionName = this.projectSettings.solutionName;
+          // Central migration runner (#71): ordered, idempotent, versioned.
+          const migration = migrateSettings(JSON.parse(data));
+          if (migration.fromNewerVersion) {
+            this.channel.appendLine(
+              `Warning: dataverse-powertools.json was written by a NEWER extension (settingsVersion ${migration.settings.settingsVersion}). Update Dataverse PowerTools if anything misbehaves.`,
+            );
+          } else if (migration.applied.length > 0) {
+            this.channel.appendLine(`Migrated settings: ${migration.applied.join("; ")}.`);
           }
+          this.projectSettings = migration.settings as ProjectSettings;
           this.connectionString = this.projectSettings.connectionString || "";
           // Interactive (OAuth) connections carry no client secret — the persisted
           // connection string is complete on its own, so don't look up a stored secret
@@ -137,6 +144,10 @@ interface ProjectSettings {
   placeholders?: TemplatePlaceholder[];
   type?: ProjectTypes;
   templateversion?: number;
+  /** Settings schema version (#71) — stamped/migrated by settingsMigrations.ts. */
+  settingsVersion?: number;
+  /** Web resource build output (#88): one bundled library (default) or one JS per source file. */
+  webresourceOutput?: "bundle" | "perFile";
   tenantId?: string;
   /** Optional environment tag (e.g. DEV / TEST / PROD) shown as a badge in the actions panel. */
   environmentLabel?: string;

--- a/src/general/settingsMigrations.spec.ts
+++ b/src/general/settingsMigrations.spec.ts
@@ -1,0 +1,32 @@
+import { describe, it, expect } from "vitest";
+import { migrateSettings, CURRENT_SETTINGS_VERSION } from "./settingsMigrations";
+
+describe("migrateSettings", () => {
+  it("backfills webresourceSolutionName and stamps the current version", () => {
+    const { settings, applied, fromNewerVersion } = migrateSettings({ solutionName: "Core" });
+    expect(settings.webresourceSolutionName).toBe("Core");
+    expect(settings.settingsVersion).toBe(CURRENT_SETTINGS_VERSION);
+    expect(applied).toHaveLength(1);
+    expect(fromNewerVersion).toBe(false);
+  });
+
+  it("is idempotent — a current-version file applies nothing", () => {
+    const once = migrateSettings({ solutionName: "Core" }).settings;
+    const twice = migrateSettings(once);
+    expect(twice.applied).toEqual([]);
+    expect(twice.settings).toEqual(once);
+  });
+
+  it("does not overwrite an explicit webresourceSolutionName", () => {
+    const { settings } = migrateSettings({ solutionName: "Core", webresourceSolutionName: "Other" });
+    expect(settings.webresourceSolutionName).toBe("Other");
+  });
+
+  it("flags files written by a newer extension and leaves them untouched", () => {
+    const raw = { settingsVersion: CURRENT_SETTINGS_VERSION + 5, futureField: "x" };
+    const { settings, fromNewerVersion, applied } = migrateSettings(raw);
+    expect(fromNewerVersion).toBe(true);
+    expect(applied).toEqual([]);
+    expect(settings.settingsVersion).toBe(CURRENT_SETTINGS_VERSION + 5);
+  });
+});

--- a/src/general/settingsMigrations.ts
+++ b/src/general/settingsMigrations.ts
@@ -1,0 +1,50 @@
+// Central, ordered, idempotent migrations for dataverse-powertools.json (#71).
+// Pure — used by context.readSettings AND component discovery, so root and
+// subfolder components migrate identically. `settingsVersion` is the explicit
+// schema version (integer, monotonic), independent of `templateversion` (which
+// describes the scaffolded template shape, not the settings schema).
+
+export const CURRENT_SETTINGS_VERSION = 1;
+
+export interface SettingsMigrationResult {
+  settings: Record<string, unknown>;
+  /** Names of migrations applied this load (for logging). */
+  applied: string[];
+  /** True when the file was written by a NEWER extension — warn, don't touch. */
+  fromNewerVersion: boolean;
+}
+
+interface SettingsMigration {
+  toVersion: number;
+  name: string;
+  migrate(settings: Record<string, unknown>): void;
+}
+
+const MIGRATIONS: SettingsMigration[] = [
+  {
+    toVersion: 1,
+    name: "backfill webresourceSolutionName from solutionName",
+    migrate(settings) {
+      if (!settings.webresourceSolutionName && settings.solutionName) {
+        settings.webresourceSolutionName = settings.solutionName;
+      }
+    },
+  },
+];
+
+export function migrateSettings(raw: Record<string, unknown>): SettingsMigrationResult {
+  const settings = { ...raw };
+  const version = typeof settings.settingsVersion === "number" ? settings.settingsVersion : 0;
+  if (version > CURRENT_SETTINGS_VERSION) {
+    return { settings, applied: [], fromNewerVersion: true };
+  }
+  const applied: string[] = [];
+  for (const migration of MIGRATIONS) {
+    if (version < migration.toVersion) {
+      migration.migrate(settings);
+      applied.push(migration.name);
+    }
+  }
+  settings.settingsVersion = CURRENT_SETTINGS_VERSION;
+  return { settings, applied, fromNewerVersion: false };
+}

--- a/src/projectTypes/activation.ts
+++ b/src/projectTypes/activation.ts
@@ -164,6 +164,18 @@ export const projectTypeActivations: Record<ProjectTypes, ProjectTypeActivation>
   },
   [ProjectTypes.webresource]: {
     initialise: (context) => initialiseWebresources(context),
+    async onProjectScaffolded(context) {
+      // Output mode (#88): the webpack template reads this setting at build time.
+      const pick = await vscode.window.showQuickPick(
+        [
+          { label: "Single bundled library (recommended)", description: "one <prefix>_library.js from library.ts", target: "bundle" as const },
+          { label: "One file per web resource", description: "one <prefix>_<name>.js per webresources_src/*.ts", target: "perFile" as const },
+        ],
+        { placeHolder: "How should web resources be built?" },
+      );
+      context.projectSettings.webresourceOutput = pick?.target ?? "bundle";
+      await context.writeSettings();
+    },
     commands: {
       "dataverse-powertools.buildWebresources": tracked("Build", buildWebresources),
       "dataverse-powertools.deployWebresources": tracked("Deploy", deployWebresources),

--- a/src/ui-test/e2e/webresourceComprehensive.e2e.ts
+++ b/src/ui-test/e2e/webresourceComprehensive.e2e.ts
@@ -116,6 +116,8 @@ describe("Web resources — comprehensive UI lifecycle (e2e)", function () {
     await answerText(env!.clientSecret);
     await answerFlexible(env!.url);
     await pickByLabel(solutionFriendlyName);
+    log("output mode prompt");
+    await pickByLabel("Single bundled library (recommended)", 600000); // output mode (#88) — restores run first
     log("waiting for restore + create-webresource prompt");
     await pickByLabel("No", 600000); // "create a new webresource?" — npm restore runs first
     await sleep(4000);

--- a/src/ui-test/e2e/webresourceInteractiveLifecycle.e2e.ts
+++ b/src/ui-test/e2e/webresourceInteractiveLifecycle.e2e.ts
@@ -87,6 +87,8 @@ describe("Web resources lifecycle — interactive auth (e2e)", function () {
     await answerFlexible(env!.url, 120000);
     log(`solution (${solutionFriendlyName})`);
     await pickByLabel(solutionFriendlyName);
+    log("output mode prompt");
+    await pickByLabel("Single bundled library (recommended)", 600000); // output mode (#88) — restores run first
     log("waiting for restores + create-webresource prompt");
     await pickByLabel("No", 600000);
     await sleep(4000);

--- a/src/ui-test/e2e/webresourceLifecycle.e2e.ts
+++ b/src/ui-test/e2e/webresourceLifecycle.e2e.ts
@@ -82,6 +82,8 @@ describe("Web resources lifecycle (e2e)", function () {
     await answerFlexible(env!.url);
     log(`solution (${solutionFriendlyName})`);
     await pickByLabel(solutionFriendlyName);
+    log("output mode prompt");
+    await pickByLabel("Single bundled library (recommended)", 600000); // output mode (#88) — restores run first
     log("waiting for restores + create-webresource prompt");
     await pickByLabel("No", 600000); // "create a new webresource?" — restores + typings run first
     await sleep(4000);

--- a/src/webresources/createWebresourceClass.ts
+++ b/src/webresources/createWebresourceClass.ts
@@ -25,9 +25,16 @@ export async function createWebResourceClass(context: DataversePowerToolsContext
     notificationId: randomUUID(),
   });
   await createTemplatedFile(context, "class", outputs.className ?? "", placeholders);
-  var library = (await vscode.workspace.fs.readFile(vscode.Uri.file(path.join(vscode.workspace.workspaceFolders[0].uri.fsPath, "webresources_src", "library.ts")))).toString();
-  library = library.trim() + ('\nexport * from "./' + outputs.className + '";\n');
-  await vscode.workspace.fs.writeFile(vscode.Uri.file(path.join(vscode.workspace.workspaceFolders[0].uri.fsPath, "webresources_src", "library.ts")), Buffer.from(library, "utf8"));
+  // In perFile output mode (#88) every source file is its own entry — the
+  // library.ts re-export barrel only exists for the bundled mode.
+  if (context.projectSettings.webresourceOutput !== "perFile") {
+    var library = (await vscode.workspace.fs.readFile(vscode.Uri.file(path.join(vscode.workspace.workspaceFolders[0].uri.fsPath, "webresources_src", "library.ts")))).toString();
+    library = library.trim() + ('\nexport * from "./' + outputs.className + '";\n');
+    await vscode.workspace.fs.writeFile(
+      vscode.Uri.file(path.join(vscode.workspace.workspaceFolders[0].uri.fsPath, "webresources_src", "library.ts")),
+      Buffer.from(library, "utf8"),
+    );
+  }
 
   const testsPlaceholders = [{ placeholder: "ClassName", value: outputs.className ?? "" }] as TemplatePlaceholder[];
   await createTemplatedFile(context, "sample.test", (outputs.className ?? "") + ".test", testsPlaceholders);

--- a/templates/webresources/webpack.common.js/1.js
+++ b/templates/webresources/webpack.common.js/1.js
@@ -2,9 +2,29 @@
 /* eslint-disable @typescript-eslint/no-var-requires */
 const Webpack = require("webpack");
 const Path = require("path");
+const Fs = require("fs");
+
+// Output mode (#88): "bundle" (default) emits one SOLUTIONPREFIX_library.js from
+// library.ts; "perFile" emits one SOLUTIONPREFIX_<name>.js per top-level
+// webresources_src/*.ts (excluding library.ts, lib/ and __tests__), each merging
+// its exports onto the SOLUTIONPREFIX global so form calls stay PREFIX.Class.Fn.
+const settings = (() => {
+  try {
+    return JSON.parse(Fs.readFileSync(Path.resolve(__dirname, "dataverse-powertools.json"), "utf8"));
+  } catch {
+    return {};
+  }
+})();
+const perFile = settings.webresourceOutput === "perFile";
+const perFileEntries = () =>
+  Object.fromEntries(
+    Fs.readdirSync(Path.resolve(__dirname, "webresources_src"))
+      .filter((f) => f.endsWith(".ts") && !f.endsWith(".d.ts") && f !== "library.ts")
+      .map((f) => [f.replace(/\.ts$/, ""), "./webresources_src/" + f]),
+  );
 
 module.exports = {
-  entry: "./webresources_src/library.ts",
+  entry: perFile ? perFileEntries() : "./webresources_src/library.ts",
   module: {
     rules: [
       {
@@ -29,11 +49,18 @@ module.exports = {
   resolve: {
     extensions: [".tsx", ".ts", ".js"],
   },
-  output: {
-    filename: "SOLUTIONPREFIX_library.js",
-    library: ["SOLUTIONPREFIX"], //used to call functions on forms eg: LIBRARYPREFIX.Class.Function
-    libraryTarget: "var",
-  },
+  output: perFile
+    ? {
+        filename: "SOLUTIONPREFIX_[name].js",
+        // assign-properties merges each file's exports onto the SOLUTIONPREFIX
+        // global, so forms still call SOLUTIONPREFIX.Class.Function.
+        library: { name: "SOLUTIONPREFIX", type: "assign-properties" },
+      }
+    : {
+        filename: "SOLUTIONPREFIX_library.js",
+        library: ["SOLUTIONPREFIX"], //used to call functions on forms eg: LIBRARYPREFIX.Class.Function
+        libraryTarget: "var",
+      },
   plugins: [
     new Webpack.ProvidePlugin({
       XrmQuery: [Path.resolve(__dirname, "./webresources_src/lib/dg.xrmquery.web.min"), "XrmQuery"],


### PR DESCRIPTION
Closes #88.

- **#88**: `webresourceOutput: bundle | perFile` chosen at project creation; per-file emits one `<prefix>_<name>.js` per source via a glob-driven webpack entry map + `assign-properties` (forms keep calling `PREFIX.Class.Fn`); Create Class skips the library.ts barrel in perFile mode; deploy already handles bin/**. Limitation noted: local debug interception targets the bundled library.
- **#71 core**: explicit integer `settingsVersion` + central ordered idempotent migration runner applied by readSettings and component discovery; newer-version files detected + warned. Legacy plugin (<3) auto-upgrade deliberately out of scope — remains tracked on #71 (issue left open for that).

Verification: 233 unit tests / lint / compile / integration green; core e2e **12/12 green** (webresource, plugin, webresource-interactive — including the new output-mode wizard step). Comprehensive step-8 env flake remains tracked in #106.

Published as a **pre-release**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)