### PR TITLE
fix(#147): remove two dead plugin commands + guard against dead declarations

### DIFF
--- a/package.json
+++ b/package.json
@@ -86,11 +86,6 @@
           "group": "inline"
         },
         {
-          "command": "dataverse-powertools.togglePluginEmitEntityEtc",
-          "when": "view == dataversePowerToolsTree && viewItem == EmitEntityEtcSetting",
-          "group": "inline"
-        },
-        {
           "command": "dataverse-powertools.editModelBuilderSetting",
           "when": "view == dataversePowerToolsTree && (viewItem == ModelBuilderSetting || viewItem == ModelBuilderFilterItem)",
           "group": "inline"
@@ -368,20 +363,6 @@
         "icon": {
           "light": "media/light/edit.svg",
           "dark": "media/dark/edit.svg"
-        }
-      },
-      {
-        "command": "dataverse-powertools.editPluginMessageFilter",
-        "title": "Dataverse PowerTools: Edit Plugin Message Filter",
-        "enablement": "dataverse-powertools.showLoaded && dataverse-powertools.isPlugin && dataverse-powertools.isPluginV3"
-      },
-      {
-        "command": "dataverse-powertools.togglePluginEmitEntityEtc",
-        "title": "Dataverse PowerTools: Toggle Emit Entity Type Code",
-        "enablement": "dataverse-powertools.showLoaded && dataverse-powertools.isPlugin && dataverse-powertools.isPluginV3",
-        "icon": {
-          "light": "media/light/sync.svg",
-          "dark": "media/dark/sync.svg"
         }
       },
       {

--- a/src/projectTypes/registry.ts
+++ b/src/projectTypes/registry.ts
@@ -95,8 +95,6 @@ export const projectTypeRegistry: readonly ProjectTypeDescriptor[] = [
       `${prefix}addWorkflowDecoration`,
       `${prefix}updateFilteringAttributes`,
       `${prefix}editModelBuilderSetting`,
-      `${prefix}editPluginMessageFilter`,
-      `${prefix}togglePluginEmitEntityEtc`,
       `${prefix}viewPluginTraceLogs`,
       `${prefix}downloadPluginProfiles`,
       `${prefix}capturePluginRun`,

--- a/src/test/suite/commandRegistration.test.ts
+++ b/src/test/suite/commandRegistration.test.ts
@@ -1,6 +1,7 @@
 import * as assert from "assert";
 import * as vscode from "vscode";
 import { projectTypeActivations } from "../../projectTypes/activation";
+import { projectTypeRegistry } from "../../projectTypes/registry";
 
 // Integration test (real VS Code extension host): activate the extension and assert
 // its command wiring. Catches renamed/missing commands and a broken
@@ -28,6 +29,18 @@ suite("Command registration (integration)", () => {
     const expected = Object.values(projectTypeActivations).flatMap((activation) => Object.keys(activation.commands));
     const missing = expected.filter((id) => !registered.has(id));
     assert.deepStrictEqual(missing, [], `commands in activation.commands not registered: ${missing.join(", ")}`);
+  });
+
+  test("every registry command is registered, or is a known lazily-registered one (#147 — no dead declarations)", async () => {
+    // The registry's commandIds are declared AND contributed in package.json but must also
+    // be REGISTERED somewhere — otherwise they show in the Command Palette and fail
+    // "command not found" when invoked (as editPluginMessageFilter/togglePluginEmitEntityEtc
+    // did until they were removed). Everything except the lazily-registered modelbuilder tree
+    // editor (created on first openEarlyboundConfig) is registered at activation.
+    const registered = new Set(await vscode.commands.getCommands(true));
+    const KNOWN_LAZY = new Set(["dataverse-powertools.editModelBuilderSetting"]);
+    const orphans = projectTypeRegistry.flatMap((descriptor) => [...descriptor.commandIds]).filter((id) => !registered.has(id) && !KNOWN_LAZY.has(id));
+    assert.deepStrictEqual(orphans, [], `registry commands neither registered nor known-lazy (dead / unwired): ${orphans.join(", ")}`);
   });
 
   test("the decoration CodeLens commands are registered globally (not per plugin component, #124)", async () => {


### PR DESCRIPTION
Part of #147 (command-registration completeness). Milestone: **0.9.0 Foundation & Quality**.

## The bug (found while building the completeness guard)
Two commands were declared in the registry **and** contributed in `package.json` — so they appeared in the **Command Palette** with titles — but were **never registered** by any code path. Invoking either failed *"command not found"*:
- `dataverse-powertools.editPluginMessageFilter`
- `dataverse-powertools.togglePluginEmitEntityEtc` (its inline menu also targeted a `viewItem`, `EmitEntityEtcSetting`, that the modelbuilder tree no longer produces)

Both were superseded by the generic `editModelBuilderSetting` tree-row editor (the "Emit Entity Type Code" / message-filter rows now route through it).

## Fix
- Removed both from `projectTypes/registry.ts` `commandIds` and `package.json` (command declarations + the dead menu entry). registry↔package.json parity still holds.
- **Guard added** (integration test): *every* registry command must be registered after activation — or be the single known lazily-registered one (`editModelBuilderSetting`, created on first `openEarlyboundConfig`). A dead/unwired declaration now fails the test, so the next one can't ship. Confirmed it goes red on the removed commands and green after.

Also verified the other 20+ plugin registry commands are all genuinely wired (not just these two) — no further dead declarations.

## Verify
- unit **389**, integration **7/7** (new guard passes), registry parity green, lint + compile clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)