### PR TITLE
test(#143): extract & unit-test the form-registration XML builder

### DIFF
--- a/src/webresources/formRegistrationXml.spec.ts
+++ b/src/webresources/formRegistrationXml.spec.ts
@@ -1,0 +1,114 @@
+import { describe, it, expect } from "vitest";
+import { applyFormRegistrations, ResolvedRegistration } from "./formRegistrationXml";
+
+/* eslint-disable @typescript-eslint/naming-convention -- Dataverse form-XML attribute keys */
+
+// A deterministic guid source so libraryUniqueId is assertable.
+function guids(): () => string {
+  let n = 0;
+  return () => `guid-${++n}`;
+}
+
+const reg = (over: Partial<ResolvedRegistration> = {}): ResolvedRegistration => ({
+  event: "onload",
+  function: "pre.Account.OnLoad",
+  libraryName: "pre_library.js",
+  triggerId: "t1",
+  ...over,
+});
+
+describe("applyFormRegistrations", () => {
+  it("scaffolds formLibraries + events on an empty form with all required handler attributes", () => {
+    const form: any = {};
+    applyFormRegistrations(form, [reg()], new Set(["pre_library.js"]), guids());
+
+    expect(form.formLibraries.Library).toEqual([{ "@_name": "pre_library.js", "@_libraryUniqueId": "{guid-1}" }]);
+    const event = form.events.event[0];
+    expect(event["@_name"]).toBe("onload");
+    expect(event["@_active"]).toBe("true");
+    const handler = event.Handlers.Handler[0];
+    // The bug (0x80048425) was a nameless library — assert the name is always present.
+    expect(handler["@_libraryName"]).toBe("pre_library.js");
+    expect(handler["@_functionName"]).toBe("pre.Account.OnLoad");
+    expect(handler["@_handlerUniqueId"]).toBe("{t1}");
+    expect(handler["@_enabled"]).toBe("true");
+    expect(handler["@_parameters"]).toBe("");
+    expect(handler["@_passExecutionContext"]).toBe("false");
+  });
+
+  it("throws on a registration with no library name (the 0x80048425 shape) — writes nothing", () => {
+    const form: any = {};
+    expect(() => applyFormRegistrations(form, [reg({ libraryName: "" })], new Set(), guids())).toThrow(/0x80048425/);
+    expect(form.formLibraries).toBeUndefined();
+  });
+
+  it("does not duplicate an already-present <Library>", () => {
+    const form: any = { formLibraries: { Library: [{ "@_name": "pre_library.js", "@_libraryUniqueId": "{existing}" }] } };
+    applyFormRegistrations(form, [reg()], new Set(["pre_library.js"]), guids());
+    expect(form.formLibraries.Library).toHaveLength(1);
+    expect(form.formLibraries.Library[0]["@_libraryUniqueId"]).toBe("{existing}");
+  });
+
+  it("emits one <Library> per distinct library (per-file output mode)", () => {
+    const form: any = {};
+    const regs = [reg({ function: "pre.A.OnLoad", libraryName: "pre_A.js", triggerId: "a" }), reg({ function: "pre.B.OnLoad", libraryName: "pre_B.js", triggerId: "b" })];
+    applyFormRegistrations(form, regs, new Set(["pre_A.js", "pre_B.js"]), guids());
+    expect(form.formLibraries.Library.map((l: any) => l["@_name"])).toEqual(["pre_A.js", "pre_B.js"]);
+  });
+
+  it("appends a new handler to an existing event and carries parameters + passExecutionContext", () => {
+    const form: any = {
+      events: { event: [{ "@_name": "onload", Handlers: { Handler: [{ "@_handlerUniqueId": "{other}", "@_libraryName": "someone_else.js", "@_functionName": "x" }] } }] },
+    };
+    applyFormRegistrations(form, [reg({ parameters: "a,b", executionContext: true })], new Set(["pre_library.js"]), guids());
+    const handlers = form.events.event[0].Handlers.Handler;
+    expect(handlers).toHaveLength(2);
+    const added = handlers.find((h: any) => h["@_handlerUniqueId"] === "{t1}");
+    expect(added["@_parameters"]).toBe("a,b");
+    expect(added["@_passExecutionContext"]).toBe("true");
+  });
+
+  it("updates an existing handler in place (same handlerUniqueId)", () => {
+    const form: any = {
+      events: {
+        event: [{ "@_name": "onload", Handlers: { Handler: [{ "@_handlerUniqueId": "{t1}", "@_functionName": "old.Fn", "@_libraryName": "pre_old.js", "@_parameters": "old" }] } }],
+      },
+    };
+    applyFormRegistrations(form, [reg({ function: "new.Fn", libraryName: "pre_new.js" })], new Set(["pre_old.js", "pre_new.js"]), guids());
+    const handlers = form.events.event[0].Handlers.Handler;
+    expect(handlers).toHaveLength(1);
+    expect(handlers[0]["@_functionName"]).toBe("new.Fn");
+    expect(handlers[0]["@_libraryName"]).toBe("pre_new.js");
+    expect(handlers[0]["@_parameters"]).toBe("");
+  });
+
+  it("prunes OUR stale handlers but leaves other solutions' handlers untouched", () => {
+    const form: any = {
+      events: {
+        event: [
+          {
+            "@_name": "onload",
+            Handlers: {
+              Handler: [
+                { "@_handlerUniqueId": "{stale}", "@_libraryName": "pre_library.js", "@_functionName": "gone" }, // ours, no longer decorated → removed
+                { "@_handlerUniqueId": "{other}", "@_libraryName": "someone_else.js", "@_functionName": "keep" }, // not ours → kept
+              ],
+            },
+          },
+        ],
+      },
+    };
+    applyFormRegistrations(form, [reg()], new Set(["pre_library.js"]), guids());
+    const ids = form.events.event[0].Handlers.Handler.map((h: any) => h["@_handlerUniqueId"]).sort();
+    expect(ids).toEqual(["{other}", "{t1}"]); // stale ours dropped, other kept, new added
+  });
+
+  it("removes events left with no handlers after pruning", () => {
+    const form: any = {
+      events: { event: [{ "@_name": "onsave", Handlers: { Handler: [{ "@_handlerUniqueId": "{stale}", "@_libraryName": "pre_library.js" }] } }] },
+    };
+    // A registration for a DIFFERENT event; the onsave event's only (owned, stale) handler is pruned → event removed.
+    applyFormRegistrations(form, [reg({ event: "onload" })], new Set(["pre_library.js"]), guids());
+    expect(form.events.event.map((e: any) => e["@_name"])).toEqual(["onload"]);
+  });
+});

--- a/src/webresources/formRegistrationXml.ts
+++ b/src/webresources/formRegistrationXml.ts
@@ -1,0 +1,117 @@
+// Pure form-XML mutation for form-event registration (#90), extracted from
+// saveFormData so the library-dedup + handler upsert/prune logic — which once
+// serialized a nameless <Library> and broke the whole form with 0x80048425 — is
+// unit-testable without vscode or a live org. Operates on the fast-xml-parser
+// JSON shape of a form's <form> element (attributes are "@_"-prefixed).
+
+/* eslint-disable @typescript-eslint/naming-convention -- keys are Dataverse form-XML attribute names */
+
+/** One handler to register, with its library name already resolved (upstream, from
+ * the publisher prefix + output mode). */
+export interface ResolvedRegistration {
+  /** Event name, e.g. "onload" / "onsave". */
+  event: string;
+  /** Handler function, e.g. "prefix.Class.OnLoad". */
+  function: string;
+  /** Resolved web-resource library name (never empty — see the guard below). */
+  libraryName: string;
+  parameters?: string;
+  executionContext?: boolean;
+  /** Stable id that identifies this handler across runs (handlerUniqueId). */
+  triggerId: string;
+}
+
+/**
+ * Apply the resolved registrations to a form's `<form>` object IN PLACE (the shape
+ * fast-xml-parser produces — `formRoot` is `form.form.form`):
+ * - ensure one `<Library>` per distinct library the handlers bind to;
+ * - upsert each handler (keyed by handlerUniqueId) under its event;
+ * - drop OUR stale handlers (bound to an owned library, triggerId no longer
+ *   decorated) — other solutions' handlers on the same form are untouched;
+ * - prune events left with no handlers.
+ *
+ * `newGuid` supplies `libraryUniqueId` values (injected so tests are deterministic).
+ * Throws if any registration lacks a library name — the exact 0x80048425 shape —
+ * so a nameless `<Library>`/handler can never be written.
+ */
+export function applyFormRegistrations(formRoot: any, registrations: ResolvedRegistration[], ownedLibraries: Set<string>, newGuid: () => string): void {
+  const nameless = registrations.find((registration) => !registration.libraryName);
+  if (nameless) {
+    throw new Error(
+      `RegisterEvent for "${nameless.function || nameless.event}" has no resolved web-resource library name — refusing to write a form without a <Library> name (0x80048425).`,
+    );
+  }
+
+  if (!formRoot.formLibraries) {
+    formRoot.formLibraries = { Library: [] };
+  }
+  // One <Library> per distinct library the form's events bind to (per-file mode can
+  // need several; bundle mode needs one).
+  for (const neededLibrary of new Set(registrations.map((registration) => registration.libraryName))) {
+    if (!formRoot.formLibraries.Library.find((library: any) => library["@_name"] === neededLibrary)) {
+      formRoot.formLibraries.Library.push({
+        "@_name": neededLibrary,
+        "@_libraryUniqueId": "{" + newGuid() + "}",
+      });
+    }
+  }
+
+  for (const registration of registrations) {
+    if (!formRoot.events) {
+      formRoot.events = { event: [] };
+    }
+    const event = formRoot.events.event.find((candidate: any) => candidate["@_name"] === registration.event);
+    if (!event) {
+      formRoot.events.event.push({
+        "@_name": registration.event,
+        "@_active": "true",
+        "@_application": "true",
+        Handlers: {
+          Handler: [
+            {
+              "@_enabled": "true",
+              "@_functionName": registration.function,
+              "@_libraryName": registration.libraryName,
+              "@_parameters": registration.parameters ?? "",
+              "@_passExecutionContext": registration.executionContext ? "true" : "false",
+              "@_handlerUniqueId": "{" + registration.triggerId + "}",
+            },
+          ],
+        },
+      });
+    } else {
+      if (!event.Handlers) {
+        event.Handlers = { Handler: [] };
+      }
+      const handler = event.Handlers.Handler.find((candidate: any) => candidate["@_handlerUniqueId"] === "{" + registration.triggerId + "}");
+      if (!handler) {
+        event.Handlers.Handler.push({
+          "@_functionName": registration.function,
+          "@_libraryName": registration.libraryName,
+          "@_handlerUniqueId": "{" + registration.triggerId + "}",
+          "@_enabled": "true",
+          "@_parameters": registration.parameters ?? "",
+          "@_passExecutionContext": registration.executionContext ? "true" : "false",
+        });
+      } else {
+        handler["@_functionName"] = registration.function;
+        handler["@_libraryName"] = registration.libraryName;
+        handler["@_parameters"] = registration.parameters ?? "";
+        handler["@_passExecutionContext"] = registration.executionContext ? "true" : "false";
+      }
+    }
+  }
+
+  // Remove any handlers bound to one of OUR library names (either output mode) whose
+  // handlerUniqueId is no longer decorated — other solutions' handlers are untouchable.
+  const liveHandlerIds = new Set(registrations.map((registration) => "{" + registration.triggerId + "}"));
+  if (formRoot.events) {
+    for (const event of formRoot.events.event) {
+      if (event.Handlers) {
+        event.Handlers.Handler = event.Handlers.Handler.filter((handler: any) => !ownedLibraries.has(handler["@_libraryName"]) || liveHandlerIds.has(handler["@_handlerUniqueId"]));
+      }
+    }
+    // Remove any now-empty events.
+    formRoot.events.event = formRoot.events.event.filter((event: any) => event.Handlers && event.Handlers.Handler.length > 0);
+  }
+}

--- a/src/webresources/saveFormData.ts
+++ b/src/webresources/saveFormData.ts
@@ -4,6 +4,7 @@ import { DataverseForm } from "../general/dataverse/DataverseForm";
 import { randomUUID } from "crypto";
 import { parseRegisterEvents, validateRegisterEvent, RegisterEventDecoration } from "./registerEventParser";
 import { webresourceLibraryName, candidateLibraryNames } from "./libraryNames";
+import { applyFormRegistrations, ResolvedRegistration } from "./formRegistrationXml";
 import { activeComponentRoot } from "../components/componentDiscovery";
 
 type SourcedRegisterEvent = RegisterEventDecoration & { sourceFile: string };
@@ -108,93 +109,18 @@ export async function saveFormDataExec(context: DataversePowerToolsContext, opti
       failedForms++;
       continue;
     }
-    /* eslint-disable @typescript-eslint/naming-convention */
-    if (!form.form.form.formLibraries) {
-      form.form.form.formLibraries = { Library: [] };
-    }
-    // One <Library> per distinct library the form's events bind to (per-file
-    // mode can need several; bundle mode needs one).
-    for (const neededLibrary of new Set(groupedRegisterEvents[formId].map(libraryFor))) {
-      if (!form.form.form.formLibraries.Library.find((l: any) => l["@_name"] === neededLibrary)) {
-        form.form.form.formLibraries.Library.push({
-          "@_name": neededLibrary,
-          "@_libraryUniqueId": "{" + randomUUID() + "}", //create a random guid
-        });
-      }
-    }
-    //loop through the groupedRegisterEvents and add the events to the form
-    for (const registerEvent of groupedRegisterEvents[formId]) {
-      const libraryName = libraryFor(registerEvent);
-      // look through the form for the event or add it if it doesn't exist
-      if (!form.form.form.events) {
-        form.form.form.events = { event: [] };
-      }
-      const event = form.form.form.events.event.find((e: any) => e["@_name"] === registerEvent.event);
+    // Resolve each event's library (prefix + output mode + source file) up front, then
+    // apply the form-XML mutation via the pure, unit-tested builder (formRegistrationXml).
+    const registrations: ResolvedRegistration[] = groupedRegisterEvents[formId].map((registerEvent) => ({
+      event: registerEvent.event,
+      function: registerEvent.function,
+      libraryName: libraryFor(registerEvent),
+      parameters: registerEvent.parameters,
+      executionContext: registerEvent.executionContext,
+      triggerId: registerEvent.triggerId,
+    }));
+    applyFormRegistrations(form.form.form, registrations, ownedLibraries, randomUUID);
 
-      if (!event) {
-        form.form.form.events.event.push({
-          "@_name": registerEvent.event,
-          "@_active": "true",
-          "@_application": "true",
-          Handlers: {
-            Handler: [
-              {
-                "@_enabled": "true",
-                "@_functionName": registerEvent.function,
-                "@_libraryName": libraryName,
-                "@_parameters": registerEvent.parameters ?? "",
-                "@_passExecutionContext": registerEvent.executionContext ? "true" : "false",
-                "@_handlerUniqueId": "{" + registerEvent.triggerId + "}",
-              },
-            ],
-          },
-        });
-      }
-      // look through the event for the handler or add it if it doesn't exist
-      else {
-        if (!event.Handlers) {
-          event.Handlers = { Handler: [] };
-        }
-        const handler = event.Handlers.Handler.find((h: any) => h["@_handlerUniqueId"] === "{" + registerEvent.triggerId + "}");
-        if (!handler) {
-          event.Handlers.Handler.push({
-            "@_functionName": registerEvent.function,
-            "@_libraryName": libraryName,
-            "@_handlerUniqueId": "{" + registerEvent.triggerId + "}",
-            "@_enabled": "true",
-            "@_parameters": registerEvent.parameters ?? "",
-            "@_passExecutionContext": registerEvent.executionContext ? "true" : "false",
-          });
-        }
-        // update the handler if it exists
-        else {
-          handler["@_functionName"] = registerEvent.function;
-          handler["@_libraryName"] = libraryName;
-          handler["@_parameters"] = registerEvent.parameters ?? "";
-          handler["@_passExecutionContext"] = registerEvent.executionContext ? "true" : "false";
-        }
-      }
-    }
-    //remove any handlers bound to one of OUR library names (either output mode) whose
-    //handlerUniqueId is no longer decorated — other solutions' handlers are untouchable
-    if (form.form.form.events) {
-      for (const event of form.form.form.events.event) {
-        if (event.Handlers) {
-          event.Handlers.Handler = event.Handlers.Handler.filter((h: any) => {
-            return !ownedLibraries.has(h["@_libraryName"]) || groupedRegisterEvents[formId].find((r) => "{" + r.triggerId + "}" === h["@_handlerUniqueId"]);
-          });
-        }
-      }
-    }
-
-    //remove any empty event arrays
-    if (form.form.form.events) {
-      form.form.form.events.event = form.form.form.events.event.filter((e: any) => {
-        return e.Handlers && e.Handlers.Handler.length > 0;
-      });
-    }
-
-    /* eslint-enable @typescript-eslint/naming-convention */
     context.channel.appendLine(`Saving Form: ${form.id}`);
     if (!(await form.saveForm())) {
       failedForms++;


### PR DESCRIPTION
#143 move 3 (extract trapped pure logic), starting with the highest-value target: the form-XML mutation in `saveFormData`. It was pure object transformation trapped in a vscode-tangled function — and it's the exact code path that shipped the **0x80048425 "nameless `<Library>`" schema bug**, with zero tests.

## Changes
- **New pure module `formRegistrationXml.ts`** (`applyFormRegistrations`): `<Library>` dedup, handler upsert/update, prune-our-stale-handlers, empty-event prune. **Behaviour-preserving** extraction (identical form-XML output; the two handler-object shapes are kept verbatim). Guid source injected for deterministic tests.
- **Defensive guard**: refuses to write a registration with no library name — turning the exact 0x80048425 shape into a clear error instead of a corrupt form.
- **8 unit tests** covering every branch: empty-form scaffold, the schema-bug guard, library dedup, per-file multi-library, append/update handler, prune-ours-keep-others, empty-event prune.
- `saveFormData` now resolves each event's library then calls the pure builder (–86 lines of tangled logic).

## Verify
- lint clean, `compile` OK, unit **366 passing (+8)**.
- The e2e form-event suites (`webresourceComprehensive`/`perFile`/`interactive`) remain the end-to-end gate and will validate on the next full run.

Part of the testing-strategy epic #143.

🤖 Generated with [Claude Code](https://claude.com/claude-code)