### PR TITLE
0.9.1 (pre-release) — Foundation & Quality (cont.)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 All notable changes to the "dataverse-powertools" extension will be documented in this file.
 
+## 0.9.1 (pre-release)
+
+Foundation & Quality (cont.) — test-layer depth, no user-facing change.
+
+- **Plugin-component integration coverage (#147).** A new integration test opens a plugin-component fixture, drives *Configure Earlybound*, and asserts the **full** set of registry commands is registered — closing the gap the no-workspace test couldn't reach (the model-builder tree's `editModelBuilderSetting` registers lazily on first use). A renamed or dropped command in any of the three registration paths now fails in CI instead of only in the manual e2e.
+- **Consolidated the duplicated OData string-escaper (#143).** `escapeODataString` — copy-pasted into four Dataverse Web API modules (plugin/workflow registration, assembly, package) — is now one shared, unit-tested pure module, with tests covering the `$filter` injection shape it exists to prevent. Behaviour is byte-identical.
+- **e2e:** the wizard project-type quick-pick now falls back to keyboard selection when a coordinate click is intercepted by the empty-editor watermark — fixes four plugin-lifecycle e2e steps that broke after the project-type picker was reordered.
+
 ## 0.9.0 (pre-release)
 
 Foundation & Quality — multi-component polish, safer onboarding, and a real integration test layer.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "dataverse-powertools",
-  "version": "0.9.0",
+  "version": "0.9.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "dataverse-powertools",
-      "version": "0.9.0",
+      "version": "0.9.1",
       "hasInstallScript": true,
       "dependencies": {
         "@azure/msal-node": "^5.4.0",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "type": "git",
     "url": "https://github.com/pete-mc/dataverse-powertools"
   },
-  "version": "0.9.0",
+  "version": "0.9.1",
   "engines": {
     "vscode": "^1.93.0"
   },

--- a/src/general/dataverse/getDataversePluginAssembly.ts
+++ b/src/general/dataverse/getDataversePluginAssembly.ts
@@ -3,10 +3,7 @@ import * as fs from "fs";
 import DataversePowerToolsContext from "../../context";
 import { DataverseContext, Options } from "./dataverseContext";
 import { dataverseApiUrl, logDataverseHttpError, logDataverseError } from "./webApi";
-
-function escapeODataString(value: string): string {
-  return value.replace(/'/g, "''");
-}
+import { escapeODataString } from "./odata";
 
 function isStrongNameRequiredError(errorText: string): boolean {
   const lower = errorText.toLowerCase();

--- a/src/general/dataverse/getDataversePluginPackage.ts
+++ b/src/general/dataverse/getDataversePluginPackage.ts
@@ -3,10 +3,7 @@ import * as fs from "fs";
 import DataversePowerToolsContext from "../../context";
 import { DataverseContext, Options } from "./dataverseContext";
 import { dataverseApiUrl, logDataverseHttpError } from "./webApi";
-
-function escapeODataString(value: string): string {
-  return value.replace(/'/g, "''");
-}
+import { escapeODataString } from "./odata";
 
 async function ensureDataverseContext(context: DataversePowerToolsContext): Promise<boolean> {
   if (!context.dataverse) {

--- a/src/general/dataverse/odata.spec.ts
+++ b/src/general/dataverse/odata.spec.ts
@@ -1,0 +1,31 @@
+import { describe, it, expect } from "vitest";
+import { escapeODataString } from "./odata";
+
+describe("escapeODataString", () => {
+  it("leaves quote-free values untouched", () => {
+    expect(escapeODataString("Account")).toBe("Account");
+    expect(escapeODataString("dvpt_MyPlugin.Steps.Create")).toBe("dvpt_MyPlugin.Steps.Create");
+  });
+
+  it("doubles a single quote (the OData escape)", () => {
+    expect(escapeODataString("O'Brien")).toBe("O''Brien");
+  });
+
+  it("doubles every quote, not just the first", () => {
+    expect(escapeODataString("'a'b'")).toBe("''a''b''");
+  });
+
+  it("produces a literal that can't break out of its surrounding quotes", () => {
+    // The injection this exists to stop: a name that closes the literal early.
+    const malicious = "x' or name ne '";
+    const filter = `name eq '${escapeODataString(malicious)}'`;
+    expect(filter).toBe("name eq 'x'' or name ne '''");
+    // Every apostrophe in the interpolated segment is doubled → no lone quote to terminate on.
+    const interpolated = filter.slice("name eq '".length, -1);
+    expect(interpolated.split("'").length % 2).toBe(1); // odd → all quotes balanced/doubled
+  });
+
+  it("handles the empty string", () => {
+    expect(escapeODataString("")).toBe("");
+  });
+});

--- a/src/general/dataverse/odata.ts
+++ b/src/general/dataverse/odata.ts
@@ -1,0 +1,15 @@
+// Pure OData helpers for the Dataverse Web API. Kept vscode-free and unit-tested — the
+// escaping here guards every `$filter=... eq '<value>'` we build against names containing a
+// single quote (which would otherwise break the query, or worse, alter its meaning). This
+// used to be copy-pasted into each getDataverse*/register* file; consolidated so there's one
+// definition to reason about and test (#143).
+
+/**
+ * Escape a string for safe interpolation inside an OData single-quoted literal.
+ *
+ * OData escapes a single quote by doubling it (`O'Brien` → `O''Brien`). Callers still supply
+ * the surrounding quotes: `` `name eq '${escapeODataString(name)}'` ``.
+ */
+export function escapeODataString(value: string): string {
+  return value.replace(/'/g, "''");
+}

--- a/src/general/dataverse/registerPluginSteps.ts
+++ b/src/general/dataverse/registerPluginSteps.ts
@@ -3,6 +3,7 @@ import DataversePowerToolsContext from "../../context";
 import { addDataverseSolutionComponent } from "./addDataverseSolutionComponent";
 import { DataverseContext, Options } from "./dataverseContext";
 import { dataverseApiUrl, logDataverseHttpError } from "./webApi";
+import { escapeODataString } from "./odata";
 
 export interface PluginStepRegistration {
   className: string;
@@ -15,10 +16,6 @@ export interface PluginStepRegistration {
   stepName: string;
   executionOrder: number;
   stepId?: string;
-}
-
-function escapeODataString(value: string): string {
-  return value.replace(/'/g, "''");
 }
 
 async function ensureDataverseContext(context: DataversePowerToolsContext): Promise<boolean> {

--- a/src/general/dataverse/registerWorkflowActivities.ts
+++ b/src/general/dataverse/registerWorkflowActivities.ts
@@ -3,6 +3,7 @@ import DataversePowerToolsContext from "../../context";
 import { addDataverseSolutionComponent } from "./addDataverseSolutionComponent";
 import { DataverseContext, Options } from "./dataverseContext";
 import { dataverseApiUrl, logDataverseHttpError } from "./webApi";
+import { escapeODataString } from "./odata";
 
 export interface WorkflowActivityRegistration {
   className: string;
@@ -29,10 +30,6 @@ interface ExistingWorkflowSnapshot {
 interface ResolvedWorkflowPluginType {
   plugintypeid: string;
   snapshot: ExistingWorkflowSnapshot;
-}
-
-function escapeODataString(value: string): string {
-  return value.replace(/'/g, "''");
 }
 
 function normalizeString(value: string | undefined): string {

--- a/src/test/suite/pluginComponentCommands.test.ts
+++ b/src/test/suite/pluginComponentCommands.test.ts
@@ -1,0 +1,76 @@
+import * as assert from "assert";
+import * as fs from "fs";
+import * as os from "os";
+import * as path from "path";
+import * as vscode from "vscode";
+import { openEarlyboundConfig } from "../../plugins/pluginTables";
+import { projectTypeRegistry } from "../../projectTypes/registry";
+
+// #147: `registry.commandIds` is a SUPERSET of what `registerAllComponentCommands` wires at
+// activation — a few commands register LAZILY. The modelbuilder tree's
+// `editModelBuilderSetting` is created in the `PluginModelBuilderTreeDataProvider`
+// constructor, which only runs on the first "Configure Earlybound" (openEarlyboundConfig).
+// The no-workspace commandRegistration.test can only assert the EAGER set and has to
+// whitelist that one lazy id — so nothing proves the lazy path actually registers it, or
+// that the whitelist stays a whitelist-of-one. This suite drives the real lazy path against
+// a plugin-component fixture and asserts the FULL registry set ends up registered with no
+// remaining gap.
+
+const EXTENSION_ID = "dataversepowertools.dataverse-powertools";
+
+// A minimal stand-in for the scoped plugin-component context openEarlyboundConfig consumes.
+// It touches vscode.subscriptions (to own the registered command + tree view), and
+// activeComponent.root (to locate modelbuilder.json — absent here, so settings load is a
+// graceful no-op). projectSettings starts empty; the loader fills pluginModelBuilder.
+function pluginCtx(root: string): any {
+  return {
+    vscode: { subscriptions: [] as vscode.Disposable[] },
+    activeComponent: { root, relativeRoot: path.basename(root), isRoot: false, settings: { type: "plugin" } },
+    projectSettings: {},
+    channel: { appendLine: () => undefined, show: () => undefined },
+    components: [],
+  };
+}
+
+suite("Plugin-component command registration (integration, #147)", () => {
+  let workspace = "";
+  let pluginRoot = "";
+
+  suiteSetup(async function () {
+    this.timeout(60000);
+    const ext = vscode.extensions.getExtension(EXTENSION_ID);
+    assert.ok(ext, `extension ${EXTENSION_ID} not found in the host`);
+    await ext.activate();
+    workspace = fs.mkdtempSync(path.join(os.tmpdir(), "dvpt-plugin-it-"));
+    pluginRoot = path.join(workspace, "plugin1");
+    fs.mkdirSync(pluginRoot, { recursive: true });
+  });
+
+  suiteTeardown(() => {
+    try {
+      fs.rmSync(workspace, { recursive: true, force: true });
+    } catch {
+      /* best effort */
+    }
+  });
+
+  test("Configure Earlybound registers the lazily-created modelbuilder command (#147)", async () => {
+    // The premise of the whitelist in commandRegistration.test: this command is NOT wired by
+    // registerAllComponentCommands, only by the tree provider's constructor. Driving
+    // openEarlyboundConfig (what the "Configure Earlybound" card action calls) must create it.
+    await openEarlyboundConfig(pluginCtx(pluginRoot));
+    const registered = new Set(await vscode.commands.getCommands(true));
+    assert.ok(registered.has("dataverse-powertools.editModelBuilderSetting"), "editModelBuilderSetting should be registered after Configure Earlybound opens the tree");
+  });
+
+  test("with every registration path driven, the FULL registry.commandIds set is registered — no dead declarations (#147)", async () => {
+    // The gap commandRegistration.test can't reach: once the lazy path has run, EVERY id the
+    // registry declares (and package.json contributes) must be registered. A renamed/dropped
+    // command in any of the three registration paths surfaces here as an orphan, in CI,
+    // without Selenium or a live org.
+    await openEarlyboundConfig(pluginCtx(pluginRoot));
+    const registered = new Set(await vscode.commands.getCommands(true));
+    const orphans = projectTypeRegistry.flatMap((descriptor) => [...descriptor.commandIds]).filter((id) => !registered.has(id));
+    assert.deepStrictEqual(orphans, [], `registry commands still unregistered after driving every registration path: ${orphans.join(", ")}`);
+  });
+});


### PR DESCRIPTION
Test-layer depth for the 0.9.x Foundation & Quality track. No user-facing behaviour change.

## Changes
- **#147 — plugin-component integration test.** New `pluginComponentCommands.test.ts` opens a plugin-component fixture, drives *Configure Earlybound* (`openEarlyboundConfig`), and asserts the **full** `registry.commandIds` set is registered — closing the gap the no-workspace `commandRegistration.test` can only whitelist (the model-builder tree's `editModelBuilderSetting` registers lazily on first use). A renamed/dropped command in any of the three registration paths now fails in CI, not just in the manual e2e. Closes #147.
- **#143 — consolidated the duplicated OData escaper.** `escapeODataString` was copy-pasted byte-identical into four Dataverse Web API modules; it's now one shared, unit-tested pure module (`src/general/dataverse/odata.ts`) with `$filter`-injection tests. Behaviour is identical. Advances the testing epic #143.
- **e2e stability.** `pickByLabel` falls back to keyboard selection when a coordinate click is intercepted by the empty-editor watermark — fixed the four plugin-lifecycle steps that broke after the project-type picker was reordered in 0.9.0.

## Verification
- Verify loop green: lint, webpack compile, `test:coverage` (exit 0), `test:integration` (9 passing incl. 2 new #147 tests).
- Full `npm run test:e2e` on the VM: **43 passing**, log audit clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)