### PR TITLE
test(#143): cover more trapped pure logic — model-builder settings + operation tracker

### DIFF
--- a/src/general/modelbuilder/settingsFile.spec.ts
+++ b/src/general/modelbuilder/settingsFile.spec.ts
@@ -1,0 +1,83 @@
+import { describe, it, expect } from "vitest";
+import { parseCsv, toArray, applyDefaults, LOG_LEVELS } from "./settingsFile";
+
+// Pure helpers behind the plugin model-builder (earlybound) settings. parseCsv is the
+// CSV/array normaliser for the entity/message filters; applyDefaults fills a partial
+// settings object. (The module imports vscode for getWorkspacePath, but these functions
+// don't touch it — vitest aliases vscode to the mock.)
+
+describe("parseCsv", () => {
+  it("returns [] for empty / nullish input", () => {
+    expect(parseCsv(undefined)).toEqual([]);
+    expect(parseCsv(null)).toEqual([]);
+    expect(parseCsv("")).toEqual([]);
+    expect(parseCsv([])).toEqual([]);
+  });
+
+  it("splits a comma string, trims, and drops empty entries", () => {
+    expect(parseCsv("account, contact ,, lead")).toEqual(["account", "contact", "lead"]);
+  });
+
+  it("dedupes case-insensitively, keeping the first occurrence's casing", () => {
+    expect(parseCsv("Account, account, Contact, ACCOUNT")).toEqual(["Account", "Contact"]);
+  });
+
+  it("normalises an array the same way as a string", () => {
+    expect(parseCsv([" Account ", "account", "", "Contact"])).toEqual(["Account", "Contact"]);
+  });
+
+  it("toArray is parseCsv over an array", () => {
+    expect(toArray(["a", "a", "b"])).toEqual(["a", "b"]);
+  });
+});
+
+describe("applyDefaults", () => {
+  it("fills every field with its default from an empty object", () => {
+    const settings = applyDefaults({});
+    expect(settings.namespace).toBe("Dataverse.Plugins");
+    expect(settings.serviceContextName).toBe("XrmSvc");
+    expect(settings.outputDirectory).toBe("generated");
+    expect(settings.entityTypesFolder).toBe("Entities");
+    expect(settings.messagesTypesFolder).toBe("Messages");
+    expect(settings.optionSetsTypesFolder).toBe("OptionSets");
+    expect(settings.logLevel).toBe("Information");
+    expect(settings.entityNamesFilter).toEqual([]);
+    expect(settings.messageNamesFilter).toEqual([]);
+    // Every boolean defaults to false.
+    for (const key of [
+      "emitEntityEtc",
+      "emitFieldsClasses",
+      "emitVirtualAttributes",
+      "generateGlobalOptionSets",
+      "generateSdkMessages",
+      "suppressGeneratedCodeAttribute",
+      "suppressINotifyPattern",
+    ] as const) {
+      expect(settings[key], key).toBe(false);
+    }
+  });
+
+  it("respects provided values and normalises the filters through parseCsv", () => {
+    const settings = applyDefaults({
+      namespace: "My.Ns",
+      emitEntityEtc: true,
+      entityNamesFilter: "account, Account, contact" as any,
+      messageNamesFilter: ["Create", "create"] as any,
+    });
+    expect(settings.namespace).toBe("My.Ns");
+    expect(settings.emitEntityEtc).toBe(true);
+    expect(settings.entityNamesFilter).toEqual(["account", "contact"]);
+    expect(settings.messageNamesFilter).toEqual(["Create"]);
+  });
+
+  it("falls back to Information for an invalid logLevel and keeps a valid one", () => {
+    expect(applyDefaults({ logLevel: "Bogus" as any }).logLevel).toBe("Information");
+    expect(applyDefaults({ logLevel: "Verbose" }).logLevel).toBe("Verbose");
+    expect(LOG_LEVELS).toContain("Verbose");
+  });
+
+  it("preserves an explicit false vs undefined (?? semantics)", () => {
+    expect(applyDefaults({ emitEntityEtc: false }).emitEntityEtc).toBe(false);
+    expect(applyDefaults({ emitEntityEtc: true }).emitEntityEtc).toBe(true);
+  });
+});

--- a/src/panel/operationTracker.spec.ts
+++ b/src/panel/operationTracker.spec.ts
@@ -1,0 +1,66 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { runTracked, getRecentOperations, resetOperations } from "./operationTracker";
+
+// The actions-panel "recent operations" feed: a 5-record ring buffer with live
+// status. vscode-free (imports only the context type), so unit-testable with a
+// minimal fake context.
+
+function fakeContext(root?: string): any {
+  return { refreshPanel: vi.fn(), activeComponent: root ? { root } : undefined };
+}
+
+describe("operationTracker", () => {
+  beforeEach(() => resetOperations());
+
+  it("records a running op then marks it success, returning the run's result", async () => {
+    const context = fakeContext("/ws/plugin");
+    const result = await runTracked(context, "Build", () => "done");
+    expect(result).toBe("done");
+    const [op] = getRecentOperations();
+    expect(op.label).toBe("Build");
+    expect(op.status).toBe("success");
+    expect(op.finishedAt).toBeTypeOf("number");
+    expect(op.componentRoot).toBe("/ws/plugin");
+    // refreshPanel fires on start and on finish.
+    expect(context.refreshPanel).toHaveBeenCalledTimes(2);
+  });
+
+  it("marks the op error and rethrows, capturing the message as detail", async () => {
+    const context = fakeContext();
+    await expect(runTracked(context, "Deploy", () => Promise.reject(new Error("boom")))).rejects.toThrow("boom");
+    const [op] = getRecentOperations();
+    expect(op.status).toBe("error");
+    expect(op.detail).toBe("boom");
+    expect(op.componentRoot).toBeUndefined();
+  });
+
+  it("keeps only the last 5 operations, newest first", async () => {
+    const context = fakeContext();
+    for (const label of ["a", "b", "c", "d", "e", "f"]) {
+      await runTracked(context, label, () => undefined);
+    }
+    expect(getRecentOperations().map((op) => op.label)).toEqual(["f", "e", "d", "c", "b"]);
+  });
+
+  it("assigns unique, increasing ids", async () => {
+    const context = fakeContext();
+    await runTracked(context, "one", () => undefined);
+    await runTracked(context, "two", () => undefined);
+    const ids = getRecentOperations().map((op) => op.id);
+    expect(new Set(ids).size).toBe(ids.length);
+    expect(ids[0]).toBeGreaterThan(ids[1]); // newest (higher id) first
+  });
+
+  it("getRecentOperations returns copies — mutating the result can't corrupt the feed", async () => {
+    await runTracked(fakeContext(), "x", () => undefined);
+    const snapshot = getRecentOperations();
+    snapshot[0].label = "TAMPERED";
+    expect(getRecentOperations()[0].label).toBe("x");
+  });
+
+  it("resetOperations clears the feed", async () => {
+    await runTracked(fakeContext(), "x", () => undefined);
+    resetOperations();
+    expect(getRecentOperations()).toEqual([]);
+  });
+});


### PR DESCRIPTION
Continues the testing-strategy epic (#143, move 3): unit-test pure logic the audit flagged as untested. **Spec-only — no shipping code changes.**

- **`general/modelbuilder/settingsFile.ts`** — `parseCsv` (comma/array normalise + case-insensitive dedupe for the entity/message filters), `toArray`, `applyDefaults` (fills a partial earlybound settings object; logLevel validation; explicit-false-vs-undefined semantics). 9 tests.
- **`panel/operationTracker.ts`** — `runTracked` success/error status transitions + rethrow, the 5-record ring buffer (newest first), unique ids, copy-on-read immutability, `resetOperations`. 6 tests.

## Verify
- unit **381 passing** (+15), lint clean.
- Zero shipping risk (only `*.spec.ts` added); the `version-check` gate skips publish on merge.

Follow-ups still open in #143: the plugin-component fixture integration test (#147), extracting the `registerPluginSteps`/`registerWorkflowActivities` OData builders + `computePanelState`, the mocked-Dataverse handler harness, and trimming e2e/live redundancy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)