### PR TITLE
0.8.6 (pre-release) — test hardening + safer form-event registration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to the "dataverse-powertools" extension will be documented in this file.
 
+## 0.8.6 (pre-release)
+
+Test hardening + safer form-event registration.
+
+- **Form-event registration fails fast on the schema-bug shape.** The form-XML builder now refuses to write a web-resource `<Library>` without a resolved name — the exact shape that once broke a form with `0x80048425` — turning a would-be corrupt form into a clear error. Behaviour is otherwise unchanged.
+- **Under the hood (no functional change):** a new CI-runnable **integration test layer** (asserts command registration and guards the multi-component duplicate-`TestController` crash that shipped in 0.8.4), and the highest-risk internal logic extracted into pure, unit-tested modules — the form-XML builder, the model-builder (earlybound) settings helpers, and the plugin profilable-steps filter (the code path behind "No registered plugin steps to profile"). Unit coverage 358 → 386. See the testing-strategy epic (#143).
+
 ## 0.8.5 (pre-release)
 
 Multi-component robustness — fixes for repos with two components of the same type.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "dataverse-powertools",
-  "version": "0.8.5",
+  "version": "0.8.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "dataverse-powertools",
-      "version": "0.8.5",
+      "version": "0.8.6",
       "hasInstallScript": true,
       "dependencies": {
         "@azure/msal-node": "^5.4.0",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "type": "git",
     "url": "https://github.com/pete-mc/dataverse-powertools"
   },
-  "version": "0.8.5",
+  "version": "0.8.6",
   "engines": {
     "vscode": "^1.93.0"
   },


### PR DESCRIPTION
Packages the testing-strategy work (#143) accumulated on `main` since 0.8.5. Behaviour-preserving apart from one fail-fast guard.

## What's in it (all already merged to main; this bumps the version to release it)
- **CI-runnable integration test layer** (#144) — asserts command registration and directly guards the multi-component duplicate-`TestController` crash that shipped in 0.8.4.
- **Highest-risk internal logic extracted to pure, unit-tested modules** — the form-XML builder (#148), the model-builder/earlybound settings helpers (#149), and the plugin profilable-steps filter (#151, the "No registered plugin steps to profile" code path / #135).
- **Form-XML builder fails fast on the `0x80048425` shape** — refuses to write a nameless `<Library>`, turning a would-be corrupt form into a clear error.
- Unit coverage **358 → 386**.

## Notes
- Only user-facing change is the fail-fast guard; everything else is internal hardening + tests.
- `release/0.8.6` bumps `package.json` to 0.8.6 so the `version-check` deploy gate publishes it (prior test PRs kept 0.8.5 and skipped publish).
- The mocked-Web-API harness (move 2) is **deferred** — node-fetch v3/ESM blocks vitest mocking without a fetch-injection refactor; tracked on #143.

## Recommended gate before merge/publish
Per the standing "run e2e before release" rule: the form-XML extraction (#148) touched the form-save shipping path, so the `webresourceComprehensive`/`perFile` e2e suites (which assert live form XML) are the right validation. Happy to run the full `npm run test:e2e` on the VM before this merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)