### PR TITLE
test(#143): extract & unit-test the profilable-steps parse/filter (the #135 locus)

### DIFF
--- a/src/general/dataverse/parseProfilableSteps.spec.ts
+++ b/src/general/dataverse/parseProfilableSteps.spec.ts
@@ -1,0 +1,59 @@
+import { describe, it, expect } from "vitest";
+import { parseProfilableSteps } from "./pluginProfiles";
+
+/* eslint-disable @typescript-eslint/naming-convention -- Dataverse OData navigation/field names */
+
+// The pure shape+filter behind getProfilableSteps — the code path behind #135
+// ("No registered plugin steps to profile" for a step that IS registered). Extracted
+// from the HTTP handler so the filtering is unit-testable without a live org
+// (mocking node-fetch v3 / ESM in vitest is a separate config concern, see #143).
+
+const validRow = {
+  sdkmessageprocessingstepid: "step-1",
+  name: "My.Plugins.AccountCreate: Create of account",
+  mode: 0,
+  statecode: 0,
+  sdkmessageid: { name: "Create" },
+  sdkmessagefilterid: { primaryobjecttypecode: "account" },
+  eventhandler_plugintype: { typename: "My.Plugins.AccountCreate", pluginassemblyid: { name: "MyPlugins" } },
+};
+
+describe("parseProfilableSteps", () => {
+  it("shapes a registered step from the expand, enriched with message + entity", () => {
+    expect(parseProfilableSteps({ value: [validRow] })).toEqual([
+      { stepId: "step-1", name: "My.Plugins.AccountCreate: Create of account", typeName: "My.Plugins.AccountCreate", message: "Create", primaryEntity: "account", mode: 0 },
+    ]);
+  });
+
+  it("scopes to the requested assembly when given", () => {
+    const other = { ...validRow, sdkmessageprocessingstepid: "step-2", eventhandler_plugintype: { typename: "Other.Plugin", pluginassemblyid: { name: "OtherAsm" } } };
+    expect(parseProfilableSteps({ value: [validRow, other] }, "MyPlugins").map((s) => s.stepId)).toEqual(["step-1"]);
+    expect(parseProfilableSteps({ value: [validRow, other] }, "OtherAsm").map((s) => s.stepId)).toEqual(["step-2"]);
+    // No assembly filter → both.
+    expect(parseProfilableSteps({ value: [validRow, other] }).map((s) => s.stepId)).toEqual(["step-1", "step-2"]);
+  });
+
+  it("drops system (Microsoft.*) steps and the profiler's own (Profiled) clones", () => {
+    const microsoft = { ...validRow, sdkmessageprocessingstepid: "ms", eventhandler_plugintype: { typename: "Microsoft.Crm.X", pluginassemblyid: { name: "Microsoft" } } };
+    const profiled = { ...validRow, sdkmessageprocessingstepid: "prof", name: "My.Plugins.AccountCreate (Profiled): Create of account" };
+    expect(parseProfilableSteps({ value: [validRow, microsoft, profiled] }).map((s) => s.stepId)).toEqual(["step-1"]);
+  });
+
+  it("#135 characterisation: a step whose plugintype expand didn't populate is dropped (typeName empty)", () => {
+    // The suspected #135 failure mode: eventhandler_plugintype comes back null for a real,
+    // active step, so typeName is "" and the `step.typeName && …` filter drops it — the
+    // handler then reports "No registered plugin steps to profile". This pins that
+    // behaviour; when #135 is diagnosed (resolve the type a different way), update it here.
+    expect(parseProfilableSteps({ value: [{ ...validRow, eventhandler_plugintype: null }] })).toEqual([]);
+    expect(parseProfilableSteps({ value: [{ ...validRow, eventhandler_plugintype: { pluginassemblyid: { name: "MyPlugins" } } }] })).toEqual([]);
+  });
+
+  it("tolerates a missing/empty result set and missing optional expands", () => {
+    expect(parseProfilableSteps({ value: [] })).toEqual([]);
+    expect(parseProfilableSteps({})).toEqual([]);
+    expect(parseProfilableSteps(undefined)).toEqual([]);
+    // message/primaryEntity are optional — a step with no filter/message still shapes.
+    const minimal = { sdkmessageprocessingstepid: "m", name: "n", eventhandler_plugintype: { typename: "A.B", pluginassemblyid: { name: "Asm" } } };
+    expect(parseProfilableSteps({ value: [minimal] })).toEqual([{ stepId: "m", name: "n", typeName: "A.B", message: undefined, primaryEntity: undefined, mode: undefined }]);
+  });
+});

--- a/src/general/dataverse/pluginProfiles.ts
+++ b/src/general/dataverse/pluginProfiles.ts
@@ -64,7 +64,18 @@ export async function getProfilableSteps(context: DataversePowerToolsContext, as
   if (!body) {
     return undefined;
   }
-  const rows: any[] = body.value ?? [];
+  return parseProfilableSteps(body, assemblyName);
+}
+
+/**
+ * Shape + filter the sdkmessageprocessingsteps response into profilable steps (pure,
+ * unit-tested). Drops steps whose plugintype expand didn't resolve a typeName, system
+ * (Microsoft.*) steps, and the profiler's own "(Profiled)" clones; optionally scopes to
+ * one assembly. NB: an active, registered step whose `eventhandler_plugintype` expand
+ * comes back empty is dropped here (typeName ""), the suspected #135 failure mode.
+ */
+export function parseProfilableSteps(body: any, assemblyName?: string): ProfilableStep[] {
+  const rows: any[] = body?.value ?? [];
   return rows
     .map((row) => {
       const type = row.eventhandler_plugintype;


### PR DESCRIPTION
Continues #143. Extracts `parseProfilableSteps` from `getProfilableSteps` — the pure shape+filter of the `sdkmessageprocessingsteps` response — so the **code path behind #135** ("No registered plugin steps to profile" for a step that IS registered) is unit-testable without a live org. Behaviour-preserving; the handler now calls the extracted function.

## Tests (5)
- Shapes a registered step (typeName/message/entity from the expand).
- Assembly scoping (with / without the filter).
- Drops system `Microsoft.*` steps and the profiler's own `(Profiled)` clones.
- Tolerates missing/empty `value` and missing optional expands.
- **#135 characterisation**: a step whose `eventhandler_plugintype` expand didn't populate is dropped (`typeName ""`) — the suspected failure mode. Pins the behaviour so a fix has a target.

## On the mocked-Web-API harness (#143 move 2)
I attempted the full mocked-`node-fetch` harness first (drive `getProfilableSteps` end-to-end against canned HTTP responses), but **node-fetch is v3 (ESM-only)** and vitest externalises it, so `vi.mock` doesn't intercept without a `deps.inline: ['node-fetch']` (or `server.deps.inline`) config change. Deferred that config work; the extraction gives the same #135-relevant coverage deterministically. Noted as a follow-up on #143.

## Verify
- unit **386 passing** (+5), lint + compile clean. Behaviour-preserving; e2e/live remain the org-level gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)