### PR TITLE
0.9.0 (pre-release) — Foundation & Quality

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 All notable changes to the "dataverse-powertools" extension will be documented in this file.
 
+## 0.9.0 (pre-release)
+
+Foundation & Quality — multi-component polish, safer onboarding, and a real integration test layer.
+
+- **Panel: minimise & organise component cards (#156).** **Ungroup** a group (its members return to the list in order); **minimise/expand individual component cards**; a **multi-component workspace opens with cards minimised** by default (your manual expand/collapse persists and wins next time). A single-type project is now **capped at one component** — to hold more, convert it to a **multi-component project**, which is also renamed and **floated to the top** of the new-project picker ("Multi-component project (two or more types)").
+- **Every component initialises on load (#146).** In a workspace with two components of the same type, the second one's Test Explorer tests + watchers now appear immediately instead of only after re-adding it.
+- **Web Resources onboarding on Add Component (#126).** Adding a Web Resources component now generates typings and offers to create a class — the same first-create experience a standalone project gets.
+- **Removed two broken Command Palette entries (#147)** — *Edit Plugin Message Filter* and *Toggle Emit Entity Type Code* were contributed but never wired up, so they failed "command not found"; both were superseded by the model-builder settings tree.
+- **Under the hood:** a new CI-runnable **integration test layer** (asserts command registration and guards the multi-component Test Explorer wiring), a guard against dead command declarations, and more internal logic extracted to pure, unit-tested modules. Unit coverage 358 → 394.
+
 ## 0.8.6 (pre-release)
 
 Test hardening + safer form-event registration.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "dataverse-powertools",
-  "version": "0.8.6",
+  "version": "0.9.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "dataverse-powertools",
-      "version": "0.8.6",
+      "version": "0.9.0",
       "hasInstallScript": true,
       "dependencies": {
         "@azure/msal-node": "^5.4.0",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "type": "git",
     "url": "https://github.com/pete-mc/dataverse-powertools"
   },
-  "version": "0.8.6",
+  "version": "0.9.0",
   "engines": {
     "vscode": "^1.93.0"
   },

--- a/src/ui-test/e2e/lib.ts
+++ b/src/ui-test/e2e/lib.ts
@@ -133,7 +133,17 @@ async function waitForPicks(input: InputBox, timeoutMs: number): Promise<number>
 export async function pickByLabel(label: string, timeoutMs = 30000): Promise<void> {
   const input = await waitForInput(timeoutMs);
   await waitForPicks(input, Math.min(timeoutMs, 30000));
-  await input.selectQuickPick(label);
+  try {
+    await input.selectQuickPick(label);
+  } catch (err) {
+    // A coordinate click on a quick-pick row can be intercepted by the empty-editor
+    // watermark <p> when the target row isn't first (ElementClickInterceptedError) —
+    // e.g. picking "Plugins" after "Multi-component project" was floated to the top.
+    // Fall back to type-to-filter + Enter, which can't be intercepted.
+    await input.setText(label);
+    await sleep(800);
+    await input.confirm();
+  }
   await sleep(2500);
 }
 


### PR DESCRIPTION
Releases the **0.9.0: Foundation & Quality** milestone accumulated on `main`.

## Highlights
- **Panel: minimise & organise component cards (#156)** — ungroup, per-card minimise, multi-component default-minimised, cap single-type at one component, rename+float the multi-component project type.
- **Every component initialises on load (#146)** — second same-type component's Test Explorer tests/watchers appear immediately (safe thanks to the #124 scoped-controller change).
- **Web Resources onboarding on Add Component (#126)** — auto typings + create-class offer.
- **Removed two broken palette commands (#147)** + a dead-declaration guard.
- **New CI-runnable integration test layer** + more pure-logic extraction. Unit 358 → 394.

## Release gate — please read
This release bundles three **behaviour / UI** changes that CI cannot validate end-to-end:
- **#156** panel collapse/ungroup DOM interactions (`media/menuPanel.js`) — no unit/e2e coverage of the webview.
- **#126** Add-Component typings-on-add timing.
- **#146** per-component init on load.

The pure model + registration logic is unit/integration-tested and CI is green, but I'd recommend, before **merging/publishing** this:
1. run the full **`npm run test:e2e`** on the VM (validates #146/#126 via the blank-root two-of-each suite), and
2. eyeball the **panel** in the Extension Host (collapse a card, ungroup a group, open a multi-component workspace) since #156's webview can't be auto-tested.

Holding the merge/publish for that call.

🤖 Generated with [Claude Code](https://claude.com/claude-code)