### PR TITLE
0.8.4 (pre-release) — drag-and-drop project reorder + grouping (#118)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to the "dataverse-powertools" extension will be documented in this file.
 
+## 0.8.4 (pre-release)
+
+Arrange your projects (#118).
+
+- **Drag-and-drop reordering + grouping.** In a multi-component repo, drag project cards in the Actions panel to reorder them, drop one onto a group header (or the "start a group" zone) to group related projects, and collapse groups with the caret. The arrangement (order + groups) is remembered in the connection-only root's `dataverse-powertools.json` and restored next session.
+- **Add Component is gated to a components workspace.** It appears only when the root is connection-only (Empty). A single-typed-project root instead offers **Convert to a components workspace**, which moves the project into a subfolder and leaves a connection-only root — after which you can add and arrange components.
+
 ## 0.8.3 (pre-release)
 
 Multi-component polish + build-pipeline hardening.

--- a/media/menuPanel.css
+++ b/media/menuPanel.css
@@ -443,3 +443,57 @@ a.download:hover {
   width: auto;
   white-space: nowrap;
 }
+
+/* Project drag-and-drop layout (#118) */
+.card.draggable {
+  cursor: grab;
+}
+.card.dragging {
+  opacity: 0.5;
+}
+.card.drop-before {
+  box-shadow: inset 0 2px 0 0 var(--vscode-focusBorder);
+}
+.card.drop-after {
+  box-shadow: inset 0 -2px 0 0 var(--vscode-focusBorder);
+}
+.group {
+  border: 1px solid var(--vscode-sideBarSectionHeader-border, rgba(128, 128, 128, 0.2));
+  border-radius: 8px;
+  margin: 6px 0;
+  padding: 2px;
+}
+.group.drop-into {
+  border-color: var(--vscode-focusBorder);
+}
+.group-head {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding: 4px 6px;
+  font-weight: 500;
+}
+.group-head .caret {
+  width: auto;
+  padding: 0 2px;
+}
+.group-head .group-name {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.group-body {
+  padding: 0 4px 4px;
+}
+.new-group-zone {
+  border: 1px dashed var(--vscode-sideBarSectionHeader-border, rgba(128, 128, 128, 0.35));
+  border-radius: 8px;
+  padding: 8px;
+  margin: 6px 0;
+  text-align: center;
+  color: var(--vscode-descriptionForeground);
+}
+.new-group-zone.drop-into {
+  border-color: var(--vscode-focusBorder);
+  color: var(--vscode-foreground);
+}

--- a/media/menuPanel.js
+++ b/media/menuPanel.js
@@ -208,7 +208,191 @@
       status.appendChild(el("span", null, card.status.text));
       c.appendChild(status);
     }
+    // Drag to reorder / group (#118). Only sub-component cards (dndId set) are draggable.
+    if (card.dndId) {
+      c.draggable = true;
+      c.dataset.dndid = card.dndId;
+      c.classList.add("draggable");
+      c.addEventListener("dragstart", onCardDragStart);
+      c.addEventListener("dragover", onCardDragOver);
+      c.addEventListener("dragleave", onCardDragLeave);
+      c.addEventListener("drop", onCardDrop);
+      c.addEventListener("dragend", onDragEnd);
+    }
     return c;
+  }
+
+  // --- drag-and-drop layout (#118) ---
+  let dragId = null;
+  let lastCards = [];
+
+  function deriveLayout(cards) {
+    const order = [];
+    const groups = [];
+    for (const card of cards) {
+      if (card.kind === "project" && card.dndId) {
+        order.push(card.dndId);
+      } else if (card.kind === "group") {
+        const members = card.projects.filter((p) => p.dndId).map((p) => p.dndId);
+        order.push.apply(order, members);
+        groups.push({ name: card.name, members: members, collapsed: card.collapsed });
+      }
+    }
+    return { order: order, groups: groups };
+  }
+
+  function moveCard(layout, id, targetId, after) {
+    const groups = layout.groups.map(function (g) {
+      return { name: g.name, collapsed: g.collapsed, members: g.members.filter((m) => m !== id) };
+    });
+    const targetGroup = layout.groups.find((g) => g.members.indexOf(targetId) !== -1);
+    if (targetGroup) {
+      const g = groups.find((x) => x.name === targetGroup.name);
+      const ti = g.members.indexOf(targetId);
+      g.members.splice(after ? ti + 1 : ti, 0, id);
+    }
+    const order = layout.order.filter((x) => x !== id);
+    const oi = order.indexOf(targetId);
+    order.splice(after ? oi + 1 : oi, 0, id);
+    return { order: order, groups: groups.filter((g) => g.members.length) };
+  }
+
+  function addToGroup(layout, id, groupName) {
+    const groups = layout.groups.map(function (g) {
+      return { name: g.name, collapsed: g.collapsed, members: g.members.filter((m) => m !== id) };
+    });
+    const g = groups.find((x) => x.name === groupName);
+    if (!g) {
+      return layout;
+    }
+    const order = layout.order.filter((x) => x !== id);
+    let lastIdx = -1;
+    g.members.forEach(function (m) {
+      lastIdx = Math.max(lastIdx, order.indexOf(m));
+    });
+    order.splice(lastIdx + 1, 0, id);
+    g.members.push(id);
+    return { order: order, groups: groups };
+  }
+
+  function sendLayout(layout) {
+    vscode.postMessage({ type: "updateLayout", layout: layout });
+  }
+
+  function clearDropHints() {
+    const nodes = document.querySelectorAll(".drop-before,.drop-after,.drop-into");
+    for (const n of nodes) {
+      n.classList.remove("drop-before", "drop-after", "drop-into");
+    }
+  }
+
+  function onCardDragStart(e) {
+    dragId = this.dataset.dndid;
+    e.dataTransfer.effectAllowed = "move";
+    this.classList.add("dragging");
+  }
+  function onDragEnd() {
+    dragId = null;
+    clearDropHints();
+    const dn = document.querySelector(".dragging");
+    if (dn) {
+      dn.classList.remove("dragging");
+    }
+  }
+  function onCardDragOver(e) {
+    if (!dragId || dragId === this.dataset.dndid) {
+      return;
+    }
+    e.preventDefault();
+    e.dataTransfer.dropEffect = "move";
+    const after = e.offsetY > this.offsetHeight / 2;
+    this.classList.toggle("drop-after", after);
+    this.classList.toggle("drop-before", !after);
+  }
+  function onCardDragLeave() {
+    this.classList.remove("drop-before", "drop-after");
+  }
+  function onCardDrop(e) {
+    e.preventDefault();
+    e.stopPropagation();
+    const target = this.dataset.dndid;
+    this.classList.remove("drop-before", "drop-after");
+    if (!dragId || dragId === target) {
+      return;
+    }
+    const after = e.offsetY > this.offsetHeight / 2;
+    sendLayout(moveCard(deriveLayout(lastCards), dragId, target, after));
+  }
+
+  function renderGroup(card) {
+    const c = el("section", "group");
+    c.dataset.group = card.name;
+    const head = el("div", "group-head");
+    const caret = el("button", "iconbtn caret");
+    caret.type = "button";
+    caret.textContent = card.collapsed ? "▸" : "▾";
+    caret.setAttribute("aria-label", (card.collapsed ? "Expand" : "Collapse") + " group " + card.name);
+    caret.addEventListener("click", function () {
+      const layout = deriveLayout(lastCards);
+      const g = layout.groups.find((x) => x.name === card.name);
+      if (g) {
+        g.collapsed = !g.collapsed;
+      }
+      sendLayout(layout);
+    });
+    head.appendChild(caret);
+    head.appendChild(el("span", "group-name grow-text", card.name));
+    head.appendChild(el("span", "small", card.projects.length + ""));
+    // Header is a drop target: dropping a card here adds it to the group.
+    head.addEventListener("dragover", function (e) {
+      if (dragId) {
+        e.preventDefault();
+        e.dataTransfer.dropEffect = "move";
+        c.classList.add("drop-into");
+      }
+    });
+    head.addEventListener("dragleave", function () {
+      c.classList.remove("drop-into");
+    });
+    head.addEventListener("drop", function (e) {
+      e.preventDefault();
+      e.stopPropagation();
+      c.classList.remove("drop-into");
+      if (dragId) {
+        sendLayout(addToGroup(deriveLayout(lastCards), dragId, card.name));
+      }
+    });
+    c.appendChild(head);
+    if (!card.collapsed) {
+      const body = el("div", "group-body");
+      for (const project of card.projects) {
+        body.appendChild(renderProject(project));
+      }
+      c.appendChild(body);
+    }
+    return c;
+  }
+
+  function newGroupZone() {
+    const z = el("div", "new-group-zone small", "Drag a project here to start a group");
+    z.addEventListener("dragover", function (e) {
+      if (dragId) {
+        e.preventDefault();
+        e.dataTransfer.dropEffect = "move";
+        z.classList.add("drop-into");
+      }
+    });
+    z.addEventListener("dragleave", function () {
+      z.classList.remove("drop-into");
+    });
+    z.addEventListener("drop", function (e) {
+      e.preventDefault();
+      z.classList.remove("drop-into");
+      if (dragId) {
+        vscode.postMessage({ type: "newGroupFromDrop", member: dragId });
+      }
+    });
+    return z;
   }
 
   function registrationsBlock(block) {
@@ -319,6 +503,7 @@
     ["requirements", renderRequirements],
     ["environment", renderEnvironment],
     ["project", renderProject],
+    ["group", renderGroup],
     ["session", renderSession],
     ["activity", renderActivity],
   ]);
@@ -357,13 +542,22 @@
     }
     closeOverflow();
     root.replaceChildren();
+    lastCards = message.model.cards;
+    let draggableCount = 0;
     for (const card of message.model.cards) {
+      if ((card.kind === "project" && card.dndId) || card.kind === "group") {
+        draggableCount++;
+      }
       const renderer = renderers.get(card.kind);
       if (typeof renderer === "function") {
         const node = renderer(card);
         node.dataset.cardId = card.id;
         root.appendChild(node);
       }
+    }
+    // Offer grouping once there are at least two arrangeable projects.
+    if (draggableCount >= 2) {
+      root.appendChild(newGroupZone());
     }
     root.appendChild(renderFooter(message.model.footer));
   });

--- a/media/walkthrough/tour.md
+++ b/media/walkthrough/tour.md
@@ -1,6 +1,6 @@
 # Find your way around
 
-- **Actions panel** — the Dataverse PowerTools icon in the activity bar. One card per component (a repo can hold plugins, web resources and solutions side by side — **＋ Add Component** scaffolds another into a subfolder), plus connection controls and the system-requirements check. No Command Palette needed.
+- **Actions panel** — the Dataverse PowerTools icon in the activity bar. One card per component (a repo can hold plugins, web resources and solutions side by side — **＋ Add Component** scaffolds another into a subfolder), plus connection controls and the system-requirements check. No Command Palette needed. In a multi-component repo you can **drag project cards to reorder them** and drop one onto a group (or the "start a group" zone) to organise them — the arrangement is remembered.
 - **Testing side bar** — plugin (.NET) and web-resource (Jest) tests appear in VS Code's native Test Explorer with run/debug support.
 - **Explorer right-click menu** — create plugin classes, workflow classes, web-resource classes and tests next to the file you clicked.
 - **CodeLens in C# files** — add or update plugin step registration decorations inline, or *Profile & debug…* to jump into the replay-debugging flow.

--- a/package.json
+++ b/package.json
@@ -546,6 +546,11 @@
         "enablement": "dataverse-powertools.showLoaded"
       },
       {
+        "command": "dataverse-powertools.convertToComponentsWorkspace",
+        "title": "Dataverse PowerTools: Convert to a Components Workspace",
+        "enablement": "dataverse-powertools.showLoaded"
+      },
+      {
         "command": "dataverse-powertools.viewPluginTraceLogs",
         "title": "Dataverse PowerTools: View Plugin Trace Logs",
         "enablement": "dataverse-powertools.showLoaded && dataverse-powertools.isPlugin"

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "type": "git",
     "url": "https://github.com/pete-mc/dataverse-powertools"
   },
-  "version": "0.8.3",
+  "version": "0.8.4",
   "engines": {
     "vscode": "^1.93.0"
   },

--- a/src/components/addComponent.ts
+++ b/src/components/addComponent.ts
@@ -49,7 +49,12 @@ async function offerNestedMigration(context: DataversePowerToolsContext, workspa
   if (pick.target === "keep") {
     return true;
   }
+  return performNestedMigration(context, workspaceRoot, typeName);
+}
 
+/** Move the current typed root project into a subfolder so the workspace root
+ * becomes connection-only (Empty). Returns true when the migration completed (#118). */
+export async function performNestedMigration(context: DataversePowerToolsContext, workspaceRoot: string, typeName: string): Promise<boolean> {
   const folderInput = await vscode.window.showInputBox({
     ignoreFocusOut: true,
     prompt: `Subfolder to move the existing ${typeName} project into`,
@@ -210,4 +215,29 @@ export async function addComponent(context: DataversePowerToolsContext): Promise
     },
   );
   vscode.window.showInformationMessage(`${descriptor.displayName} component added in ${folderName} (inherits the workspace connection).`);
+}
+
+/** Convert a single-typed-project workspace into a components workspace (#118): move
+ * the root project into a subfolder so the root is connection-only, then Add Component
+ * becomes available. On an already-Empty root it just points at Add Component. */
+export async function convertToComponentsWorkspace(context: DataversePowerToolsContext): Promise<void> {
+  const workspaceRoot = vscode.workspace.workspaceFolders?.[0]?.uri.fsPath;
+  if (!workspaceRoot) {
+    vscode.window.showErrorMessage("Open a workspace folder first.");
+    return;
+  }
+  if (!context.projectSettings.type) {
+    const choice = await vscode.window.showInformationMessage("This workspace is already a components workspace (connection-only root).", "Add Component");
+    if (choice === "Add Component") {
+      await addComponent(context);
+    }
+    return;
+  }
+  const typeName = getProjectTypeDescriptor(context.projectSettings.type)?.displayName ?? context.projectSettings.type;
+  if (await performNestedMigration(context, workspaceRoot, typeName)) {
+    const choice = await vscode.window.showInformationMessage(`Converted — the ${typeName} project moved to a subfolder and the root is now connection-only.`, "Add Component");
+    if (choice === "Add Component") {
+      await addComponent(context);
+    }
+  }
 }

--- a/src/components/discovery.spec.ts
+++ b/src/components/discovery.spec.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { resolveComponents, componentForPath, componentsOfType, normalizeFsPath, resolveTargetComponent, DiscoveredComponent } from "./discovery";
+import { resolveComponents, componentForPath, componentsOfType, normalizeFsPath, resolveTargetComponent, applyLayout, DiscoveredComponent } from "./discovery";
 
 const root = "C:\\repo";
 const file = (path: string, settings: object) => ({ path, content: JSON.stringify(settings) });
@@ -147,5 +147,45 @@ describe("resolveTargetComponent (#119 command target)", () => {
   it("pick candidates are exactly the components of the type", () => {
     const res = resolveTargetComponent(components, "plugin", undefined, undefined);
     expect(res.kind === "pick" && res.candidates.map((c) => c.relativeRoot)).toEqual(["pluginA", "pluginB"]);
+  });
+});
+
+describe("applyLayout (#118 sidebar arrangement)", () => {
+  const components = resolveComponents(root, [
+    file("C:\\repo\\dataverse-powertools.json", { connectionString: "cs" }),
+    file("C:\\repo\\plugins\\dataverse-powertools.json", { type: "plugin" }),
+    file("C:\\repo\\web\\dataverse-powertools.json", { type: "webresources" }),
+    file("C:\\repo\\solution\\dataverse-powertools.json", { type: "solution" }),
+  ]).components;
+  const shape = (rows: ReturnType<typeof applyLayout>) =>
+    rows.map((r) => (r.kind === "component" ? r.component.relativeRoot : `[${r.name}:${r.components.map((c) => c.relativeRoot).join(",")}${r.collapsed ? " ×" : ""}]`));
+
+  it("excludes the root and keeps discovery order with no layout", () => {
+    expect(shape(applyLayout(components, undefined))).toEqual(["plugins", "solution", "web"]);
+  });
+
+  it("orders by layout.order, appending unlisted in discovery order", () => {
+    expect(shape(applyLayout(components, { order: ["solution", "plugins"] }))).toEqual(["solution", "plugins", "web"]);
+  });
+
+  it("emits a group at its first member's position with all members nested", () => {
+    const rows = applyLayout(components, { order: ["web", "plugins", "solution"], groups: [{ name: "Backend", members: ["plugins", "solution"] }] });
+    expect(shape(rows)).toEqual(["web", "[Backend:plugins,solution]"]);
+  });
+
+  it("carries the collapsed flag and honours member order within a group", () => {
+    const rows = applyLayout(components, { order: ["solution", "plugins", "web"], groups: [{ name: "G", members: ["plugins", "solution"], collapsed: true }] });
+    expect(shape(rows)).toEqual(["[G:solution,plugins ×]", "web"]);
+  });
+
+  it("ignores stale layout entries and a member listed in two groups (first wins)", () => {
+    const rows = applyLayout(components, {
+      order: ["plugins", "gone"],
+      groups: [
+        { name: "A", members: ["plugins"] },
+        { name: "B", members: ["plugins", "web"] },
+      ],
+    });
+    expect(shape(rows)).toEqual(["[A:plugins]", "solution", "[B:web]"]);
   });
 });

--- a/src/components/discovery.ts
+++ b/src/components/discovery.ts
@@ -20,6 +20,8 @@ export interface ComponentSettings {
   solutionName?: string;
   environmentLabel?: string;
   environmentId?: string;
+  /** Sidebar arrangement (#118) — only meaningful on the root (Empty) component. */
+  layout?: Layout;
   [key: string]: unknown;
 }
 
@@ -143,6 +145,75 @@ export function componentForPath(components: DiscoveredComponent[], fsPath: stri
 /** Components of a given project type (registry id). */
 export function componentsOfType(components: DiscoveredComponent[], type: string): DiscoveredComponent[] {
   return components.filter((c) => c.settings.type === type);
+}
+
+/** User-arranged sidebar layout (#118), stored on the root (Empty) component's
+ * dataverse-powertools.json. relativeRoots identify components. */
+export interface LayoutGroup {
+  name: string;
+  members: string[];
+  collapsed?: boolean;
+}
+export interface Layout {
+  /** Display order of components, by relativeRoot. Unlisted ones append (discovery order). */
+  order?: string[];
+  /** Named groups; a component belongs to at most one (first that lists it). */
+  groups?: LayoutGroup[];
+}
+
+/** One top-level row of the arranged sidebar: a standalone item or a group. Generic
+ * over the item so it serves both DiscoveredComponent and the panel's project cards. */
+export type LayoutRow<T> = { kind: "component"; component: T } | { kind: "group"; name: string; collapsed: boolean; components: T[] };
+
+/** The minimum an item needs to be arranged: its relativeRoot id and whether it's the root. */
+export interface Arrangeable {
+  relativeRoot: string;
+  isRoot: boolean;
+}
+
+/**
+ * Arrange the non-root items into ordered top-level rows per the saved layout (#118). Pure.
+ * - Order: `layout.order` (by relativeRoot); items not listed keep their given order after the listed ones.
+ * - Groups: a group appears at the position of its first ordered member, with all its members nested (in order).
+ * - Stale layout entries (deleted components) are ignored; newly-added components simply append / stay ungrouped.
+ */
+export function applyLayout<T extends Arrangeable>(components: T[], layout: Layout | undefined): LayoutRow<T>[] {
+  const subs = components.filter((c) => !c.isRoot);
+  const order = layout?.order ?? [];
+  const orderIndex = (c: Arrangeable) => {
+    const i = order.indexOf(c.relativeRoot);
+    return i === -1 ? Number.MAX_SAFE_INTEGER : i;
+  };
+  const ordered = subs
+    .map((c, i) => ({ c, i }))
+    .sort((a, b) => orderIndex(a.c) - orderIndex(b.c) || a.i - b.i)
+    .map((x) => x.c);
+
+  const groupOf = new Map<string, string>();
+  const collapsedOf = new Map<string, boolean>();
+  for (const group of layout?.groups ?? []) {
+    if (!collapsedOf.has(group.name)) {
+      collapsedOf.set(group.name, !!group.collapsed);
+    }
+    for (const member of group.members) {
+      if (!groupOf.has(member)) {
+        groupOf.set(member, group.name);
+      }
+    }
+  }
+
+  const rows: LayoutRow<T>[] = [];
+  const emitted = new Set<string>();
+  for (const component of ordered) {
+    const groupName = groupOf.get(component.relativeRoot);
+    if (!groupName) {
+      rows.push({ kind: "component", component });
+    } else if (!emitted.has(groupName)) {
+      emitted.add(groupName);
+      rows.push({ kind: "group", name: groupName, collapsed: collapsedOf.get(groupName) ?? false, components: ordered.filter((c) => groupOf.get(c.relativeRoot) === groupName) });
+    }
+  }
+  return rows;
 }
 
 /** Outcome of resolving which component a command targets (#119). */

--- a/src/context.ts
+++ b/src/context.ts
@@ -7,7 +7,7 @@ import { workspaceFilePath } from "./general/paths";
 import { parseConnectionString, buildConnectionString, getOrganizationUrl, mergeCredentialConnectionString } from "./general/connectionString";
 import { parseAuthType, DataverseAuthType } from "./general/dataverse/authTypes";
 import { ProjectTypes } from "./projectTypes/registry";
-import type { DiscoveredComponent } from "./components/discovery";
+import type { DiscoveredComponent, Layout } from "./components/discovery";
 import { migrateSettings } from "./general/settingsMigrations";
 import { fsMigrationIo } from "./general/migrationIo";
 import path = require("path");
@@ -174,6 +174,8 @@ interface ProjectSettings {
   environmentId?: string;
   /** Revision of the type's template CONFIG FILES this project last received (#113). */
   configRevision?: number;
+  /** Sidebar arrangement of sub-components (#118) — only on the root (Empty) settings. */
+  layout?: Layout;
   solutionName?: string;
   webresourceSolutionName?: string;
   connectionString?: string;

--- a/src/general/initialiseExtension.ts
+++ b/src/general/initialiseExtension.ts
@@ -2,7 +2,7 @@ import * as vscode from "vscode";
 import DataversePowerToolsContext, { PowertoolsTemplate } from "../context";
 import { isSupportedProjectType } from "../projectTypes/registry";
 import { discoverWorkspaceComponents } from "../components/componentDiscovery";
-import { addComponent } from "../components/addComponent";
+import { addComponent, convertToComponentsWorkspace } from "../components/addComponent";
 import { createServicePrincipalString, updateConnectionString, switchEnvironment, refreshConnection } from "./connectionStringManager";
 import { openEnvironment, openAdminCenter, openMakerPortal } from "./openPortals";
 import { createNewProject } from "./generateTemplates";
@@ -37,6 +37,7 @@ export async function generalInitialise(context: DataversePowerToolsContext) {
     context.vscode.subscriptions.push(vscode.commands.registerCommand("dataverse-powertools.openMakerPortal", () => openMakerPortal(context)));
     context.vscode.subscriptions.push(vscode.commands.registerCommand("dataverse-powertools.openSettings", () => context.openSettings()));
     context.vscode.subscriptions.push(vscode.commands.registerCommand("dataverse-powertools.addComponent", () => addComponent(context)));
+    context.vscode.subscriptions.push(vscode.commands.registerCommand("dataverse-powertools.convertToComponentsWorkspace", () => convertToComponentsWorkspace(context)));
   }
 
   await vscode.commands.executeCommand("setContext", "dataverse-powertools.detectingFolderSettings", false);

--- a/src/panel/menuModel.spec.ts
+++ b/src/panel/menuModel.spec.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { buildMenuModel, PanelState, ProjectCardState, ALLOWED_EXTERNAL_URLS, environmentName, Card } from "./menuModel";
+import { buildMenuModel, PanelState, ProjectCardState, ALLOWED_EXTERNAL_URLS, environmentName, sanitizeLayout, Card } from "./menuModel";
 import { projectTypeRegistry } from "../projectTypes/registry";
 
 function project(overrides: Partial<ProjectCardState> = {}): ProjectCardState {
@@ -345,5 +345,26 @@ describe("project layout (#118)", () => {
   it("gates Add Component to Empty roots; a typed root offers convert", () => {
     expect(addCmd(buildMenuModel(multi({ rootIsEmpty: true })).cards)).toBe("dataverse-powertools.addComponent");
     expect(addCmd(buildMenuModel(multi({ rootIsEmpty: false })).cards)).toBe("dataverse-powertools.convertToComponentsWorkspace");
+  });
+});
+
+describe("sanitizeLayout (#118 untrusted webview input)", () => {
+  it("keeps well-formed order + groups", () => {
+    expect(sanitizeLayout({ order: ["a", "b"], groups: [{ name: "G", members: ["a"], collapsed: true }] })).toEqual({
+      order: ["a", "b"],
+      groups: [{ name: "G", members: ["a"], collapsed: true }],
+    });
+  });
+
+  it("drops non-strings, nameless/empty groups, and caps the name", () => {
+    const out = sanitizeLayout({ order: ["a", 3, null], groups: [{ name: "", members: ["a"] }, { name: "G", members: [] }, { name: "H", members: ["x", 5] }, 7] });
+    expect(out.order).toEqual(["a"]);
+    expect(out.groups).toEqual([{ name: "H", members: ["x"], collapsed: false }]);
+  });
+
+  it("tolerates junk", () => {
+    expect(sanitizeLayout(undefined)).toEqual({ order: [], groups: [] });
+    expect(sanitizeLayout("nope")).toEqual({ order: [], groups: [] });
+    expect(sanitizeLayout({ order: "x" }).order).toEqual([]);
   });
 });

--- a/src/panel/menuModel.spec.ts
+++ b/src/panel/menuModel.spec.ts
@@ -312,3 +312,38 @@ describe("registry menu self-parity", () => {
     }
   });
 });
+
+describe("project layout (#118)", () => {
+  const multi = (over: Partial<PanelState> = {}) =>
+    state({
+      projects: [
+        project({ type: "plugin", relativeRoot: "plugins", root: "c:/repo/plugins", isRoot: false }),
+        project({ type: "webresources", relativeRoot: "web", root: "c:/repo/web", isRoot: false }),
+        project({ type: "solution", relativeRoot: "sol", root: "c:/repo/sol", isRoot: false }),
+      ],
+      rootIsEmpty: true,
+      ...over,
+    });
+  const projectDnd = (cards: ReturnType<typeof buildMenuModel>["cards"]) => cards.filter((c) => c.kind === "project").map((c) => (c as { dndId: string }).dndId);
+  const addCmd = (cards: ReturnType<typeof buildMenuModel>["cards"]) =>
+    (cards.find((c) => c.kind === "actions" && c.id === "addComponent") as { actions: { command: string }[] }).actions[0].command;
+
+  it("orders sub-project cards by layout.order (unlisted append)", () => {
+    expect(projectDnd(buildMenuModel(multi({ layout: { order: ["web", "sol"] } })).cards)).toEqual(["web", "sol", "plugins"]);
+  });
+
+  it("emits a collapsible group card holding its member project cards", () => {
+    const cards = buildMenuModel(multi({ layout: { order: ["web", "plugins", "sol"], groups: [{ name: "Backend", members: ["plugins", "sol"], collapsed: true }] } })).cards;
+    const group = cards.find((c) => c.kind === "group") as { name: string; collapsed: boolean; projects: { dndId: string }[] };
+    expect(group.name).toBe("Backend");
+    expect(group.collapsed).toBe(true);
+    expect(group.projects.map((p) => p.dndId)).toEqual(["plugins", "sol"]);
+    // The grouped members are not also emitted as top-level project cards.
+    expect(projectDnd(cards)).toEqual(["web"]);
+  });
+
+  it("gates Add Component to Empty roots; a typed root offers convert", () => {
+    expect(addCmd(buildMenuModel(multi({ rootIsEmpty: true })).cards)).toBe("dataverse-powertools.addComponent");
+    expect(addCmd(buildMenuModel(multi({ rootIsEmpty: false })).cards)).toBe("dataverse-powertools.convertToComponentsWorkspace");
+  });
+});

--- a/src/panel/menuModel.ts
+++ b/src/panel/menuModel.ts
@@ -188,6 +188,24 @@ export const HELP_LINKS: readonly { label: string; url: string }[] = [
 /** URLs the webview is allowed to ask the host to open. */
 export const ALLOWED_EXTERNAL_URLS: readonly string[] = [...Object.values(DOWNLOAD_URLS), ...HELP_LINKS.map((l) => l.url)];
 
+/** Validate a layout arriving from the webview (untrusted) into a well-formed shape (#118).
+ * Keeps only string ids, caps group names, drops empty/nameless groups. Pure. */
+export function sanitizeLayout(raw: unknown): Layout {
+  const obj = (raw ?? {}) as { order?: unknown; groups?: unknown };
+  const order = Array.isArray(obj.order) ? obj.order.filter((x): x is string => typeof x === "string") : [];
+  const groups = Array.isArray(obj.groups)
+    ? obj.groups
+        .filter((g): g is { name: unknown; members: unknown; collapsed?: unknown } => !!g && typeof g === "object")
+        .map((g) => ({
+          name: typeof g.name === "string" ? g.name.slice(0, 60) : "",
+          members: Array.isArray(g.members) ? g.members.filter((m): m is string => typeof m === "string") : [],
+          collapsed: !!g.collapsed,
+        }))
+        .filter((g) => g.name && g.members.length)
+    : [];
+  return { order, groups };
+}
+
 /** Short environment name from the org URL: https://contoso.crm.dynamics.com -> contoso. */
 export function environmentName(organizationUrl: string | undefined): string {
   if (!organizationUrl) {

--- a/src/panel/menuModel.ts
+++ b/src/panel/menuModel.ts
@@ -7,7 +7,7 @@
 // each a card; actions hang off the object they belong to; rare actions live
 // in a per-card ⋯ overflow; requirements collapse to a footer line once green.
 import { MenuAction, ProjectMenuState, getProjectTypeDescriptor } from "../projectTypes/registry";
-import { normalizeFsPath } from "../components/discovery";
+import { normalizeFsPath, applyLayout, Layout } from "../components/discovery";
 
 export interface RequirementRow {
   id: "dotnet" | "node" | "pac";
@@ -91,6 +91,8 @@ export type Card =
       name: string;
       typeLabel: string;
       detail?: string;
+      /** relativeRoot — the drag id for reordering/grouping (#118); "" for the root card (not draggable). */
+      dndId: string;
       primary: MenuAction;
       secondary: MenuAction[];
       overflow: MenuAction[];
@@ -100,6 +102,8 @@ export type Card =
       /** Plugin cards embed a profiler/debugging block, right under the buttons (#63). */
       debugging?: DebuggingBlock;
     }
+  /** A user-defined group of project cards (#118), collapsible, a drop target. */
+  | { kind: "group"; id: string; name: string; collapsed: boolean; projects: Card[] }
   | { kind: "session"; id: "session"; text: string; detail?: string; stop: MenuAction }
   | { kind: "activity"; id: "activity"; items: ActivityItem[] };
 
@@ -160,6 +164,10 @@ export interface PanelState {
     node: boolean;
     pac: boolean;
   };
+  /** User-arranged sidebar layout from the root settings (#118). */
+  layout?: Layout;
+  /** The root is connection-only (Empty) — Add Component is offered only then (#118). */
+  rootIsEmpty?: boolean;
 }
 
 /** Full walkthrough reference: <publisher>.<extension>#<walkthrough id in package.json>. */
@@ -322,37 +330,51 @@ export function buildMenuModel(state: PanelState): MenuModel {
     });
   }
 
-  for (const project of state.projects) {
+  const buildProjectCard = (project: ProjectCardState): Card => {
     const descriptor = getProjectTypeDescriptor(project.type);
     if (!descriptor) {
-      cards.push({
+      return {
         kind: "notice",
         id: `unsupported:${project.relativeRoot || "root"}`,
         text: `Project type "${project.type}"${project.relativeRoot ? ` (${project.relativeRoot})` : ""} is not supported by this version of the extension.`,
-      });
-      continue;
+      };
     }
     const menu = descriptor.menu(project);
     const isWebresource = descriptor.id === "webresources";
-    const isPlugin = descriptor.id === "plugin";
-    cards.push({
+    if (isWebresource) {
+      hasWebresourceCard = true;
+    }
+    return {
       kind: "project",
       id: `project:${descriptor.id}${project.isRoot ? "" : `:${project.relativeRoot}`}`,
       name: project.name || descriptor.displayName,
       typeLabel: descriptor.displayName.toUpperCase(),
       detail: project.isRoot ? project.detail : [project.relativeRoot, project.detail].filter(Boolean).join(" · "),
+      dndId: project.isRoot ? "" : project.relativeRoot,
       primary: forComponent({ ...menu.primary, label: menu.primary.label.replace("{environment}", environment) }, project),
       secondary: menu.secondary.map((action) => forComponent(action, project)),
       overflow: [...menu.overflow, { command: "dataverse-powertools.restoreDependencies", label: "Restore dependencies" }].map((action) => forComponent(action, project)),
       status: statusFromActivity(state.activity, project),
-      // Each web-resource card carries its OWN registrations (multiple
-      // components of the type each get theirs), right under the buttons.
+      // Each web-resource card carries its OWN registrations (multiple components each).
       registrations: isWebresource ? registrationsFor(state, project) : undefined,
       // Plugin cards carry the profiler/debugging workflow (#63).
-      debugging: isPlugin ? debuggingFor(project) : undefined,
-    });
-    if (isWebresource) {
-      hasWebresourceCard = true;
+      debugging: descriptor.id === "plugin" ? debuggingFor(project) : undefined,
+    };
+  };
+
+  // Root/typed-root cards stay pinned above the arranged sub-components (#118). Sub
+  // components are ordered + grouped per the saved layout.
+  for (const project of state.projects.filter((p) => p.isRoot)) {
+    cards.push(buildProjectCard(project));
+  }
+  for (const row of applyLayout(
+    state.projects.filter((p) => !p.isRoot),
+    state.layout,
+  )) {
+    if (row.kind === "component") {
+      cards.push(buildProjectCard(row.component));
+    } else {
+      cards.push({ kind: "group", id: `group:${row.name}`, name: row.name, collapsed: row.collapsed, projects: row.components.map(buildProjectCard) });
     }
   }
 
@@ -366,11 +388,16 @@ export function buildMenuModel(state: PanelState): MenuModel {
     });
   }
 
-  // A workspace becomes multi-component by adding one — no upfront mono choice.
+  // Add Component only when the root is connection-only (Empty). A typed root offers
+  // an explicit convert-to-components-workspace step first (#118).
   cards.push({
     kind: "actions",
     id: "addComponent",
-    actions: [{ command: "dataverse-powertools.addComponent", label: "＋ Add Component…" }],
+    actions: [
+      state.rootIsEmpty === false
+        ? { command: "dataverse-powertools.convertToComponentsWorkspace", label: "Convert to a components workspace…" }
+        : { command: "dataverse-powertools.addComponent", label: "＋ Add Component…" },
+    ],
   });
 
   if (state.activity.length > 0) {

--- a/src/panel/menuPanel.ts
+++ b/src/panel/menuPanel.ts
@@ -1,6 +1,7 @@
 import * as vscode from "vscode";
 import DataversePowerToolsContext from "../context";
-import { buildMenuModel, ALLOWED_EXTERNAL_URLS } from "./menuModel";
+import { buildMenuModel, ALLOWED_EXTERNAL_URLS, sanitizeLayout } from "./menuModel";
+import { Layout } from "../components/discovery";
 import { computePanelState } from "./panelState";
 import { projectTypeRegistry } from "../projectTypes/registry";
 import { onDebugSessionChanged } from "../webresources/debug/debugWebresources";
@@ -11,6 +12,7 @@ import { openScannedRegistration } from "./registrationsScanner";
 const GENERAL_PANEL_COMMANDS = [
   "dataverse-powertools.initialiseProject",
   "dataverse-powertools.addComponent",
+  "dataverse-powertools.convertToComponentsWorkspace",
   "dataverse-powertools.restoreDependencies",
   "dataverse-powertools.refreshConnection",
   "dataverse-powertools.updateConnectionString",
@@ -67,7 +69,7 @@ export class MenuPanelViewProvider implements vscode.WebviewViewProvider {
     void this.view.webview.postMessage({ type: "model", model: buildMenuModel(computePanelState(this.context)) });
   }
 
-  private async onMessage(message: { type?: string; command?: string; args?: unknown[]; url?: string; index?: number }): Promise<void> {
+  private async onMessage(message: { type?: string; command?: string; args?: unknown[]; url?: string; index?: number; layout?: unknown; member?: unknown }): Promise<void> {
     switch (message?.type) {
       case "ready":
         this.refresh();
@@ -94,7 +96,33 @@ export class MenuPanelViewProvider implements vscode.WebviewViewProvider {
           await vscode.env.openExternal(vscode.Uri.parse(message.url));
         }
         break;
+      case "updateLayout":
+        // Re-arranged in the webview (#118): persist the sanitised layout on the root settings.
+        await this.saveLayout(sanitizeLayout(message.layout));
+        break;
+      case "newGroupFromDrop": {
+        if (typeof message.member !== "string") {
+          break;
+        }
+        const member = message.member;
+        const name = (await vscode.window.showInputBox({ prompt: "Name for the new group", ignoreFocusOut: true }))?.trim();
+        if (!name) {
+          break;
+        }
+        const current = sanitizeLayout(this.context.projectSettings.layout);
+        const groups = (current.groups ?? []).map((group) => ({ ...group, members: group.members.filter((m) => m !== member) })).filter((group) => group.members.length);
+        groups.push({ name: name.slice(0, 60), members: [member] });
+        await this.saveLayout({ order: current.order, groups });
+        break;
+      }
     }
+  }
+
+  /** Persist the sidebar layout on the root settings and re-render (#118). */
+  private async saveLayout(layout: Layout): Promise<void> {
+    this.context.projectSettings.layout = layout;
+    await this.context.writeSettings();
+    this.refresh();
   }
 
   private renderHtml(webview: vscode.Webview): string {

--- a/src/panel/panelState.ts
+++ b/src/panel/panelState.ts
@@ -99,5 +99,9 @@ export function computePanelState(context: DataversePowerToolsContext): PanelSta
     })),
     activity: activityItems(),
     requirements: getSystemRequirementsStatus(),
+    // Sidebar arrangement + Add-Component gating (#118): the root's own layout, and
+    // whether the root is connection-only (Empty) vs a typed single-project root.
+    layout: (settings.layout as PanelState["layout"]) ?? undefined,
+    rootIsEmpty: loaded ? !settings.type : undefined,
   };
 }


### PR DESCRIPTION
Closes #118 — arrange projects in the Actions panel.

## What
- **Reorder + group** project cards by drag-and-drop in a multi-component repo. Drop a card onto another to reorder (respecting its group), onto a group header to add it, or onto a "start a group" zone to create one; a caret collapses groups. The arrangement (`layout: { order, groups }`) is persisted on the connection-only root's `dataverse-powertools.json` and restored next session.
- **Add Component gated to a components workspace** — it shows only when the root is Empty. A typed root instead offers **Convert to a components workspace** (`performNestedMigration`: moves the project into a subfolder, root becomes connection-only), after which Add Component + arranging are available.

## How (pure-first, per the repo pattern)
- `applyLayout(components, layout)` (generic, pure, unit-tested) → ordered rows of standalone components or groups; the menu model renders group cards with nested project cards; each card carries its `dndId` (relativeRoot).
- Webview computes the new layout on each gesture and posts it; the host `sanitizeLayout`s it (pure, unit-tested — validates untrusted input) and `writeSettings` + re-renders.
- `Layout` added to settings; new `convertToComponentsWorkspace` command (registered + package.json + panel allowlist).

## Verification
- `npm run lint` clean, `npm run compile` green, **336 unit tests** (applyLayout, sanitizeLayout, order/group rendering, gating), integration green.
- Full `npm run test:e2e` — **38 passing (28m)** on the VM (regression smoke with the new panel; the lone log-audit flag is a false positive — a `dotnet restore` that took *404 ms*).

Webview drag-and-drop interaction is inherently hard to assert in Selenium; the layout math is covered by unit tests and the full UI suite confirms the panel renders + persists.