### PR TITLE
fix(#146): initialise every component of a type on load, not just the first

### DIFF
--- a/src/components/discovery.spec.ts
+++ b/src/components/discovery.spec.ts
@@ -3,6 +3,7 @@ import {
   resolveComponents,
   componentForPath,
   componentsOfType,
+  componentsToInitialise,
   normalizeFsPath,
   resolveTargetComponent,
   applyLayout,
@@ -160,6 +161,37 @@ describe("resolveTargetComponent (#119 command target)", () => {
   it("pick candidates are exactly the components of the type", () => {
     const res = resolveTargetComponent(components, "plugin", undefined, undefined);
     expect(res.kind === "pick" && res.candidates.map((c) => c.relativeRoot)).toEqual(["pluginA", "pluginB"]);
+  });
+});
+
+describe("componentsToInitialise (#146 per-component init on load)", () => {
+  it("returns EVERY typed component — both of each type — not just the first", () => {
+    const { components } = resolveComponents(root, [
+      file("C:\\repo\\dataverse-powertools.json", { connectionString: "cs" }), // connection-only root, no type
+      file("C:\\repo\\web1\\dataverse-powertools.json", { type: "webresources" }),
+      file("C:\\repo\\web2\\dataverse-powertools.json", { type: "webresources" }),
+      file("C:\\repo\\plugin1\\dataverse-powertools.json", { type: "plugin" }),
+      file("C:\\repo\\plugin2\\dataverse-powertools.json", { type: "plugin" }),
+    ]);
+    // The bug (#146): the old loop initialised only the first of each type, so web2/plugin2
+    // never got a Test Explorer controller on load. This must list all four.
+    expect(componentsToInitialise(components).map((c) => c.relativeRoot)).toEqual(["plugin1", "plugin2", "web1", "web2"]);
+  });
+
+  it("excludes the connection-only root and unsupported/unknown types", () => {
+    const { components } = resolveComponents(root, [
+      file("C:\\repo\\dataverse-powertools.json", { connectionString: "cs" }),
+      file("C:\\repo\\mystery\\dataverse-powertools.json", { type: "not-a-real-type" }),
+      file("C:\\repo\\plugin\\dataverse-powertools.json", { type: "plugin" }),
+    ]);
+    expect(componentsToInitialise(components).map((c) => c.relativeRoot)).toEqual(["plugin"]);
+  });
+
+  it("returns the single root component for a legacy single-project workspace", () => {
+    const { components } = resolveComponents(root, [file("C:\\repo\\dataverse-powertools.json", { type: "webresources", connectionString: "cs" })]);
+    const toInit = componentsToInitialise(components);
+    expect(toInit).toHaveLength(1);
+    expect(toInit[0].isRoot).toBe(true);
   });
 });
 

--- a/src/components/discovery.ts
+++ b/src/components/discovery.ts
@@ -8,6 +8,7 @@
 // path→component resolution. Unit-tested in discovery.spec.ts.
 
 import { migrateSettings, MigrationIo } from "../general/settingsMigrations";
+import { isSupportedProjectType } from "../projectTypes/registry";
 
 /** The parsed shape of a component's dataverse-powertools.json (loosely typed —
  * the full ProjectSettings interface lives in context.ts, which imports vscode). */
@@ -155,6 +156,15 @@ export function componentForPath(components: DiscoveredComponent[], fsPath: stri
 /** Components of a given project type (registry id). */
 export function componentsOfType(components: DiscoveredComponent[], type: string): DiscoveredComponent[] {
   return components.filter((c) => c.settings.type === type);
+}
+
+/** Every discovered component with a supported project type — the set the activation
+ * loop initialises on load. It returns ALL of them, not just the first of each type
+ * (#146): each component needs its own scoped Test Explorer controller + watchers
+ * created, which is safe now that controller ids are per-component (#124). The
+ * connection-only root (no type) and unknown types are excluded. */
+export function componentsToInitialise(components: DiscoveredComponent[]): DiscoveredComponent[] {
+  return components.filter((c) => isSupportedProjectType(c.settings.type));
 }
 
 /** A VS Code TestController id scoped to one component (#84/#47). VS Code throws

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -5,7 +5,7 @@ import fs = require("fs");
 import DataversePowerToolsContext from "./context";
 import { getProjectTypeActivation, registerAllComponentCommands } from "./projectTypes/activation";
 import { componentScopedContext } from "./components/componentDiscovery";
-import { componentsOfType } from "./components/discovery";
+import { componentsToInitialise } from "./components/discovery";
 import { clearStoredCredentials } from "./general/connectionStringManager";
 import { checkConfigRevision } from "./general/configRefresh";
 import { registerProfilerCodeLens } from "./plugins/profilerCodeLens";
@@ -54,26 +54,30 @@ export async function initialise(context: DataversePowerToolsContext) {
     await vscode.commands.executeCommand("setContext", `dataverse-powertools.${key}`, false);
   }
 
-  const presentTypes = new Set<string>();
-  for (const component of context.components) {
-    if (component.settings.type) {
-      presentTypes.add(component.settings.type);
+  // Initialise EVERY typed component on load (#146) — not just the first of each type —
+  // so each component's scoped Test Explorer controller + watchers are created (safe now
+  // that controller ids are per-component, #124). Type context keys set inside initialise*
+  // are idempotent. A legacy single-project workspace resolves to one root component and
+  // behaves exactly as before; a workspace whose only type is on the (undiscovered) root
+  // falls back to the base context.
+  const toInitialise = componentsToInitialise(context.components);
+  if (toInitialise.length > 0) {
+    for (const component of toInitialise) {
+      const activation = getProjectTypeActivation(component.settings.type);
+      if (!activation) {
+        continue;
+      }
+      const scoped = componentScopedContext(context, component);
+      await activation.initialise(scoped);
+      // Stale config-file detection (#113): offer the one-click refresh.
+      checkConfigRevision(scoped);
     }
-  }
-  if (presentTypes.size === 0 && context.projectSettings.type) {
-    presentTypes.add(context.projectSettings.type);
-  }
-
-  for (const type of presentTypes) {
-    const activation = getProjectTypeActivation(type);
-    if (!activation) {
-      continue;
+  } else if (context.projectSettings.type) {
+    const activation = getProjectTypeActivation(context.projectSettings.type);
+    if (activation) {
+      await activation.initialise(context);
+      checkConfigRevision(context);
     }
-    const first = componentsOfType(context.components, type)[0];
-    const scoped = first ? componentScopedContext(context, first) : context;
-    await activation.initialise(scoped);
-    // Stale config-file detection (#113): offer the one-click refresh.
-    checkConfigRevision(scoped);
   }
   context.refreshPanel?.();
 }


### PR DESCRIPTION
Fixes #146. Milestone: **0.9.0 Foundation & Quality**.

## The bug
The activation loop (`extension.ts`) initialised once per project **type**, using `componentsOfType(...)[0]`. So in a workspace with two plugin (or two web-resource) components, only the **first** got its scoped Test Explorer controller + registrations watcher on load — the second component's tests didn't appear in the Testing side bar until it was re-added.

## The fix
Iterate **every** typed component instead of the first-of-each-type. This is safe **only because** the #124 fix made controller ids per-component with a dispose-on-reinit registry — before that, per-component init on load would have crashed with "duplicate controller with ID." Type context keys inside `initialise*` are idempotent; the modelbuilder tree is singleton-guarded; the decoration CodeLens registers once globally.

- New pure `componentsToInitialise()` in `discovery.ts` selects the set (every supported-type component; excludes the connection-only root and unknown types), **unit-tested** — including the #146 case (returns *both* of each type) and the legacy single-project case (one root component, unchanged).
- Single-project workspaces resolve to one root component → identical behaviour to before.

## Verify
- unit **389 passing** (+3), integration **6/6** (extension still activates cleanly with the per-component loop), lint + compile clean.
- Behaviour change is scoped to multi-component load; the e2e blank-root two-of-each suite is the org-level gate.

Follow-up (#147): a fixture-based integration test that activates a two-of-each workspace and asserts a controller per component — deeper guard than the pure-selection unit test here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)