### PR TITLE
0.8.5 (pre-release) — multi-component robustness fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 All notable changes to the "dataverse-powertools" extension will be documented in this file.
 
+## 0.8.5 (pre-release)
+
+Multi-component robustness — fixes for repos with two components of the same type.
+
+- **Create Webresource Class works in a subfolder component (and honours the "create test?" answer).** In a multi-component repo, **New class** threw `ENOENT` on `library.ts` — it looked at the workspace root instead of the web-resource component, so the class file was created but the barrel export and the test were not. It now resolves against the active component, and only writes the test when you ask for one.
+- **Adding a Web Resources component to a blank root substitutes the publisher prefix.** `webpack.common.js` kept the literal `SOLUTIONPREFIX` token instead of your prefix, so the built library was misnamed. The new component now carries the inherited prefix at scaffold time.
+- **A second component of the same type no longer errors.** Adding a second web-resource or plugin component used to fail at the end of **Add Component** with *"duplicate controller with ID"* / *"command … already exists"* (the component was scaffolded, but the command reported an error): the Test Explorer controller collided on a hardcoded id and the plugin decoration commands re-registered. Controllers are now scoped per component, and those commands register once.
+- **Component settings stay inheritance-clean.** Running a settings-writing command (e.g. **Switch Output Mode**) on a subfolder component no longer bakes the root's connection into that component's `dataverse-powertools.json` — which would have made it self-contained and stopped it tracking the root's connection changes.
+- Covered by a new headless monorepo test and an extended blank-root e2e that adds **two of every component type** and verifies command targeting; the full e2e suite (43 tests, both auth types) is green.
+
 ## 0.8.4 (pre-release)
 
 Arrange your projects (#118).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -74,6 +74,15 @@ whatever else has focus. Key facts:
   tree-kills its watcher on stop; the comprehensive suite reaps stragglers in `before`. In a
   very long session, background full-e2e runs can get killed ~10 min in — run subsets or start
   fresh. Never kill the user's own VS Code (`AppData\Local\Programs\Microsoft VS Code`).
+- **Authoring UI e2e steps — two traps that cost a run each:** (1) Gate each step on the command's
+  FINAL signal (its last log line, e.g. `[Components] N components discovered`), NOT an intermediate
+  artifact like an npm/paket lockfile — those are written mid-command, so the test proceeds while the
+  command is still running and the *next* command overlaps it (interleaved output, a busy UI). (2)
+  Select quick-pick items by keyboard (type-to-filter + Enter via `answerText`), not a coordinate
+  click — closing all editors reveals the empty-editor watermark whose `<p>` hints sit over the
+  quick-pick rows and intercept clicks (`ElementClickInterceptedError`). Also: file-existence asserts
+  pass even when a command errored *after* scaffolding, so assert no "resulted in an error"
+  notification too.
 
 ## Traps specific to this repo
 
@@ -91,6 +100,27 @@ whatever else has focus. Key facts:
   access token authorizes the call, not the tenant. This class of bug shipped three times
   (#91 typings, #90/register form events under interactive). The e2e's `*InteractiveLifecycle`
   suites exist to catch it — if you touch a Dataverse path, they must stay green.
+- **A per-type `initialise*` runs ONCE PER COMPONENT — never register global singletons there.**
+  With multi-component workspaces (#47), two components of the *same type* both run that type's
+  `initialise*`. Anything registered there with a fixed identity collides on the second one:
+  a `vscode.tests.createTestController(id, …)` throws "duplicate controller with ID", a
+  `registerCommand(id, …)` throws "command … already exists". Fixes: TestController ids are
+  scoped per component (`scopedTestControllerId` + a dispose-on-reinit registry, in
+  [pluginTestController.ts](src/plugins/pluginTestController.ts)/[webresourceTestController.ts](src/webresources/webresourceTestController.ts));
+  commands and CodeLens providers register ONCE globally in [extension.ts](src/extension.ts) /
+  `registerAllComponentCommands` — never in an `initialise*`. **Both of these shipped in 0.8.4**
+  and were caught by the two-of-each e2e (below), not by any unit test.
+- **A scoped component's `writeSettings()` must not persist INHERITED fields.** Discovery
+  ([resolveComponents](src/components/discovery.ts)) merges the root's connection/tenant/prefix/env
+  into each subfolder component's in-memory settings for a complete view. `writeSettings` strips
+  `activeComponent.inheritedFields` before writing so they aren't baked into the component's file —
+  otherwise the component gains its own `connectionString`, which makes `resolveComponents` treat it
+  as self-contained and it STOPS tracking the root's connection changes. Any command that writes a
+  subfolder component's settings (e.g. Switch Output Mode) hits this path.
+- **Two components of the same type is a distinct test surface.** The three bugs above are invisible
+  to unit tests and to a one-of-each e2e — the [blankRootComponents](src/ui-test/e2e/blankRootComponents.e2e.ts)
+  suite now adds TWO of every type and asserts targeting + no error notification. Keep it green when
+  touching any per-type `initialise*`, discovery, or `runForComponent`.
 - **Build/tests run the project's LOCAL bins via `npx`, never a bare `webpack`/`jest`.** The
   template installs webpack/jest/ts-loader as devDependencies; a bare `webpack` only resolves a
   *global* install and fails ("'webpack' is not recognized") where there isn't one. See
@@ -145,10 +175,13 @@ modern plugin flow already shells out to `dotnet`/`pac`.
 ## Test Explorer (native Testing API, #84)
 
 Plugin (.NET) and web-resource (Jest) tests surface in VS Code's Testing side bar via a
-`TestController` created per project type in the feature `initialise*`
+`TestController` created per COMPONENT in the feature `initialise*`
 ([src/plugins/pluginTestController.ts](src/plugins/pluginTestController.ts),
 [src/webresources/webresourceTestController.ts](src/webresources/webresourceTestController.ts)),
-disposed through `context.subscriptions`. The result/discovery **parsers are pure and
+disposed through `context.subscriptions`. The controller id is scoped per component
+(`scopedTestControllerId`) so two same-type components don't collide on a duplicate id (see the
+multi-component trap above), and a per-id registry disposes the stale controller on re-discovery.
+The result/discovery **parsers are pure and
 unit-tested** — `parseTrx`, `parseDotnetListTests` (plugins), `parseJestJson` (web resources);
 keep parsing logic there, not in the controllers. Plugins run `dotnet test --logger trx`
 (+ `--filter`); web resources run the local `npx jest --json --testLocationInResults`.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "dataverse-powertools",
-  "version": "0.7.4",
+  "version": "0.8.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "dataverse-powertools",
-      "version": "0.7.4",
+      "version": "0.8.5",
       "hasInstallScript": true,
       "dependencies": {
         "@azure/msal-node": "^5.4.0",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "type": "git",
     "url": "https://github.com/pete-mc/dataverse-powertools"
   },
-  "version": "0.8.4",
+  "version": "0.8.5",
   "engines": {
     "vscode": "^1.93.0"
   },

--- a/src/components/addComponent.ts
+++ b/src/components/addComponent.ts
@@ -164,13 +164,18 @@ export async function addComponent(context: DataversePowerToolsContext): Promise
   const componentRoot = path.join(workspaceRoot, folderName);
   await fs.promises.mkdir(componentRoot, { recursive: true });
 
-  // The component's own settings: type + template version only — everything
-  // else (connection, prefix, environment label) is inherited from the root.
+  // The component's own settings. The connection stays inherited from the root
+  // (never written here), but the publisher PREFIX is carried so template
+  // generation can substitute SOLUTIONPREFIX now — the same prefix gets baked into
+  // the component's webpack.common.js, so it belongs with the component (and
+  // discovery would inherit the same value anyway). Fixes SOLUTIONPREFIX not being
+  // replaced when adding a web-resource component to a blank root.
   const componentSettings: DiscoveredComponent["settings"] = {
     type: descriptor.id,
     templateversion: descriptor.defaultTemplateVersion,
     configRevision: descriptor.configRevision,
     solutionName: context.projectSettings.solutionName,
+    prefix: context.projectSettings.prefix,
   };
   const component: DiscoveredComponent = {
     root: normalizeFsPath(componentRoot),

--- a/src/components/discovery.spec.ts
+++ b/src/components/discovery.spec.ts
@@ -1,5 +1,14 @@
 import { describe, it, expect } from "vitest";
-import { resolveComponents, componentForPath, componentsOfType, normalizeFsPath, resolveTargetComponent, applyLayout, DiscoveredComponent } from "./discovery";
+import {
+  resolveComponents,
+  componentForPath,
+  componentsOfType,
+  normalizeFsPath,
+  resolveTargetComponent,
+  applyLayout,
+  scopedTestControllerId,
+  DiscoveredComponent,
+} from "./discovery";
 
 const root = "C:\\repo";
 const file = (path: string, settings: object) => ({ path, content: JSON.stringify(settings) });
@@ -147,6 +156,32 @@ describe("resolveTargetComponent (#119 command target)", () => {
   it("pick candidates are exactly the components of the type", () => {
     const res = resolveTargetComponent(components, "plugin", undefined, undefined);
     expect(res.kind === "pick" && res.candidates.map((c) => c.relativeRoot)).toEqual(["pluginA", "pluginB"]);
+  });
+});
+
+describe("scopedTestControllerId (#84/#47 duplicate-controller guard)", () => {
+  const components = resolveComponents(root, [
+    file("C:\\repo\\dataverse-powertools.json", { connectionString: "cs" }),
+    file("C:\\repo\\web\\dataverse-powertools.json", { type: "webresources" }),
+    file("C:\\repo\\web2\\dataverse-powertools.json", { type: "webresources" }),
+  ]).components;
+
+  it("gives two same-type components DISTINCT ids (no VS Code duplicate-controller crash)", () => {
+    const [a, b] = componentsOfType(components, "webresources");
+    const idA = scopedTestControllerId("dataverse-powertools.webresourceTests", a.root, a.isRoot);
+    const idB = scopedTestControllerId("dataverse-powertools.webresourceTests", b.root, b.isRoot);
+    expect(idA).not.toEqual(idB);
+    expect(idA).toBe("dataverse-powertools.webresourceTests::c:/repo/web");
+    expect(idB).toBe("dataverse-powertools.webresourceTests::c:/repo/web2");
+  });
+
+  it("keeps the bare id for the root component (single-project behaviour unchanged)", () => {
+    expect(scopedTestControllerId("dataverse-powertools.pluginTests", "C:\\repo", true)).toBe("dataverse-powertools.pluginTests");
+    expect(scopedTestControllerId("dataverse-powertools.pluginTests", undefined, false)).toBe("dataverse-powertools.pluginTests");
+  });
+
+  it("is stable across re-inits of the same component (same root → same id)", () => {
+    expect(scopedTestControllerId("x", "C:\\repo\\web", false)).toBe(scopedTestControllerId("x", "c:/repo/web/", false));
   });
 });
 

--- a/src/components/discovery.spec.ts
+++ b/src/components/discovery.spec.ts
@@ -45,10 +45,14 @@ describe("resolveComponents", () => {
     expect(inherited.settings.tenantId).toBe("t-1");
     expect(inherited.settings.prefix).toBe("ctso");
     expect(inherited.settings.environmentLabel).toBe("DEV");
-    // Self-contained component keeps its own values untouched.
+    // The inherited fields are recorded so writeSettings can strip them (not bake them
+    // into the component's file, which would make it self-contained — #47).
+    expect(inherited.inheritedFields).toEqual(["connectionString", "tenantId", "prefix", "environmentLabel"]);
+    // Self-contained component keeps its own values untouched and inherits nothing.
     const selfContained = components.find((c) => c.relativeRoot === "other")!;
     expect(selfContained.settings.connectionString).toBe("own-cs");
     expect(selfContained.settings.prefix).toBe("own");
+    expect(selfContained.inheritedFields).toBeUndefined();
   });
 
   it("reports malformed settings files without dropping the rest", () => {

--- a/src/components/discovery.ts
+++ b/src/components/discovery.ts
@@ -147,6 +147,16 @@ export function componentsOfType(components: DiscoveredComponent[], type: string
   return components.filter((c) => c.settings.type === type);
 }
 
+/** A VS Code TestController id scoped to one component (#84/#47). VS Code throws
+ * "duplicate controller with ID" if two controllers share an id, so a base id like
+ * `dataverse-powertools.webresourceTests` must be suffixed with the component root when
+ * a workspace has TWO components of the same type. The root component keeps the bare id
+ * (byte-identical single-project behaviour). Normalised so the same component maps to the
+ * same id across re-inits. */
+export function scopedTestControllerId(baseId: string, componentRoot: string | undefined, isRoot: boolean): string {
+  return !componentRoot || isRoot ? baseId : `${baseId}::${normalizeFsPath(componentRoot)}`;
+}
+
 /** User-arranged sidebar layout (#118), stored on the root (Empty) component's
  * dataverse-powertools.json. relativeRoots identify components. */
 export interface LayoutGroup {

--- a/src/components/discovery.ts
+++ b/src/components/discovery.ts
@@ -33,6 +33,11 @@ export interface DiscoveredComponent {
   /** True for the workspace-root component (today's single-project layout). */
   isRoot: boolean;
   settings: ComponentSettings;
+  /** Fields whose value was inherited from the root at discovery (not present in this
+   * component's own file). They're merged into `settings` for a complete in-memory view,
+   * but must NOT be persisted back — writeSettings strips them so the component keeps
+   * inheriting the root's connection/tenant/env instead of baking in a stale copy (#47). */
+  inheritedFields?: string[];
 }
 
 export interface DiscoveryResult {
@@ -110,10 +115,15 @@ export function resolveComponents(
       if (component.isRoot || component.settings.connectionString) {
         continue;
       }
+      const inherited: string[] = [];
       for (const field of INHERITED_FIELDS) {
         if (component.settings[field] === undefined && rootComponent.settings[field] !== undefined) {
           component.settings[field] = rootComponent.settings[field];
+          inherited.push(field);
         }
+      }
+      if (inherited.length > 0) {
+        component.inheritedFields = inherited;
       }
     }
   }

--- a/src/components/monorepoLifecycle.spec.ts
+++ b/src/components/monorepoLifecycle.spec.ts
@@ -1,0 +1,232 @@
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import * as fs from "fs";
+import * as os from "os";
+import * as path from "path";
+import { resolveComponents, resolveTargetComponent, componentsOfType, DiscoveredComponent, normalizeFsPath } from "./discovery";
+
+// Monorepo lifecycle (#47/#119): a connection-only root with TWO components of EVERY
+// type in subfolders, scaffolded from the REAL templates. Proves the two things that
+// matter for a multi-component workspace, headlessly and deterministically (no VS Code,
+// no network, no Selenium): (1) commands resolve to the RIGHT component, and (2) each
+// component's template is set up correctly (per-type marker files present, placeholders
+// substituted, connection inherited not duplicated). The plugin v3 pac-init layer and the
+// full build/deploy round-trip are UI-covered by the blank-root e2e; here we exercise the
+// pure copy+substitute engine (identical across versions) plus the type-agnostic resolver.
+
+const TEMPLATES = path.resolve(__dirname, "..", "..", "templates");
+const PREFIX = "mono";
+const SOLUTION = "MonoSolution";
+const CONNECTION = "AuthType=ClientSecret;Url=https://mono.crm.dynamics.com;ClientId=id;ClientSecret=secret";
+const TENANT = "tenant-guid";
+
+// type → { templateFolder, version to scaffold, per-type marker files }. Plugin uses the
+// file-complete v1 template (v3's csproj comes from `pac plugin init`, e2e-covered); the
+// copy+substitute path it exercises is the same one v3 runs for its own files.
+interface TypeSpec {
+  type: string;
+  folder: string;
+  version: number;
+  markers: string[];
+}
+const TYPES: TypeSpec[] = [
+  { type: "plugin", folder: "plugin", version: 1, markers: ["Plugin.sln", "plugins_src/plugins_src.csproj", "plugins_src/spkl.json"] },
+  { type: "webresources", folder: "webresources", version: 1, markers: ["webpack.common.js", "webresources_src/library.ts", "tsconfig.build.json"] },
+  { type: "solution", folder: "solution", version: 2, markers: ["paket.dependencies", "nuget.config", ".gitignore"] },
+  { type: "portal", folder: "portal", version: 1, markers: ["tsconfig.json", "build/portalpublish.cmd", "paket.dependencies"] },
+];
+
+/** Mirror generateTemplates' copy+substitute: skip scaffold:false (on-demand Create-*
+ * templates), rename .tstemplate → .ts, substitute SOLUTIONPREFIX/SOLUTIONPLACEHOLDER and
+ * any declared placeholders so no raw token survives into a real project. */
+function scaffold(destDir: string, spec: TypeSpec): void {
+  const template = JSON.parse(fs.readFileSync(path.join(TEMPLATES, spec.folder, "template.json"), "utf8")).find((t: any) => t.version === spec.version);
+  for (const f of template.files ?? []) {
+    if (f.scaffold === false) {
+      continue;
+    }
+    const ext = f.extension === ".tstemplate" ? ".ts" : f.extension;
+    let data = fs.readFileSync(path.join(TEMPLATES, spec.folder, f.filename + f.extension, f.version + f.extension), "utf8");
+    data = data.replace(/SOLUTIONPREFIX/g, PREFIX).replace(/SOLUTIONPLACEHOLDER/g, SOLUTION);
+    for (const p of template.placeholders ?? []) {
+      if (p.placeholder === "SOLUTIONPREFIX" || p.placeholder === "SOLUTIONPLACEHOLDER") {
+        continue;
+      }
+      data = data.replace(new RegExp(p.placeholder, "g"), p.placeholder.toLowerCase());
+    }
+    const dest = path.join(destDir, ...(f.path ?? []), f.filename + ext);
+    fs.mkdirSync(path.dirname(dest), { recursive: true });
+    fs.writeFileSync(dest, data, "utf8");
+  }
+}
+
+/** Every text file under a folder (templates are all text; no node_modules here). */
+function walkFiles(dir: string): string[] {
+  const out: string[] = [];
+  for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+    const full = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      out.push(...walkFiles(full));
+    } else {
+      out.push(full);
+    }
+  }
+  return out;
+}
+
+describe("monorepo: two of every component type (#47/#119)", () => {
+  let workspace = "";
+  let components: DiscoveredComponent[] = [];
+  // relativeRoot per (type, instance) e.g. instances["plugin"] = ["plugin-a", "plugin-b"].
+  const instances: Record<string, string[]> = {};
+
+  beforeAll(() => {
+    workspace = fs.mkdtempSync(path.join(os.tmpdir(), "dvpt_mono_"));
+    // Connection-only root (Empty): the connection + companions live here; components inherit.
+    fs.writeFileSync(
+      path.join(workspace, "dataverse-powertools.json"),
+      JSON.stringify({ connectionString: CONNECTION, prefix: PREFIX, tenantId: TENANT, environmentLabel: "DEV", solutionName: SOLUTION }, null, 2),
+    );
+
+    for (const spec of TYPES) {
+      instances[spec.type] = [];
+      for (const suffix of ["a", "b"]) {
+        const rel = `${spec.folder}-${suffix}`;
+        instances[spec.type].push(rel);
+        const root = path.join(workspace, rel);
+        fs.mkdirSync(root, { recursive: true });
+        scaffold(root, spec);
+        // Component settings exactly as addComponent writes them post-fix: own type +
+        // carried prefix (so template substitution ran), NO connectionString (inherits).
+        fs.writeFileSync(
+          path.join(root, "dataverse-powertools.json"),
+          JSON.stringify({ type: spec.type, templateversion: spec.version, prefix: PREFIX, solutionName: SOLUTION }, null, 2),
+        );
+      }
+    }
+
+    // Discover exactly as the extension does: read every settings file off disk, resolve.
+    const settingsFiles = walkFiles(workspace)
+      .filter((f) => path.basename(f) === "dataverse-powertools.json")
+      .map((f) => ({ path: f, content: fs.readFileSync(f, "utf8") }));
+    components = resolveComponents(workspace, settingsFiles).components;
+  });
+
+  afterAll(() => {
+    if (workspace && !process.env.DVPT_KEEP_PROJECT) {
+      fs.rmSync(workspace, { recursive: true, force: true });
+    }
+  });
+
+  const componentOf = (rel: string) => components.find((c) => c.relativeRoot === rel) as DiscoveredComponent;
+  const resolvedRel = (res: ReturnType<typeof resolveTargetComponent>) => (res.kind === "resolved" ? res.component.relativeRoot : res.kind);
+
+  it("discovers the root plus two components of every type (9 total)", () => {
+    expect(components).toHaveLength(1 + TYPES.length * 2);
+    const roots = components.filter((c) => c.isRoot);
+    expect(roots).toHaveLength(1);
+    expect(roots[0].relativeRoot).toBe("");
+    for (const spec of TYPES) {
+      expect(componentsOfType(components, spec.type).map((c) => c.relativeRoot)).toEqual(instances[spec.type]);
+    }
+  });
+
+  it("every component inherits the root connection and companions, and sets none of its own", () => {
+    for (const spec of TYPES) {
+      for (const rel of instances[spec.type]) {
+        const settingsOnDisk = JSON.parse(fs.readFileSync(path.join(workspace, rel, "dataverse-powertools.json"), "utf8"));
+        expect(settingsOnDisk.connectionString, `${rel} keeps no own connection`).toBeUndefined();
+        const resolved = componentOf(rel);
+        expect(resolved.settings.type, `${rel} type`).toBe(spec.type);
+        expect(resolved.settings.connectionString, `${rel} inherits connection`).toBe(CONNECTION);
+        expect(resolved.settings.tenantId, `${rel} inherits tenant`).toBe(TENANT);
+        expect(resolved.settings.environmentLabel, `${rel} inherits env label`).toBe("DEV");
+      }
+    }
+  });
+
+  // ---- Commands target the right component (#119 resolveTargetComponent ladder) ----
+  describe("command targeting", () => {
+    for (const spec of TYPES) {
+      it(`${spec.type}: disambiguates the two components by hint / active editor / picker`, () => {
+        const [a, b] = instances[spec.type];
+        const compA = componentOf(a);
+        const compB = componentOf(b);
+
+        // No hint, no active editor → ask, with exactly the two components of this type.
+        const noContext = resolveTargetComponent(components, spec.type, undefined, undefined);
+        expect(noContext.kind).toBe("pick");
+        expect(noContext.kind === "pick" && noContext.candidates.map((c) => c.relativeRoot)).toEqual([a, b]);
+
+        // Panel-card hint = a component root → that exact component.
+        expect(resolvedRel(resolveTargetComponent(components, spec.type, compA.root, undefined))).toBe(a);
+
+        // Explorer/CodeLens hint = a real scaffolded file inside B → B.
+        const fileInB = path.join(compB.root, spec.markers[0]);
+        expect(resolvedRel(resolveTargetComponent(components, spec.type, fileInB, undefined))).toBe(b);
+
+        // Active editor inside B, no hint → B (not A).
+        expect(resolvedRel(resolveTargetComponent(components, spec.type, undefined, fileInB))).toBe(b);
+      });
+    }
+
+    it("does not leak targeting across types (a plugin file never resolves a webresources command)", () => {
+      const pluginFile = path.join(componentOf(instances["plugin"][0]).root, "Plugin.sln");
+      // Active editor is a plugin file; command is webresources with two candidates → still ask.
+      const res = resolveTargetComponent(components, "webresources", undefined, pluginFile);
+      expect(res.kind).toBe("pick");
+      expect(res.kind === "pick" && res.candidates.map((c) => c.relativeRoot)).toEqual(instances["webresources"]);
+    });
+
+    it("a wrong-type explicit hint suppresses active-editor inference (user pointed elsewhere)", () => {
+      const webFile = path.join(componentOf(instances["webresources"][0]).root, "webpack.common.js");
+      const pluginActive = path.join(componentOf(instances["plugin"][1]).root, "Plugin.sln");
+      // hint = a webresources file, command = plugin, active editor = plugin-b: the explicit
+      // (wrong-type) hint blocks inference, so it asks among the plugins rather than picking plugin-b.
+      expect(resolveTargetComponent(components, "plugin", webFile, pluginActive).kind).toBe("pick");
+    });
+  });
+
+  // ---- Each component template is set up correctly ----
+  describe("template setup", () => {
+    for (const spec of TYPES) {
+      for (const suffix of [0, 1]) {
+        it(`${spec.type} #${suffix + 1}: scaffolds its marker files with no leftover template tokens`, () => {
+          const root = path.join(workspace, instances[spec.type][suffix]);
+          for (const marker of spec.markers) {
+            expect(fs.existsSync(path.join(root, marker)), `${instances[spec.type][suffix]}/${marker} scaffolded`).toBe(true);
+          }
+          // No raw SOLUTIONPREFIX/SOLUTIONPLACEHOLDER (or other placeholder) survived substitution.
+          for (const file of walkFiles(root)) {
+            if (path.basename(file) === "dataverse-powertools.json") {
+              continue;
+            }
+            const text = fs.readFileSync(file, "utf8");
+            expect(text.includes("SOLUTIONPREFIX"), `${file} has no raw SOLUTIONPREFIX`).toBe(false);
+            expect(text.includes("SOLUTIONPLACEHOLDER"), `${file} has no raw SOLUTIONPLACEHOLDER`).toBe(false);
+          }
+        });
+      }
+    }
+
+    it("web resources: webpack output uses the real prefix and library.ts is the buildable stub", () => {
+      for (const rel of instances["webresources"]) {
+        const root = path.join(workspace, rel);
+        const webpackCommon = fs.readFileSync(path.join(root, "webpack.common.js"), "utf8");
+        expect(webpackCommon, `${rel} webpack uses ${PREFIX}_library.js`).toContain(`${PREFIX}_library.js`);
+        const library = fs.readFileSync(path.join(root, "webresources_src", "library.ts"), "utf8");
+        expect(library.includes('export * from "./account"'), `${rel} library.ts is not the demo barrel`).toBe(false);
+        // scaffold:false on-demand templates must NOT be scaffolded into the project.
+        expect(fs.existsSync(path.join(root, "webresources_src", "class.ts")), `${rel} has no stray class.ts`).toBe(false);
+        expect(fs.existsSync(path.join(root, "webresources_src", "__tests__")), `${rel} has no scaffolded __tests__`).toBe(false);
+      }
+    });
+
+    it("plugins: each carries its own project scaffold (sln + csproj) independently", () => {
+      for (const rel of instances["plugin"]) {
+        const root = path.join(workspace, rel);
+        expect(fs.existsSync(path.join(root, "Plugin.sln")), `${rel} sln`).toBe(true);
+        expect(fs.existsSync(path.join(root, "plugins_src", "plugins_src.csproj")), `${rel} csproj`).toBe(true);
+      }
+    });
+  });
+});

--- a/src/context.ts
+++ b/src/context.ts
@@ -88,6 +88,13 @@ export default class DataversePowerToolsContext {
     if (filePath !== undefined) {
       let toWrite = JSON.parse(JSON.stringify(this.projectSettings));
       delete toWrite.pluginModelBuilder;
+      // A subfolder component must not PERSIST fields it only inherited from the root
+      // (connection, tenant, env). Discovery merges them into its in-memory settings for a
+      // complete view, but writing them back would make the component self-contained — it
+      // would then stop tracking the root's connection changes (#47).
+      for (const field of this.activeComponent?.inheritedFields ?? []) {
+        delete toWrite[field];
+      }
       if (typeof toWrite.connectionString === "string" && toWrite.connectionString.length > 0) {
         // Persist only the non-secret base; client id/secret live in secret storage.
         const parts = parseConnectionString(toWrite.connectionString);

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -9,6 +9,7 @@ import { componentsOfType } from "./components/discovery";
 import { clearStoredCredentials } from "./general/connectionStringManager";
 import { checkConfigRevision } from "./general/configRefresh";
 import { registerProfilerCodeLens } from "./plugins/profilerCodeLens";
+import { registerDecorationCodeLens } from "./plugins/decorationsCodeLens";
 import { registerMenuPanel } from "./panel/menuPanel";
 import { registerSystemRequirementCommands } from "./general/systemRequirements";
 import { initInteractiveTokenCache } from "./general/dataverse/tokenAcquisition";
@@ -29,6 +30,10 @@ export async function activate(vscodeContext: vscode.ExtensionContext) {
   registerAllComponentCommands(context);
   // Profiler toggle CodeLens on [CrmPluginRegistration] classes (#112).
   registerProfilerCodeLens(context);
+  // Class-decoration / filtering-attribute CodeLens on plugin .cs files. Registered
+  // ONCE here (its commands + provider are global) — never per plugin component, or a
+  // second plugin component's initialise throws "command … already exists" (#47).
+  registerDecorationCodeLens(context);
   await vscode.commands.executeCommand("setContext", "dataverse-powertools.folderStateReady", false);
   await vscode.commands.executeCommand("setContext", "dataverse-powertools.detectingFolderSettings", true);
   await vscode.commands.executeCommand("setContext", "dataverse-powertools.hasSupportedProjectType", true);

--- a/src/plugins/initialisePlugins.ts
+++ b/src/plugins/initialisePlugins.ts
@@ -1,19 +1,19 @@
 import DataversePowerToolsContext from "../context";
 import * as vscode from "vscode";
 import { loadPluginModelBuilderSettings, updatePluginModelBuilderSettingsContext } from "../general/modelbuilder";
-import { registerDecorationCodeLens } from "./decorationsCodeLens";
 import { createPluginTestController } from "./pluginTestController";
 
 // Per-type setup for plugin (v3) components: context keys, model-builder
-// settings, CodeLens, test controller. Commands register once globally in
-// projectTypes/activation.ts (#47) — never here.
+// settings, test controller. Commands and the decoration CodeLens register ONCE
+// globally in extension.ts / projectTypes/activation.ts (#47) — never here, or a
+// second plugin component's initialise re-registers and VS Code throws
+// "command … already exists".
 export async function initialisePlugins(context: DataversePowerToolsContext): Promise<void> {
   vscode.commands.executeCommand("setContext", "dataverse-powertools.isPlugin", true);
   vscode.commands.executeCommand("setContext", "dataverse-powertools.isPluginV3", true);
   await vscode.commands.executeCommand("setContext", "dataverse-powertools.hasPluginUnitTesting", !!context.projectSettings.pluginUnitTestingEnabled);
   await loadPluginModelBuilderSettings(context);
   void updatePluginModelBuilderSettingsContext(context);
-  registerDecorationCodeLens(context);
   // Surface the plugin's .NET tests in the native Test Explorer (#84).
   createPluginTestController(context);
 }

--- a/src/plugins/pluginTestController.ts
+++ b/src/plugins/pluginTestController.ts
@@ -8,6 +8,11 @@ import { resolveTestProjectPath } from "./unitTesting";
 import { parseDotnetListTests } from "./parseDotnetListTests";
 import { parseTrx, TrxTestResult } from "./parseTrx";
 import { activeComponentRoot } from "../components/componentDiscovery";
+import { scopedTestControllerId } from "../components/discovery";
+
+// One controller per component, keyed by its unique id — re-initialising the same
+// component (re-discovery) disposes the stale controller instead of colliding on the id.
+const controllersById = new Map<string, vscode.TestController>();
 
 // Test Explorer integration for a plugin project's .NET tests (#84). Discovers tests via
 // `dotnet test --list-tests`, runs them via `dotnet test --logger trx` and parses the TRX for live
@@ -195,7 +200,14 @@ async function runHandler(
 }
 
 export function createPluginTestController(context: DataversePowerToolsContext): vscode.TestController {
-  const controller = vscode.tests.createTestController("dataverse-powertools.pluginTests", "Plugin Tests (.NET)");
+  // Scope the controller id to the component so two plugin components don't collide
+  // ("Attempt to insert a duplicate controller with ID …", #47). Label by folder so the
+  // user can tell each component's tests apart in the Test Explorer.
+  const id = scopedTestControllerId("dataverse-powertools.pluginTests", activeComponentRoot(context), !context.activeComponent);
+  controllersById.get(id)?.dispose();
+  const rel = context.activeComponent?.relativeRoot;
+  const controller = vscode.tests.createTestController(id, rel ? `Plugin Tests (.NET) — ${rel}` : "Plugin Tests (.NET)");
+  controllersById.set(id, controller);
   controller.resolveHandler = async (item) => {
     if (!item) {
       await discover(context, controller);
@@ -207,6 +219,13 @@ export function createPluginTestController(context: DataversePowerToolsContext):
   controller.createRunProfile("Run", vscode.TestRunProfileKind.Run, (request, token) => void runHandler(context, controller, request, token, false), true);
   controller.createRunProfile("Debug", vscode.TestRunProfileKind.Debug, (request, token) => void runHandler(context, controller, request, token, true), false);
   void discover(context, controller);
-  context.vscode.subscriptions.push(controller);
+  context.vscode.subscriptions.push({
+    dispose: () => {
+      controller.dispose();
+      if (controllersById.get(id) === controller) {
+        controllersById.delete(id);
+      }
+    },
+  });
   return controller;
 }

--- a/src/ui-test/e2e/blankRootComponents.e2e.ts
+++ b/src/ui-test/e2e/blankRootComponents.e2e.ts
@@ -128,6 +128,12 @@ describe("Blank root + one component of each type (e2e)", function () {
     const settings = readSettings("webresources");
     expect(settings.type).to.equal("webresources");
     expect(settings.connectionString, "component inherits the root connection — no own connectionString").to.equal(undefined);
+    // Template substitution must run at Add-Component time (the component carries the
+    // inherited prefix): webpack.common.js has the real prefix, not the literal token.
+    const webpackCommon = fs.readFileSync(path.join(workspace, "webresources", "webpack.common.js"), "utf8");
+    expect(webpackCommon, "SOLUTIONPREFIX token substituted").to.not.contain("SOLUTIONPREFIX");
+    expect(settings.prefix, "component carries the inherited publisher prefix").to.be.a("string").and.not.equal("");
+    expect(webpackCommon, "webpack.common.js uses the real prefix").to.contain(`${settings.prefix}_library.js`);
   });
 
   it("adds a Plugins component into a subfolder (pac init + restore)", async () => {

--- a/src/ui-test/e2e/blankRootComponents.e2e.ts
+++ b/src/ui-test/e2e/blankRootComponents.e2e.ts
@@ -12,6 +12,7 @@ import {
   runCommand,
   runCommandResilient,
   waitForFile,
+  waitForOutput,
   dismissOverlays,
   sleep,
   E2EClient,
@@ -53,6 +54,18 @@ describe("Blank root + two components of each type (e2e)", function () {
       }
       await sleep(2000);
     }
+  }
+
+  /** Gate on the Add Component command FULLY completing. Its last step logs
+   * "[Components] N components discovered"; without waiting for it the test returns
+   * as soon as the npm/paket lockfile appears (mid-add), so mocha starts the NEXT
+   * add while this one is still restoring + discovering — the two scaffolds then
+   * overlap (doubled restore/discovery output). `count` = components after this add
+   * (the connection-only root + every component added so far). */
+  async function waitForAddComplete(count: number): Promise<void> {
+    const seen = await waitForOutput(`${count} components discovered`, 180000);
+    expect(seen, `Add Component finished (discovery logged ${count} components)`).to.not.equal(undefined);
+    await sleep(3000); // let the post-discovery tail (initialise + panel refresh) settle
   }
 
   /** Read visible notification text from the DOM. Must run BEFORE dismissOverlays (which
@@ -198,6 +211,7 @@ describe("Blank root + two components of each type (e2e)", function () {
     expect(webpackCommon, "SOLUTIONPREFIX token substituted").to.not.contain("SOLUTIONPREFIX");
     expect(settings.prefix, "component carries the inherited publisher prefix").to.be.a("string").and.not.equal("");
     expect(webpackCommon, "webpack.common.js uses the real prefix").to.contain(`${settings.prefix}_library.js`);
+    await waitForAddComplete(2); // root + webresources — don't let the next add overlap
   });
 
   it("adds a SECOND Web Resources component into a distinct subfolder", async () => {
@@ -212,6 +226,7 @@ describe("Blank root + two components of each type (e2e)", function () {
     const webpackCommon = fs.readFileSync(path.join(workspace, "webresources2", "webpack.common.js"), "utf8");
     expect(webpackCommon, "SOLUTIONPREFIX substituted in the second component too").to.not.contain("SOLUTIONPREFIX");
     expect(webpackCommon).to.contain(`${settings.prefix}_library.js`);
+    await waitForAddComplete(3); // root + webresources + webresources2
     // The second web-resource component's Test Explorer controller must get a distinct id —
     // a duplicate id makes Add Component throw "duplicate controller with ID" (#47).
     await assertCommandDidNotError("second Web Resources add");
@@ -247,6 +262,7 @@ describe("Blank root + two components of each type (e2e)", function () {
     expect(settings.type).to.equal("plugin");
     expect(settings.pluginProjectName).to.equal("E2EBlankPlugin");
     expect(settings.connectionString).to.equal(undefined);
+    await waitForAddComplete(4); // root + 2 webresources + plugin
   });
 
   it("adds a SECOND Plugins component into a distinct subfolder (own project scaffold)", async () => {
@@ -261,6 +277,7 @@ describe("Blank root + two components of each type (e2e)", function () {
     expect(settings.type).to.equal("plugin");
     expect(settings.pluginProjectName, "second plugin keeps its own project name").to.equal("E2EBlankPlugin2");
     expect(settings.connectionString).to.equal(undefined);
+    await waitForAddComplete(5); // root + 2 webresources + 2 plugins
     // Same duplicate-controller guard for the plugin Test Explorer controller (#47).
     await assertCommandDidNotError("second Plugins add");
   });
@@ -276,6 +293,7 @@ describe("Blank root + two components of each type (e2e)", function () {
     expect(settings.type).to.equal("solution");
     expect(settings.templateversion, "integer template version (1.1 float retired, #71)").to.equal(2);
     expect(settings.connectionString).to.equal(undefined);
+    await waitForAddComplete(6); // root + 2 webresources + 2 plugins + solution
   });
 
   it("adds a SECOND Solution component into a distinct subfolder", async () => {
@@ -287,6 +305,7 @@ describe("Blank root + two components of each type (e2e)", function () {
     const settings = readSettings("solution2");
     expect(settings.type).to.equal("solution");
     expect(settings.connectionString).to.equal(undefined);
+    await waitForAddComplete(7); // root + 2 webresources + 2 plugins + 2 solutions
   });
 
   it("adds a Portal component into a subfolder", async () => {
@@ -296,6 +315,7 @@ describe("Blank root + two components of each type (e2e)", function () {
     const settings = readSettings("portal");
     expect(settings.type).to.equal("portal");
     expect(settings.connectionString).to.equal(undefined);
+    await waitForAddComplete(8); // root + 2 webresources + 2 plugins + 2 solutions + portal
   });
 
   it("adds a SECOND Portal component into a distinct subfolder", async () => {
@@ -305,6 +325,7 @@ describe("Blank root + two components of each type (e2e)", function () {
     const settings = readSettings("portal2");
     expect(settings.type).to.equal("portal");
     expect(settings.connectionString).to.equal(undefined);
+    await waitForAddComplete(9); // root + two of every type
   });
 
   it("root stays a typeless connection-only file after all additions", async () => {

--- a/src/ui-test/e2e/blankRootComponents.e2e.ts
+++ b/src/ui-test/e2e/blankRootComponents.e2e.ts
@@ -8,7 +8,6 @@ import {
   answerText,
   answerFlexible,
   pickByLabel,
-  pickExactLabel,
   runCommand,
   runCommandResilient,
   waitForFile,
@@ -237,12 +236,13 @@ describe("Blank root + two components of each type (e2e)", function () {
     // ask which one; picking webresources2 scopes Switch Output Mode's settings write to it
     // alone — the first component's settings must be untouched. This is the UI-level #119 proof.
     await closeAllEditors();
-    // Clear any lingering "component added" toast — it can intercept the quick-pick click.
     await dismissOverlays();
     await runCommandResilient("Dataverse PowerTools: Switch Web Resource Output Mode");
-    await pickExactLabel("webresources2", 30000); // the "Which component?" picker
-    await dismissOverlays(); // drop toasts before the second pick (they overlap the list)
-    await pickByLabel("One file per web resource", 30000); // the mode picker
+    // Select by keyboard (type-to-filter + Enter), NOT a coordinate click: closing all
+    // editors reveals the empty-editor watermark, whose keybinding-hint <p> elements sit
+    // over the quick-pick rows and intercept clicks (ElementClickInterceptedError).
+    await answerText("webresources2"); // the "Which component?" picker → filters to the one, Enter selects
+    await answerText("One file per web resource"); // the mode picker
     expect(await waitForSettings("webresources2", (s) => s.webresourceOutput === "perFile", 30000), "webresources2 switched to perFile").to.equal(true);
     expect(readSettings("webresources").webresourceOutput, "the FIRST component's output mode is untouched").to.not.equal("perFile");
   });

--- a/src/ui-test/e2e/blankRootComponents.e2e.ts
+++ b/src/ui-test/e2e/blankRootComponents.e2e.ts
@@ -42,6 +42,25 @@ describe("Blank root + two components of each type (e2e)", function () {
     }
   }
 
+  /** Read visible notification text from the DOM. Must run BEFORE dismissOverlays (which
+   * wipes toasts) so a command-error notification can be asserted. A command that throws
+   * shows "Command '…' resulted in an error" — e.g. the duplicate-TestController crash a
+   * second same-type component used to trigger (#47). */
+  async function assertCommandDidNotError(context: string): Promise<void> {
+    await sleep(6000); // let the command settle so any error notification has surfaced
+    let text = "";
+    try {
+      text = String(
+        (await VSBrowser.instance.driver.executeScript(
+          "return Array.from(document.querySelectorAll('.notification-list-item-message, .notification-toast, .monaco-dialog-box')).map(function(e){return e.textContent || '';}).join(' ||| ');",
+        )) ?? "",
+      );
+    } catch {
+      /* no notifications surface readable */
+    }
+    expect(/resulted in an error/i.test(text), `${context}: a command surfaced an error notification — "${text.slice(0, 300)}"`).to.equal(false);
+  }
+
   /** Clear the active editor so runForComponent falls to its picker (not active-editor inference). */
   async function closeAllEditors(): Promise<void> {
     try {
@@ -180,6 +199,9 @@ describe("Blank root + two components of each type (e2e)", function () {
     const webpackCommon = fs.readFileSync(path.join(workspace, "webresources2", "webpack.common.js"), "utf8");
     expect(webpackCommon, "SOLUTIONPREFIX substituted in the second component too").to.not.contain("SOLUTIONPREFIX");
     expect(webpackCommon).to.contain(`${settings.prefix}_library.js`);
+    // The second web-resource component's Test Explorer controller must get a distinct id —
+    // a duplicate id makes Add Component throw "duplicate controller with ID" (#47).
+    await assertCommandDidNotError("second Web Resources add");
   });
 
   it("a webresources command targets the component the user picks (two present) and scopes its write", async () => {
@@ -223,6 +245,8 @@ describe("Blank root + two components of each type (e2e)", function () {
     expect(settings.type).to.equal("plugin");
     expect(settings.pluginProjectName, "second plugin keeps its own project name").to.equal("E2EBlankPlugin2");
     expect(settings.connectionString).to.equal(undefined);
+    // Same duplicate-controller guard for the plugin Test Explorer controller (#47).
+    await assertCommandDidNotError("second Plugins add");
   });
 
   it("adds a Solution component into a subfolder", async () => {

--- a/src/ui-test/e2e/blankRootComponents.e2e.ts
+++ b/src/ui-test/e2e/blankRootComponents.e2e.ts
@@ -2,7 +2,20 @@ import * as path from "path";
 import * as fs from "fs";
 import { expect } from "chai";
 import { VSBrowser } from "vscode-extension-tester";
-import { loadE2EEnv, freshWorkspace, answerText, answerFlexible, pickByLabel, pickExactLabel, runCommand, waitForFile, dismissOverlays, sleep, E2EClient } from "./lib";
+import {
+  loadE2EEnv,
+  freshWorkspace,
+  answerText,
+  answerFlexible,
+  pickByLabel,
+  pickExactLabel,
+  runCommand,
+  runCommandResilient,
+  waitForFile,
+  dismissOverlays,
+  sleep,
+  E2EClient,
+} from "./lib";
 import { resetAllCredentials } from "./lib";
 
 // End-to-end for the BLANK (connection-only) root + Add Component (user request):
@@ -209,8 +222,11 @@ describe("Blank root + two components of each type (e2e)", function () {
     // ask which one; picking webresources2 scopes Switch Output Mode's settings write to it
     // alone — the first component's settings must be untouched. This is the UI-level #119 proof.
     await closeAllEditors();
-    await runCommand("Dataverse PowerTools: Switch Web Resource Output Mode");
+    // Clear any lingering "component added" toast — it can intercept the quick-pick click.
+    await dismissOverlays();
+    await runCommandResilient("Dataverse PowerTools: Switch Web Resource Output Mode");
     await pickExactLabel("webresources2", 30000); // the "Which component?" picker
+    await dismissOverlays(); // drop toasts before the second pick (they overlap the list)
     await pickByLabel("One file per web resource", 30000); // the mode picker
     expect(await waitForSettings("webresources2", (s) => s.webresourceOutput === "perFile", 30000), "webresources2 switched to perFile").to.equal(true);
     expect(readSettings("webresources").webresourceOutput, "the FIRST component's output mode is untouched").to.not.equal("perFile");

--- a/src/ui-test/e2e/blankRootComponents.e2e.ts
+++ b/src/ui-test/e2e/blankRootComponents.e2e.ts
@@ -2,16 +2,19 @@ import * as path from "path";
 import * as fs from "fs";
 import { expect } from "chai";
 import { VSBrowser } from "vscode-extension-tester";
-import { loadE2EEnv, freshWorkspace, answerText, answerFlexible, pickByLabel, runCommand, waitForFile, dismissOverlays, sleep, E2EClient } from "./lib";
+import { loadE2EEnv, freshWorkspace, answerText, answerFlexible, pickByLabel, pickExactLabel, runCommand, waitForFile, dismissOverlays, sleep, E2EClient } from "./lib";
 import { resetAllCredentials } from "./lib";
 
 // End-to-end for the BLANK (connection-only) root + Add Component (user request):
-// initialise an "Empty (components in subfolders)" workspace, then add one
-// component of EVERY other type into subfolders. Each component's settings file
+// initialise an "Empty (components in subfolders)" workspace, then add TWO
+// components of EVERY other type into subfolders. Each component's settings file
 // must carry its type but NO connection (it inherits the root's); the root file
 // must stay typeless with the connection. Scaffold + restore per type is proven
 // by a marker file (plugin's is the pac-init csproj, so its restore path runs).
-describe("Blank root + one component of each type (e2e)", function () {
+// With two web-resource components present, a webresources command must target
+// the ONE the user picks (runForComponent's picker) and scope its write to it —
+// the UI-level proof of #119 command targeting the headless monorepo spec models.
+describe("Blank root + two components of each type (e2e)", function () {
   this.timeout(1500000);
   const env = loadE2EEnv();
   let workspace: string;
@@ -19,6 +22,35 @@ describe("Blank root + one component of each type (e2e)", function () {
 
   function readSettings(relative: string): any {
     return JSON.parse(fs.readFileSync(path.join(workspace, relative, "dataverse-powertools.json"), "utf8"));
+  }
+
+  /** Poll a component's settings until a predicate holds (a command's write landed). */
+  async function waitForSettings(relative: string, predicate: (settings: any) => boolean, timeoutMs: number): Promise<boolean> {
+    const deadline = Date.now() + timeoutMs;
+    for (;;) {
+      try {
+        if (predicate(readSettings(relative))) {
+          return true;
+        }
+      } catch {
+        /* file mid-write — retry */
+      }
+      if (Date.now() > deadline) {
+        return false;
+      }
+      await sleep(2000);
+    }
+  }
+
+  /** Clear the active editor so runForComponent falls to its picker (not active-editor inference). */
+  async function closeAllEditors(): Promise<void> {
+    try {
+      await runCommand("View: Close All Editors");
+    } catch {
+      /* nothing open */
+    }
+    await sleep(1000);
+    await dismissOverlays();
   }
 
   /** Poll for any file matching a predicate under a folder (recursive). */
@@ -136,6 +168,32 @@ describe("Blank root + one component of each type (e2e)", function () {
     expect(webpackCommon, "webpack.common.js uses the real prefix").to.contain(`${settings.prefix}_library.js`);
   });
 
+  it("adds a SECOND Web Resources component into a distinct subfolder", async () => {
+    await startAddComponent("Web Resources");
+    await answerText("webresources2"); // a second web-resource component alongside the first
+    expect(await waitForFile(path.join(workspace, "webresources2", "dataverse-powertools.json"), 600000), "webresources2 settings").to.equal(true);
+    expect(await waitForFile(path.join(workspace, "webresources2", "webpack.common.js"), 60000), "webresources2 scaffold").to.equal(true);
+    expect(await waitForFile(path.join(workspace, "webresources2", "node_modules", ".package-lock.json"), 600000), "npm install finished").to.equal(true);
+    const settings = readSettings("webresources2");
+    expect(settings.type).to.equal("webresources");
+    expect(settings.connectionString, "second component also inherits the root connection").to.equal(undefined);
+    const webpackCommon = fs.readFileSync(path.join(workspace, "webresources2", "webpack.common.js"), "utf8");
+    expect(webpackCommon, "SOLUTIONPREFIX substituted in the second component too").to.not.contain("SOLUTIONPREFIX");
+    expect(webpackCommon).to.contain(`${settings.prefix}_library.js`);
+  });
+
+  it("a webresources command targets the component the user picks (two present) and scopes its write", async () => {
+    // Two web-resource components now exist. With no active editor, runForComponent must
+    // ask which one; picking webresources2 scopes Switch Output Mode's settings write to it
+    // alone — the first component's settings must be untouched. This is the UI-level #119 proof.
+    await closeAllEditors();
+    await runCommand("Dataverse PowerTools: Switch Web Resource Output Mode");
+    await pickExactLabel("webresources2", 30000); // the "Which component?" picker
+    await pickByLabel("One file per web resource", 30000); // the mode picker
+    expect(await waitForSettings("webresources2", (s) => s.webresourceOutput === "perFile", 30000), "webresources2 switched to perFile").to.equal(true);
+    expect(readSettings("webresources").webresourceOutput, "the FIRST component's output mode is untouched").to.not.equal("perFile");
+  });
+
   it("adds a Plugins component into a subfolder (pac init + restore)", async () => {
     await startAddComponent("Plugins");
     await answerText("plugin"); // subfolder
@@ -153,6 +211,20 @@ describe("Blank root + one component of each type (e2e)", function () {
     expect(settings.connectionString).to.equal(undefined);
   });
 
+  it("adds a SECOND Plugins component into a distinct subfolder (own project scaffold)", async () => {
+    await startAddComponent("Plugins");
+    await answerText("plugin2"); // second plugin component alongside the first
+    await answerText("E2EBlankPlugin2"); // distinct plugin project name
+    expect(await waitForFile(path.join(workspace, "plugin2", "dataverse-powertools.json"), 600000), "plugin2 settings").to.equal(true);
+    expect(await waitForMatch(path.join(workspace, "plugin2"), (file) => file.endsWith(".csproj"), 600000), "plugin2 csproj scaffolded").to.equal(true);
+    expect(await waitForMatch(path.join(workspace, "plugin2"), (file) => file.endsWith(".sln"), 300000), "plugin2 normalised layout (.sln)").to.equal(true);
+    expect(await waitForMatch(path.join(workspace, "plugin2"), (file) => file === "project.assets.json", 600000), "plugin2 dotnet restore finished").to.equal(true);
+    const settings = readSettings("plugin2");
+    expect(settings.type).to.equal("plugin");
+    expect(settings.pluginProjectName, "second plugin keeps its own project name").to.equal("E2EBlankPlugin2");
+    expect(settings.connectionString).to.equal(undefined);
+  });
+
   it("adds a Solution component into a subfolder", async () => {
     await startAddComponent("Solution");
     await answerText("solution"); // subfolder
@@ -166,6 +238,17 @@ describe("Blank root + one component of each type (e2e)", function () {
     expect(settings.connectionString).to.equal(undefined);
   });
 
+  it("adds a SECOND Solution component into a distinct subfolder", async () => {
+    await startAddComponent("Solution");
+    await answerText("solution2"); // second solution component alongside the first
+    expect(await waitForFile(path.join(workspace, "solution2", "dataverse-powertools.json"), 600000), "solution2 settings").to.equal(true);
+    expect(await waitForFile(path.join(workspace, "solution2", "nuget.config"), 120000), "solution2 scaffold").to.equal(true);
+    expect(await waitForFile(path.join(workspace, "solution2", "paket.lock"), 600000), "solution2 paket install finished").to.equal(true);
+    const settings = readSettings("solution2");
+    expect(settings.type).to.equal("solution");
+    expect(settings.connectionString).to.equal(undefined);
+  });
+
   it("adds a Portal component into a subfolder", async () => {
     await startAddComponent("Portal");
     await answerText("portal"); // subfolder
@@ -175,9 +258,22 @@ describe("Blank root + one component of each type (e2e)", function () {
     expect(settings.connectionString).to.equal(undefined);
   });
 
+  it("adds a SECOND Portal component into a distinct subfolder", async () => {
+    await startAddComponent("Portal");
+    await answerText("portal2"); // second portal component alongside the first
+    expect(await waitForFile(path.join(workspace, "portal2", "dataverse-powertools.json"), 300000), "portal2 settings").to.equal(true);
+    const settings = readSettings("portal2");
+    expect(settings.type).to.equal("portal");
+    expect(settings.connectionString).to.equal(undefined);
+  });
+
   it("root stays a typeless connection-only file after all additions", async () => {
     const settings = readSettings(".");
     expect(settings.type).to.equal(undefined);
     expect(settings.connectionString).to.be.a("string").and.not.equal("");
+    // Eight components discovered off the root: two of every type, each type-scoped, none owning a connection.
+    for (const rel of ["webresources", "webresources2", "plugin", "plugin2", "solution", "solution2", "portal", "portal2"]) {
+      expect(readSettings(rel).connectionString, `${rel} inherits (owns no connection)`).to.equal(undefined);
+    }
   });
 });

--- a/src/ui-test/e2e/logAudit.spec.ts
+++ b/src/ui-test/e2e/logAudit.spec.ts
@@ -35,6 +35,14 @@ describe("auditLog", () => {
     expect(auditLog("A publish is already running — retrying in 20s (1/7)…\nPublish Complete")).toEqual([]);
   });
 
+  it("does not flag build/restore timings whose ms count looks like an HTTP status", () => {
+    // The http-error rule is case-insensitive, so "401 ms" would match "401 " + a letter.
+    expect(auditLog("Restored c:\\repo\\plugin2\\Plugin2.csproj (in 401 ms).")).toEqual([]);
+    expect(auditLog("Determining projects to restore... Restored (in 429 ms).")).toEqual([]);
+    // A genuine HTTP 401 with a reason phrase is still caught.
+    expect(auditLog("Request failed: 401 Unauthorized")).toHaveLength(1);
+  });
+
   it("flags network errors and HRESULTs", () => {
     const findings = auditLog("request to https://login.microsoftonline.com failed, reason: getaddrinfo ENOTFOUND login.microsoftonline.com");
     expect(findings).toHaveLength(1);

--- a/src/ui-test/e2e/logAudit.ts
+++ b/src/ui-test/e2e/logAudit.ts
@@ -44,6 +44,7 @@ const BENIGN: RegExp[] = [
   /hierarchyLevel|errorhandler/i, // metadata/typings identifiers containing "error"
   /Failed=0\b/i, // trx-style counters
   /passExecutionContext/i, // form XML attribute containing "ExecutionContext"
+  /\(in \d+\s*ms\)/i, // build/restore timing "Restored … (in 401 ms)" — the http-error rule's /i makes [A-Z] match the "ms", not an HTTP 401
 ];
 
 /** Audit a full e2e log. Returns findings for suspicious lines not covered by

--- a/src/webresources/createWebresourceClass.ts
+++ b/src/webresources/createWebresourceClass.ts
@@ -5,6 +5,7 @@ import { MultiStepInput, shouldResume, validationIgnore } from "../general/input
 import { getDataverseForms } from "../general/dataverse/getDataverseForms";
 import { getDataverseTables } from "../general/dataverse/getDataverseTables";
 import { createTemplatedFile } from "../general/generateTemplates";
+import { activeComponentRoot } from "../components/componentDiscovery";
 import { buildWebResourceClassPlaceholders } from "./webResourceClassTemplate";
 import path = require("path");
 
@@ -26,18 +27,21 @@ export async function createWebResourceClass(context: DataversePowerToolsContext
   });
   await createTemplatedFile(context, "class", outputs.className ?? "", placeholders);
   // In perFile output mode (#88) every source file is its own entry — the
-  // library.ts re-export barrel only exists for the bundled mode.
+  // library.ts re-export barrel only exists for the bundled mode. Resolve it
+  // against the ACTIVE COMPONENT root (not the workspace root) so it works for a
+  // web-resource component in a subfolder, matching createTemplatedFile.
   if (context.projectSettings.webresourceOutput !== "perFile") {
-    var library = (await vscode.workspace.fs.readFile(vscode.Uri.file(path.join(vscode.workspace.workspaceFolders[0].uri.fsPath, "webresources_src", "library.ts")))).toString();
+    const componentRoot = activeComponentRoot(context) ?? vscode.workspace.workspaceFolders[0].uri.fsPath;
+    const libraryUri = vscode.Uri.file(path.join(componentRoot, "webresources_src", "library.ts"));
+    let library = (await vscode.workspace.fs.readFile(libraryUri)).toString();
     library = library.trim() + ('\nexport * from "./' + outputs.className + '";\n');
-    await vscode.workspace.fs.writeFile(
-      vscode.Uri.file(path.join(vscode.workspace.workspaceFolders[0].uri.fsPath, "webresources_src", "library.ts")),
-      Buffer.from(library, "utf8"),
-    );
+    await vscode.workspace.fs.writeFile(libraryUri, Buffer.from(library, "utf8"));
   }
 
-  const testsPlaceholders = [{ placeholder: "ClassName", value: outputs.className ?? "" }] as TemplatePlaceholder[];
-  await createTemplatedFile(context, "sample.test", (outputs.className ?? "") + ".test", testsPlaceholders);
+  if (outputs.addTest) {
+    const testsPlaceholders = [{ placeholder: "ClassName", value: outputs.className ?? "" }] as TemplatePlaceholder[];
+    await createTemplatedFile(context, "sample.test", (outputs.className ?? "") + ".test", testsPlaceholders);
+  }
 }
 
 async function collectInputs(context: DataversePowerToolsContext) {

--- a/src/webresources/webresourceTestController.ts
+++ b/src/webresources/webresourceTestController.ts
@@ -4,6 +4,11 @@ import DataversePowerToolsContext from "../context";
 import { parseJestJson, extractJestJson, JestAssertion } from "./parseJestJson";
 import { jestPathArgs } from "./jestPaths";
 import { activeComponentRoot } from "../components/componentDiscovery";
+import { scopedTestControllerId } from "../components/discovery";
+
+// One controller per component, keyed by its unique id — re-initialising the same
+// component (re-discovery) disposes the stale controller instead of colliding on the id.
+const controllersById = new Map<string, vscode.TestController>();
 
 // Test Explorer integration for a Web Resources project's Jest tests (#84). Discovers the test files,
 // runs them via the project's LOCAL jest (through `npx`, like the webpack build), and reports live
@@ -174,7 +179,14 @@ function* mapIterable(items: vscode.TestItemCollection): Generator<vscode.TestIt
 }
 
 export function createWebresourceTestController(context: DataversePowerToolsContext): vscode.TestController {
-  const controller = vscode.tests.createTestController("dataverse-powertools.webresourceTests", "Web Resource Tests (Jest)");
+  // Scope the controller id to the component so two web-resource components don't collide
+  // ("Attempt to insert a duplicate controller with ID …", #47). Label by folder so the
+  // user can tell each component's tests apart in the Test Explorer.
+  const id = scopedTestControllerId("dataverse-powertools.webresourceTests", activeComponentRoot(context), !context.activeComponent);
+  controllersById.get(id)?.dispose();
+  const rel = context.activeComponent?.relativeRoot;
+  const controller = vscode.tests.createTestController(id, rel ? `Web Resource Tests (Jest) — ${rel}` : "Web Resource Tests (Jest)");
+  controllersById.set(id, controller);
   controller.resolveHandler = async (item) => {
     if (!item) {
       await discoverTestFiles(controller);
@@ -186,6 +198,13 @@ export function createWebresourceTestController(context: DataversePowerToolsCont
   controller.createRunProfile("Run", vscode.TestRunProfileKind.Run, (request, token) => void runHandler(context, controller, request, token, false), true);
   controller.createRunProfile("Debug", vscode.TestRunProfileKind.Debug, (request, token) => void runHandler(context, controller, request, token, true), false);
   void discoverTestFiles(controller);
-  context.vscode.subscriptions.push(controller);
+  context.vscode.subscriptions.push({
+    dispose: () => {
+      controller.dispose();
+      if (controllersById.get(id) === controller) {
+        controllersById.delete(id);
+      }
+    },
+  });
   return controller;
 }


### PR DESCRIPTION
## Summary

Fixes **five** multi-component bugs — two reported by the user, and **three shipped in 0.8.4** that were caught by extending the blank-root e2e to **two of every component type**.

### Bugs fixed
1. **Create Webresource Class in a subfolder component** threw `ENOENT` on `library.ts` (it read the workspace root, not the active component) — the class file was created but the barrel export and the test weren't. Now resolves against the active component and only writes the test when asked.
2. **SOLUTIONPREFIX not substituted** when adding a Web Resources component to a blank root — `webpack.common.js` kept the literal token, misnaming the built library. The component now carries the inherited prefix at scaffold time.
3. **Duplicate `TestController` id** — a second same-type component re-ran `initialise*` and collided on a hardcoded controller id ("duplicate controller with ID"). Now scoped per component (`scopedTestControllerId`) with a dispose-on-reinit registry.
4. **Duplicate command registration** — the plugin decoration CodeLens registered its commands per plugin component ("command … already exists"). Now registered once in `extension.ts`.
5. **Inherited connection persisted** — a scoped component's `writeSettings()` baked the root's connection/tenant/env into the component file, making it self-contained so it stopped tracking root changes. `writeSettings` now strips `inheritedFields`.

Bugs 3–5 only surface with a **second component of the same type** — invisible to unit tests and to the one-of-each e2e.

### Tests added
- **Headless monorepo spec** (`monorepoLifecycle.spec.ts`) — builds two of every type from the real templates and asserts command targeting + per-type template setup (18 assertions, no VS Code/network).
- **Extended blank-root e2e** to add **two of every type**, prove UI-level command targeting (`runForComponent` picker), and assert Add Component surfaces no error notification.
- Log-audit allowlist fix for `(in NNN ms)` restore-timing false positives.

### Verification
- `npm run test:unit` — **358 passing**
- `npm run lint` / `compile` / `compile-tests` — clean
- `npm run test:e2e` (Windows VM) — **43/43 passing**, both auth types, log audit clean
- Learnings recorded in `CLAUDE.md` (multi-component traps).

🤖 Generated with [Claude Code](https://claude.com/claude-code)