### PR TITLE
ci: setup-dotnet@v5 (node24) + publish only on version change

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -5,10 +5,33 @@ on:
 
 name: Deploy Extension
 env:
+  # publish-vscode-extension still ships a node20 action.yml; GitHub force-runs it on
+  # node24 via this flag (checkout/setup-node/setup-dotnet are already native node24).
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
 permissions:
   contents: read
 jobs:
+  version-check:
+    # Every push to main runs this workflow, but the Marketplace rejects a duplicate
+    # version — so only publish when package.json's version actually changed vs the
+    # previous commit. A docs/CI-only push then skips deploy instead of failing on a
+    # "version already exists" republish (which would leave main red).
+    name: Version changed?
+    runs-on: ubuntu-latest
+    outputs:
+      changed: ${{ steps.check.outputs.changed }}
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 2
+      - id: check
+        shell: bash
+        run: |
+          new=$(jq -r .version package.json)
+          old=$(git show HEAD~1:package.json 2>/dev/null | jq -r .version 2>/dev/null || echo "none")
+          echo "previous=$old current=$new"
+          if [ "$new" != "$old" ]; then echo "changed=true" >> "$GITHUB_OUTPUT"; else echo "changed=false" >> "$GITHUB_OUTPUT"; fi
+
   build-test:
     name: Lint, build & test
     runs-on: ubuntu-latest
@@ -30,7 +53,8 @@ jobs:
 
   deploy:
     name: Publish to Marketplace
-    needs: build-test
+    needs: [build-test, version-check]
+    if: needs.version-check.outputs.changed == 'true'
     # Windows runner: vscode:prepublish builds the net48 capture tool
     # (profiler-tool/ -> tools/pluginprofiler/) from source, which .NET Framework
     # can only compile on Windows. Everything else (webpack/vsce) is cross-platform.
@@ -42,7 +66,7 @@ jobs:
       - uses: actions/setup-node@v6
         with:
           node-version: 20
-      - uses: actions/setup-dotnet@v4
+      - uses: actions/setup-dotnet@v5
         with:
           dotnet-version: "8.0.x"
       - run: npm ci


### PR DESCRIPTION
## Summary

Updates the publish pipeline (`.github/workflows/main.yml`), addressing the Node 20 deprecation warning from the 0.8.5 publish run and hardening the trigger.

- **`actions/setup-dotnet` v4 → v5** — v5's `action.yml` declares `node24`, so it no longer relies on the force-flag. (`checkout`/`setup-node` are already v6/node24.)
- **`HaaLeo/publish-vscode-extension@v2`** stays as-is — its newest tag is still `v2` (node20); GitHub force-runs it on node24 via the existing `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true` flag (now commented to explain why).
- **Publish only when the version changed.** The Deploy workflow fires on every push to `main`, but the Marketplace rejects a duplicate version — so a docs/CI-only push (like this one) would fail the publish step on *"version already exists"* and leave `main` red. A new `version-check` job compares `package.json`'s version against the previous commit and gates `deploy` on it; non-release pushes now skip publish cleanly.

## Verification

- YAML validated locally (js-yaml).
- On merge, `version-check` will see 0.8.5 == 0.8.5 → `deploy` skips (no duplicate republish), `main` stays green. The next real release (version bump) publishes as normal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)