### PR TITLE
feat(#126): first-create onboarding when adding a Web Resources component

### DIFF
--- a/src/components/addComponent.ts
+++ b/src/components/addComponent.ts
@@ -220,6 +220,14 @@ export async function addComponent(context: DataversePowerToolsContext): Promise
     },
   );
   vscode.window.showInformationMessage(`${descriptor.displayName} component added in ${folderName} (inherits the workspace connection).`);
+
+  // First-create onboarding (#126) — e.g. web resources generate typings + offer a class.
+  // Best-effort: the component is already added, so a hiccup here must not fail Add Component.
+  try {
+    await getProjectTypeActivation(descriptor.id)?.onComponentAdded?.(scoped);
+  } catch (error) {
+    scoped.channel.appendLine(`[Add Component] Post-add onboarding failed (non-fatal): ${error}`);
+  }
 }
 
 /** Convert a single-typed-project workspace into a components workspace (#118): move

--- a/src/projectTypes/activation.ts
+++ b/src/projectTypes/activation.ts
@@ -64,6 +64,11 @@ export interface ProjectTypeActivation {
   onProjectScaffolded?(context: DataversePowerToolsContext): Promise<void>;
   /** Runs during createNewProject after generalInitialise (per-type first-run steps). */
   onProjectCreated?(context: DataversePowerToolsContext): Promise<void>;
+  /** Runs after a component is added via Add Component (#126), once it's scaffolded,
+   * restored and initialised — the first-create niceties the standalone create flow gets
+   * (e.g. generate typings, offer to create a class). Best-effort: the component already
+   * exists, so a failure here doesn't fail Add Component. */
+  onComponentAdded?(context: DataversePowerToolsContext): Promise<void>;
 }
 
 function isPluginV3(context: DataversePowerToolsContext): boolean {
@@ -241,6 +246,24 @@ export const projectTypeActivations: Record<ProjectTypes, ProjectTypeActivation>
             await createWebResourceClass(context);
           }
         });
+    },
+    async onComponentAdded(context) {
+      // First-create onboarding for a Web Resources component added via Add Component
+      // (#126): generate typings, then offer to create a class — the same niceties the
+      // standalone create flow (onProjectCreated) gives. initialiseWebresources already ran
+      // via initialise(). Typings is best-effort (needs a live connection).
+      try {
+        await generateTypings(context);
+      } catch (error) {
+        context.channel.appendLine(`[Add Component] Generate typings skipped (non-fatal): ${error}`);
+      }
+      // Offer via a NON-blocking notification (fire-and-forget): a quick pick would block
+      // adding further components. The user can ignore it and add more.
+      void vscode.window.showInformationMessage("Web Resources component added. Create a web resource class?", "Create class").then(async (choice) => {
+        if (choice === "Create class") {
+          await createWebResourceClass(context);
+        }
+      });
     },
   },
   [ProjectTypes.solution]: {

--- a/src/ui-test/e2e/blankRootComponents.e2e.ts
+++ b/src/ui-test/e2e/blankRootComponents.e2e.ts
@@ -211,6 +211,9 @@ describe("Blank root + two components of each type (e2e)", function () {
     expect(settings.prefix, "component carries the inherited publisher prefix").to.be.a("string").and.not.equal("");
     expect(webpackCommon, "webpack.common.js uses the real prefix").to.contain(`${settings.prefix}_library.js`);
     await waitForAddComplete(2); // root + webresources — don't let the next add overlap
+    // #126: Add Component auto-generates typings for the new web-resource component; gate on
+    // its output so the run doesn't proceed while typings is still generating.
+    expect(await waitForFile(path.join(workspace, "webresources", "webresources_src", "lib", "dg.xrmquery.web.min.js"), 300000), "typings generated on add (#126)").to.equal(true);
   });
 
   it("adds a SECOND Web Resources component into a distinct subfolder", async () => {
@@ -226,6 +229,11 @@ describe("Blank root + two components of each type (e2e)", function () {
     expect(webpackCommon, "SOLUTIONPREFIX substituted in the second component too").to.not.contain("SOLUTIONPREFIX");
     expect(webpackCommon).to.contain(`${settings.prefix}_library.js`);
     await waitForAddComplete(3); // root + webresources + webresources2
+    // #126: gate on the auto-generated typings before proceeding (see the first add).
+    expect(
+      await waitForFile(path.join(workspace, "webresources2", "webresources_src", "lib", "dg.xrmquery.web.min.js"), 300000),
+      "typings generated on second add (#126)",
+    ).to.equal(true);
     // The second web-resource component's Test Explorer controller must get a distinct id —
     // a duplicate id makes Add Component throw "duplicate controller with ID" (#47).
     await assertCommandDidNotError("second Web Resources add");


### PR DESCRIPTION
Fixes #126. Milestone: **0.9.0 Foundation & Quality**.

## The gap
Adding a Web Resources component into a blank root gave a thinner experience than the standalone create flow (`onProjectCreated`): **no auto typings, no offer to create a class**.

## The change
- New optional `ProjectTypeActivation.onComponentAdded(context)` hook, run **best-effort** by `addComponent` after the component is scaffolded/restored/initialised — a failure there can't fail Add Component (the component already exists).
- **Web Resources** `onComponentAdded`: generate typings (best-effort; needs a live connection), then offer to create a class via a **non-blocking notification** ("Create a web resource class?"). A quick pick would block adding further components, so it's a fire-and-forget toast.
- Blank-root e2e updated to gate each web-resource add on the auto-generated typings output (`webresources_src/lib/dg.xrmquery.web.min.js`), so the run doesn't overlap the typings generation; the offer toast is non-blocking (cleared by `dismissOverlays`).

## Verify
- lint, compile, compile-tests, unit **389** green.
- This changes the Add Component flow, so the **blank-root e2e is the org-level gate** (it validates typings-on-add end to end). Not run here per the no-e2e directive — worth a VM run before the next release to confirm the timing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)