### PR TITLE
feat(#156): panel + project-type UX for multi-component workspaces

### DIFF
--- a/media/menuPanel.js
+++ b/media/menuPanel.js
@@ -174,6 +174,17 @@
   function renderProject(card) {
     const c = el("section", "card");
     const row = el("div", "head");
+    // Minimise/expand toggle (#156) — only sub-component cards (dndId set) collapse.
+    if (card.dndId) {
+      const caret = el("button", "iconbtn caret");
+      caret.type = "button";
+      caret.textContent = card.collapsed ? "▸" : "▾";
+      caret.setAttribute("aria-label", (card.collapsed ? "Expand" : "Collapse") + " " + card.name);
+      caret.addEventListener("click", function () {
+        toggleCardCollapse(card.dndId);
+      });
+      row.appendChild(caret);
+    }
     row.appendChild(el("span", "title", card.name));
     row.appendChild(el("span", "badge type", card.typeLabel));
     row.appendChild(el("span", "grow"));
@@ -186,21 +197,24 @@
     if (card.detail) {
       c.appendChild(el("div", "small", card.detail));
     }
-    c.appendChild(button({ command: card.primary.command, args: card.primary.args, label: "▶ " + card.primary.label }, "action primary big"));
-    if (card.secondary.length) {
-      const secondaryRow = el("div", "secondary-row");
-      for (const action of card.secondary) {
-        secondaryRow.appendChild(button(action, "action"));
+    // Collapsed cards show just name/type/detail/status — hide the action rows (#156).
+    if (!card.collapsed) {
+      c.appendChild(button({ command: card.primary.command, args: card.primary.args, label: "▶ " + card.primary.label }, "action primary big"));
+      if (card.secondary.length) {
+        const secondaryRow = el("div", "secondary-row");
+        for (const action of card.secondary) {
+          secondaryRow.appendChild(button(action, "action"));
+        }
+        c.appendChild(secondaryRow);
       }
-      c.appendChild(secondaryRow);
-    }
-    // Web-resource cards embed their own Form Registrations, right under the buttons.
-    if (card.registrations) {
-      c.appendChild(registrationsBlock(card.registrations));
-    }
-    // Plugin cards embed the profiler/debugging workflow.
-    if (card.debugging) {
-      c.appendChild(debuggingBlock(card.debugging));
+      // Web-resource cards embed their own Form Registrations, right under the buttons.
+      if (card.registrations) {
+        c.appendChild(registrationsBlock(card.registrations));
+      }
+      // Plugin cards embed the profiler/debugging workflow.
+      if (card.debugging) {
+        c.appendChild(debuggingBlock(card.debugging));
+      }
     }
     if (card.status) {
       const status = el("div", "statusline");
@@ -225,20 +239,32 @@
   // --- drag-and-drop layout (#118) ---
   let dragId = null;
   let lastCards = [];
+  let lastMultiComponent = false;
 
+  // Reconstruct the full layout from the rendered cards. collapsedCards (#156) is the set
+  // of cards whose collapse DIFFERS from the workspace default (multiComponent) — derived
+  // from each card's rendered `collapsed`, so it round-trips through a re-render.
   function deriveLayout(cards) {
     const order = [];
     const groups = [];
+    const collapsedCards = [];
+    function noteCollapse(p) {
+      if (p.dndId && !!p.collapsed !== lastMultiComponent) {
+        collapsedCards.push(p.dndId);
+      }
+    }
     for (const card of cards) {
       if (card.kind === "project" && card.dndId) {
         order.push(card.dndId);
+        noteCollapse(card);
       } else if (card.kind === "group") {
         const members = card.projects.filter((p) => p.dndId).map((p) => p.dndId);
         order.push.apply(order, members);
         groups.push({ name: card.name, members: members, collapsed: card.collapsed });
+        card.projects.forEach(noteCollapse);
       }
     }
-    return { order: order, groups: groups };
+    return { order: order, groups: groups, collapsedCards: collapsedCards };
   }
 
   function moveCard(layout, id, targetId, after) {
@@ -254,7 +280,7 @@
     const order = layout.order.filter((x) => x !== id);
     const oi = order.indexOf(targetId);
     order.splice(after ? oi + 1 : oi, 0, id);
-    return { order: order, groups: groups.filter((g) => g.members.length) };
+    return { order: order, groups: groups.filter((g) => g.members.length), collapsedCards: layout.collapsedCards };
   }
 
   function addToGroup(layout, id, groupName) {
@@ -272,7 +298,20 @@
     });
     order.splice(lastIdx + 1, 0, id);
     g.members.push(id);
-    return { order: order, groups: groups };
+    return { order: order, groups: groups, collapsedCards: layout.collapsedCards };
+  }
+
+  // Toggle a card's minimise state (#156): flip its membership in collapsedCards (the
+  // override set), which flips its rendered `collapsed` on the next model.
+  function toggleCardCollapse(dndId) {
+    const layout = deriveLayout(lastCards);
+    const i = layout.collapsedCards.indexOf(dndId);
+    if (i === -1) {
+      layout.collapsedCards.push(dndId);
+    } else {
+      layout.collapsedCards.splice(i, 1);
+    }
+    sendLayout(layout);
   }
 
   function sendLayout(layout) {
@@ -343,6 +382,19 @@
     head.appendChild(caret);
     head.appendChild(el("span", "group-name grow-text", card.name));
     head.appendChild(el("span", "small", card.projects.length + ""));
+    // Ungroup (#156): dissolve the group; members fall back to the ungrouped list in order
+    // (deriveLayout already keeps them in `order`, so dropping the group entry is enough).
+    const ungroup = el("button", "iconbtn");
+    ungroup.type = "button";
+    ungroup.textContent = "⊗";
+    ungroup.title = "Ungroup";
+    ungroup.setAttribute("aria-label", "Ungroup " + card.name);
+    ungroup.addEventListener("click", function () {
+      const layout = deriveLayout(lastCards);
+      layout.groups = layout.groups.filter((g) => g.name !== card.name);
+      sendLayout(layout);
+    });
+    head.appendChild(ungroup);
     // Header is a drop target: dropping a card here adds it to the group.
     head.addEventListener("dragover", function (e) {
       if (dragId) {
@@ -543,6 +595,7 @@
     closeOverflow();
     root.replaceChildren();
     lastCards = message.model.cards;
+    lastMultiComponent = !!message.model.multiComponent;
     let draggableCount = 0;
     for (const card of message.model.cards) {
       if ((card.kind === "project" && card.dndId) || card.kind === "group") {

--- a/src/components/addComponent.ts
+++ b/src/components/addComponent.ts
@@ -23,35 +23,6 @@ function sanitizeFolderName(input: string): string | undefined {
   return trimmed;
 }
 
-/** When the workspace root is itself a typed project (the single-project layout),
- * offer to switch to the nested layout before adding the second component: move
- * the existing project into a subfolder and leave a connection-only root behind,
- * exactly like the "Empty (components in subfolders)" wizard option. Returns
- * false when the user cancels the whole Add Component flow. */
-async function offerNestedMigration(context: DataversePowerToolsContext, workspaceRoot: string): Promise<boolean> {
-  if (!context.projectSettings.type) {
-    return true; // root is already connection-only — nothing to migrate
-  }
-  const typeName = getProjectTypeDescriptor(context.projectSettings.type)?.displayName ?? context.projectSettings.type;
-  const pick = await vscode.window.showQuickPick(
-    [
-      { label: `Yes — move the ${typeName} project into a subfolder first`, description: "recommended", target: "migrate" },
-      { label: "No — keep it at the root and nest the new component inside it", target: "keep" },
-    ],
-    {
-      placeHolder: `This workspace is a single ${typeName} project. Switch to the nested layout (connection-only root, one subfolder per component)?`,
-      ignoreFocusOut: true,
-    },
-  );
-  if (!pick) {
-    return false;
-  }
-  if (pick.target === "keep") {
-    return true;
-  }
-  return performNestedMigration(context, workspaceRoot, typeName);
-}
-
 /** Move the current typed root project into a subfolder so the workspace root
  * becomes connection-only (Empty). Returns true when the migration completed (#118). */
 export async function performNestedMigration(context: DataversePowerToolsContext, workspaceRoot: string, typeName: string): Promise<boolean> {
@@ -122,6 +93,21 @@ export async function addComponent(context: DataversePowerToolsContext): Promise
     return;
   }
 
+  // Cap single-type projects at one component (#156): only the multi-component container
+  // (connection-only root) may hold 2+. A typed single-project root must be converted
+  // explicitly first — no silent nested-migration-into-a-sibling from here.
+  if (context.projectSettings.type) {
+    const typeName = getProjectTypeDescriptor(context.projectSettings.type)?.displayName ?? context.projectSettings.type;
+    const choice = await vscode.window.showInformationMessage(
+      `This is a single ${typeName} project. To hold more than one component, convert it to a multi-component project first.`,
+      "Convert to a multi-component project",
+    );
+    if (choice === "Convert to a multi-component project") {
+      await convertToComponentsWorkspace(context);
+    }
+    return;
+  }
+
   const typePick = await vscode.window.showQuickPick(
     projectTypeRegistry.map((d) => ({ label: d.displayName, target: d })),
     { placeHolder: "Which component type?" },
@@ -130,12 +116,6 @@ export async function addComponent(context: DataversePowerToolsContext): Promise
     return;
   }
   const descriptor = typePick.target;
-
-  // Single-project root? Offer the switch to the nested layout first (the
-  // existing project moves into a subfolder, the root goes connection-only).
-  if (!(await offerNestedMigration(context, workspaceRoot))) {
-    return;
-  }
 
   const folderInput = await vscode.window.showInputBox({
     ignoreFocusOut: true,

--- a/src/components/discovery.ts
+++ b/src/components/discovery.ts
@@ -189,6 +189,11 @@ export interface Layout {
   order?: string[];
   /** Named groups; a component belongs to at most one (first that lists it). */
   groups?: LayoutGroup[];
+  /** Component cards (by relativeRoot) whose collapse state DIFFERS from the workspace
+   * default (#156). The default is collapsed for a multi-component workspace, expanded for
+   * a single-component one — so this is the set of user overrides; a card's rendered
+   * collapse is `multiComponent XOR collapsedCards.includes(relativeRoot)`. */
+  collapsedCards?: string[];
 }
 
 /** One top-level row of the arranged sidebar: a standalone item or a group. Generic

--- a/src/general/connectionStringManager.ts
+++ b/src/general/connectionStringManager.ts
@@ -411,10 +411,11 @@ export type ProjectTypePick = "cancelled" | "empty" | "selected";
 export async function getProjectType(context: DataversePowerToolsContext): Promise<ProjectTypePick> {
   const result = await window.showQuickPick(
     [
+      // The multi-component container floated to the top (#156): a connection-only root
+      // with each component in its own subfolder — the recommended layout for anything
+      // beyond a single project. `target: undefined` keeps the connection-only-root semantics.
+      { label: "Multi-component project (two or more types)", description: "one connection-only root; each component in its own subfolder", target: undefined },
       ...projectTypeRegistry.map((d) => ({ label: d.displayName, description: d.displayName, target: d.id as string | undefined })),
-      // A connection-only root: components are added into subfolders later
-      // (Add Component), with no parent project type (user feedback).
-      { label: "Empty (components in subfolders)", description: "connection-only root — add components later", target: undefined },
     ],
     { placeHolder: "Select a Project Type." },
   );

--- a/src/panel/menuModel.spec.ts
+++ b/src/panel/menuModel.spec.ts
@@ -349,11 +349,17 @@ describe("project layout (#118)", () => {
 });
 
 describe("sanitizeLayout (#118 untrusted webview input)", () => {
-  it("keeps well-formed order + groups", () => {
-    expect(sanitizeLayout({ order: ["a", "b"], groups: [{ name: "G", members: ["a"], collapsed: true }] })).toEqual({
+  it("keeps well-formed order + groups + collapsedCards", () => {
+    expect(sanitizeLayout({ order: ["a", "b"], groups: [{ name: "G", members: ["a"], collapsed: true }], collapsedCards: ["b"] })).toEqual({
       order: ["a", "b"],
       groups: [{ name: "G", members: ["a"], collapsed: true }],
+      collapsedCards: ["b"],
     });
+  });
+
+  it("keeps only string ids in collapsedCards (#156, untrusted)", () => {
+    expect(sanitizeLayout({ collapsedCards: ["a", 3, null, "b"] }).collapsedCards).toEqual(["a", "b"]);
+    expect(sanitizeLayout({ collapsedCards: "nope" }).collapsedCards).toEqual([]);
   });
 
   it("drops non-strings, nameless/empty groups, and caps the name", () => {
@@ -363,8 +369,48 @@ describe("sanitizeLayout (#118 untrusted webview input)", () => {
   });
 
   it("tolerates junk", () => {
-    expect(sanitizeLayout(undefined)).toEqual({ order: [], groups: [] });
-    expect(sanitizeLayout("nope")).toEqual({ order: [], groups: [] });
+    expect(sanitizeLayout(undefined)).toEqual({ order: [], groups: [], collapsedCards: [] });
+    expect(sanitizeLayout("nope")).toEqual({ order: [], groups: [], collapsedCards: [] });
     expect(sanitizeLayout({ order: "x" }).order).toEqual([]);
+  });
+});
+
+describe("card minimise default (#156)", () => {
+  const webState = (over: Partial<PanelState> = {}): PanelState =>
+    state({
+      loaded: true,
+      projects: [project({ type: "webresources", relativeRoot: "web1", isRoot: false }), project({ type: "plugin", relativeRoot: "plugin1", isRoot: false })],
+      ...over,
+    });
+  const projectCards = (s: PanelState) => buildMenuModel(s).cards.filter((c) => c.kind === "project") as Extract<Card, { kind: "project" }>[];
+
+  it("multi-component workspace defaults all component cards to collapsed", () => {
+    const collapsed = projectCards(webState({ multiComponent: true })).map((c) => c.collapsed);
+    expect(collapsed).toEqual([true, true]);
+  });
+
+  it("single-component workspace shows cards expanded", () => {
+    const collapsed = projectCards(webState({ multiComponent: false })).map((c) => c.collapsed);
+    expect(collapsed).toEqual([false, false]);
+  });
+
+  it("collapsedCards overrides the default per card (multi → expand one; single → collapse one)", () => {
+    // Multi default collapsed; overriding web1 expands just it.
+    let cards = projectCards(webState({ multiComponent: true, layout: { collapsedCards: ["web1"] } }));
+    expect(cards.map((c) => [c.dndId, c.collapsed])).toEqual([
+      ["web1", false],
+      ["plugin1", true],
+    ]);
+    // Single default expanded; overriding web1 collapses just it.
+    cards = projectCards(webState({ multiComponent: false, layout: { collapsedCards: ["web1"] } }));
+    expect(cards.map((c) => [c.dndId, c.collapsed])).toEqual([
+      ["web1", true],
+      ["plugin1", false],
+    ]);
+  });
+
+  it("exposes multiComponent on the model for the webview override maths", () => {
+    expect(buildMenuModel(webState({ multiComponent: true })).multiComponent).toBe(true);
+    expect(buildMenuModel(webState({ multiComponent: false })).multiComponent).toBe(false);
   });
 });

--- a/src/panel/menuModel.ts
+++ b/src/panel/menuModel.ts
@@ -93,6 +93,8 @@ export type Card =
       detail?: string;
       /** relativeRoot — the drag id for reordering/grouping (#118); "" for the root card (not draggable). */
       dndId: string;
+      /** Card minimised (#156): the webview hides the action rows, shows just name/type/status. */
+      collapsed: boolean;
       primary: MenuAction;
       secondary: MenuAction[];
       overflow: MenuAction[];
@@ -109,6 +111,9 @@ export type Card =
 
 export interface MenuModel {
   cards: Card[];
+  /** More than one component — cards default to minimised; the webview reconstructs the
+   * per-card collapse OVERRIDES (collapsedCards) as `collapsed !== multiComponent` (#156). */
+  multiComponent: boolean;
   footer: {
     /** All requirements green — render the collapsed "✓ requirements" line. */
     requirementsOk: boolean;
@@ -168,6 +173,8 @@ export interface PanelState {
   layout?: Layout;
   /** The root is connection-only (Empty) — Add Component is offered only then (#118). */
   rootIsEmpty?: boolean;
+  /** More than one discovered component — cards default to minimised (#156). */
+  multiComponent?: boolean;
 }
 
 /** Full walkthrough reference: <publisher>.<extension>#<walkthrough id in package.json>. */
@@ -191,7 +198,7 @@ export const ALLOWED_EXTERNAL_URLS: readonly string[] = [...Object.values(DOWNLO
 /** Validate a layout arriving from the webview (untrusted) into a well-formed shape (#118).
  * Keeps only string ids, caps group names, drops empty/nameless groups. Pure. */
 export function sanitizeLayout(raw: unknown): Layout {
-  const obj = (raw ?? {}) as { order?: unknown; groups?: unknown };
+  const obj = (raw ?? {}) as { order?: unknown; groups?: unknown; collapsedCards?: unknown };
   const order = Array.isArray(obj.order) ? obj.order.filter((x): x is string => typeof x === "string") : [];
   const groups = Array.isArray(obj.groups)
     ? obj.groups
@@ -203,7 +210,9 @@ export function sanitizeLayout(raw: unknown): Layout {
         }))
         .filter((g) => g.name && g.members.length)
     : [];
-  return { order, groups };
+  // Per-card collapse overrides (#156) — untrusted webview input, keep only string ids.
+  const collapsedCards = Array.isArray(obj.collapsedCards) ? obj.collapsedCards.filter((x): x is string => typeof x === "string") : [];
+  return { order, groups, collapsedCards };
 }
 
 /** Short environment name from the org URL: https://contoso.crm.dynamics.com -> contoso. */
@@ -317,7 +326,7 @@ function footerFor(state: PanelState, cards: Card[]): MenuModel["footer"] {
 export function buildMenuModel(state: PanelState): MenuModel {
   if (state.detecting) {
     const cards: Card[] = [{ kind: "notice", id: "detecting", text: "Getting things ready — detecting your Dataverse project…", spinner: true }];
-    return { cards, footer: footerFor(state, cards) };
+    return { cards, multiComponent: !!state.multiComponent, footer: footerFor(state, cards) };
   }
 
   if (!state.loaded) {
@@ -333,7 +342,7 @@ export function buildMenuModel(state: PanelState): MenuModel {
       },
       requirementsCard(state),
     ];
-    return { cards, footer: footerFor(state, cards) };
+    return { cards, multiComponent: !!state.multiComponent, footer: footerFor(state, cards) };
   }
 
   const cards: Card[] = [environmentCard(state)];
@@ -369,6 +378,9 @@ export function buildMenuModel(state: PanelState): MenuModel {
       typeLabel: descriptor.displayName.toUpperCase(),
       detail: project.isRoot ? project.detail : [project.relativeRoot, project.detail].filter(Boolean).join(" · "),
       dndId: project.isRoot ? "" : project.relativeRoot,
+      // Minimised by default in a multi-component workspace; collapsedCards holds the
+      // user's overrides so a manual expand/collapse persists (#156). Root card never collapses.
+      collapsed: !project.isRoot && state.multiComponent !== (state.layout?.collapsedCards ?? []).includes(project.relativeRoot),
       primary: forComponent({ ...menu.primary, label: menu.primary.label.replace("{environment}", environment) }, project),
       secondary: menu.secondary.map((action) => forComponent(action, project)),
       overflow: [...menu.overflow, { command: "dataverse-powertools.restoreDependencies", label: "Restore dependencies" }].map((action) => forComponent(action, project)),
@@ -413,7 +425,7 @@ export function buildMenuModel(state: PanelState): MenuModel {
     id: "addComponent",
     actions: [
       state.rootIsEmpty === false
-        ? { command: "dataverse-powertools.convertToComponentsWorkspace", label: "Convert to a components workspace…" }
+        ? { command: "dataverse-powertools.convertToComponentsWorkspace", label: "Convert to a multi-component project…" }
         : { command: "dataverse-powertools.addComponent", label: "＋ Add Component…" },
     ],
   });
@@ -426,5 +438,5 @@ export function buildMenuModel(state: PanelState): MenuModel {
     cards.push(requirementsCard(state));
   }
 
-  return { cards, footer: footerFor(state, cards) };
+  return { cards, multiComponent: !!state.multiComponent, footer: footerFor(state, cards) };
 }

--- a/src/panel/panelState.ts
+++ b/src/panel/panelState.ts
@@ -103,5 +103,7 @@ export function computePanelState(context: DataversePowerToolsContext): PanelSta
     // whether the root is connection-only (Empty) vs a typed single-project root.
     layout: (settings.layout as PanelState["layout"]) ?? undefined,
     rootIsEmpty: loaded ? !settings.type : undefined,
+    // More than one discovered component → the panel minimises cards by default (#156).
+    multiComponent: (context.components?.length ?? 0) > 1,
   };
 }

--- a/src/ui-test/e2e/blankRootComponents.e2e.ts
+++ b/src/ui-test/e2e/blankRootComponents.e2e.ts
@@ -174,7 +174,7 @@ describe("Blank root + two components of each type (e2e)", function () {
     await resetAllCredentials(log);
     await runCommand("Dataverse PowerTools: Initialise Project");
     log("project type: Empty");
-    await pickByLabel("Empty (components in subfolders)");
+    await pickByLabel("Multi-component project (two or more types)");
     log("auth type");
     await pickByLabel("Service principal (client secret)");
     await answerText(env!.tenantId);


### PR DESCRIPTION
Fixes #156. Milestone: **0.9.0 Foundation & Quality**.

Five refinements to the panel + new-project flow for multi-component workspaces (#47/#118):

1. **Ungroup** — a group header ⊗ dissolves the group; members return to the ungrouped list in order.
2. **Minimise individual cards** — each component card gets a collapse caret (mirrors the group one); collapsed hides the action rows, keeps name/type/detail/status. Persisted via a new `Layout.collapsedCards` (validated in `sanitizeLayout`).
3. **Multi-component default minimised** — with >1 component, cards default collapsed. The rendered collapse is `multiComponent XOR collapsedCards.includes(id)`, so `collapsedCards` holds the user's *overrides* and a manual expand/collapse persists and wins on reload.
4. **Cap single-type projects at one component** — a typed single-project root no longer silently nests a second sibling; Add Component redirects it to an explicit **Convert to a multi-component project**. Only the connection-only container holds 2+.
5. **Rename + float the multi-component type** — "Empty (components in subfolders)" → **"Multi-component project (two or more types)"**, floated to the top of the new-project selector; convert label + `blankRootComponents.e2e.ts` label updated.

## Tests / verify
- Pure model changes **unit-tested**: `sanitizeLayout` `collapsedCards` round-trip + untrusted-input filtering; card-minimise default (multi collapsed, single expanded) + per-card override; `model.multiComponent`. Unit **394**, lint/compile/compile-tests green.
- **Needs a visual check:** the webview collapse/ungroup DOM interactions (`media/menuPanel.js`) can't be unit- or e2e-validated — worth eyeballing in the running extension (the browser preview / Extension Host) before the 0.9.0 release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)