### PR TITLE
0.11.0 (pre-release) — Plugins: deterministic packaging + profiling diagnostics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 All notable changes to the "dataverse-powertools" extension will be documented in this file.
 
+## 0.11.0 (pre-release)
+
+Plugins — deterministic packaging and diagnosable profiling.
+
+- **Deterministic plugin package name + no stale deploys (#134).** *Build Package & Deploy* now clears stale `*.nupkg` from the project's `bin` before packing, so exactly one, correctly prefixed package (`<prefix>_<name>.<version>.nupkg`) is produced and deployed — fixing the intermittent `Plugin.1.0.0` vs `dvpt_Plugin.1.0.0` naming and the occasional stale-DLL deploy. The naming rules now live in one shared, unit-tested module so every path names the package identically.
+- **Profiling explains an empty step list (#135).** When *Profile a step* finds no profilable steps even though steps are registered, the output now breaks down exactly why each was skipped (no resolved plugin type / system / already-profiled / other assembly), so the cause is visible instead of a bare "No registered plugin steps to profile". (The underlying case where a live step's plugin-type lookup returns empty is still under investigation — this makes it diagnosable.)
+
+> Still open in this milestone: the trace-log status tag (#137) and the per-step profiling toggle UX (#139) are larger panel features tracked for a following release.
+
 ## 0.10.0 (pre-release)
 
 Plugins — early-bound authoring quality-of-life.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "dataverse-powertools",
-  "version": "0.10.0",
+  "version": "0.11.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "dataverse-powertools",
-      "version": "0.10.0",
+      "version": "0.11.0",
       "hasInstallScript": true,
       "dependencies": {
         "@azure/msal-node": "^5.4.0",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "type": "git",
     "url": "https://github.com/pete-mc/dataverse-powertools"
   },
-  "version": "0.10.0",
+  "version": "0.11.0",
   "engines": {
     "vscode": "^1.93.0"
   },

--- a/src/general/dataverse/parseProfilableSteps.spec.ts
+++ b/src/general/dataverse/parseProfilableSteps.spec.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { parseProfilableSteps } from "./pluginProfiles";
+import { parseProfilableSteps, profilableStepsDiagnostics } from "./pluginProfiles";
 
 /* eslint-disable @typescript-eslint/naming-convention -- Dataverse OData navigation/field names */
 
@@ -55,5 +55,26 @@ describe("parseProfilableSteps", () => {
     // message/primaryEntity are optional — a step with no filter/message still shapes.
     const minimal = { sdkmessageprocessingstepid: "m", name: "n", eventhandler_plugintype: { typename: "A.B", pluginassemblyid: { name: "Asm" } } };
     expect(parseProfilableSteps({ value: [minimal] })).toEqual([{ stepId: "m", name: "n", typeName: "A.B", message: undefined, primaryEntity: undefined, mode: undefined }]);
+  });
+});
+
+describe("profilableStepsDiagnostics (#135 — explain an empty result)", () => {
+  it("counts each drop reason so a 'no steps' outcome is diagnosable", () => {
+    const microsoft = { ...validRow, sdkmessageprocessingstepid: "ms", eventhandler_plugintype: { typename: "Microsoft.Crm.X", pluginassemblyid: { name: "Microsoft" } } };
+    const profiled = { ...validRow, sdkmessageprocessingstepid: "prof", name: "My.Plugins.AccountCreate (Profiled): Create of account" };
+    const noType = { ...validRow, sdkmessageprocessingstepid: "nt", eventhandler_plugintype: null };
+    const diag = profilableStepsDiagnostics({ value: [validRow, microsoft, profiled, noType] });
+    expect(diag).toEqual({ total: 4, kept: 1, droppedNoType: 1, droppedSystem: 1, droppedProfiled: 1, droppedByAssembly: 0 });
+  });
+
+  it("attributes the whole result to the empty-plugintype bucket when that's the cause", () => {
+    const noType = { ...validRow, eventhandler_plugintype: null };
+    const diag = profilableStepsDiagnostics({ value: [noType] });
+    expect(diag).toEqual({ total: 1, kept: 0, droppedNoType: 1, droppedSystem: 0, droppedProfiled: 0, droppedByAssembly: 0 });
+  });
+
+  it("counts assembly-scoped drops", () => {
+    const other = { ...validRow, sdkmessageprocessingstepid: "o", eventhandler_plugintype: { typename: "Other.Plugin", pluginassemblyid: { name: "OtherAsm" } } };
+    expect(profilableStepsDiagnostics({ value: [validRow, other] }, "MyPlugins")).toMatchObject({ total: 2, kept: 1, droppedByAssembly: 1 });
   });
 });

--- a/src/general/dataverse/pluginProfiles.ts
+++ b/src/general/dataverse/pluginProfiles.ts
@@ -64,7 +64,58 @@ export async function getProfilableSteps(context: DataversePowerToolsContext, as
   if (!body) {
     return undefined;
   }
-  return parseProfilableSteps(body, assemblyName);
+  const steps = parseProfilableSteps(body, assemblyName);
+  // #135: the query succeeded but every step was filtered out — log WHY so a "No registered
+  // plugin steps" dead-end is diagnosable (which bucket the user's live step fell into).
+  if (steps.length === 0 && (body?.value?.length ?? 0) > 0) {
+    const d = profilableStepsDiagnostics(body, assemblyName);
+    context.channel.appendLine(
+      `[Profiler] ${d.total} active step(s) returned but none were profilable${assemblyName ? ` for assembly "${assemblyName}"` : ""}: ` +
+        `${d.droppedNoType} without a resolved plugin type, ${d.droppedSystem} system (Microsoft.*), ` +
+        `${d.droppedProfiled} already-profiled clones, ${d.droppedByAssembly} in other assemblies. ` +
+        (d.droppedNoType > 0
+          ? `A registered, firing step counted under "without a resolved plugin type" means its plugintype expand came back empty — redeploy the plugin and retry; if it persists, report the step name.`
+          : ""),
+    );
+  }
+  return steps;
+}
+
+export interface ProfilableStepsDiagnostics {
+  total: number;
+  kept: number;
+  droppedNoType: number;
+  droppedSystem: number;
+  droppedProfiled: number;
+  droppedByAssembly: number;
+}
+
+/**
+ * Classify each returned step by why parseProfilableSteps keeps or drops it (pure,
+ * unit-tested). Mirrors the same filter order so the counts explain an empty result — the
+ * diagnostic behind #135's "No registered plugin steps to profile".
+ */
+export function profilableStepsDiagnostics(body: any, assemblyName?: string): ProfilableStepsDiagnostics {
+  const rows: any[] = body?.value ?? [];
+  const diag: ProfilableStepsDiagnostics = { total: rows.length, kept: 0, droppedNoType: 0, droppedSystem: 0, droppedProfiled: 0, droppedByAssembly: 0 };
+  for (const row of rows) {
+    const type = row.eventhandler_plugintype;
+    const typeName = (type?.typename as string) ?? "";
+    const name = (row.name as string) ?? "";
+    const stepAssembly = (type?.pluginassemblyid?.name as string) ?? "";
+    if (!typeName) {
+      diag.droppedNoType++;
+    } else if (typeName.startsWith("Microsoft.")) {
+      diag.droppedSystem++;
+    } else if (/\(Profiled\)/.test(name)) {
+      diag.droppedProfiled++;
+    } else if (assemblyName && stepAssembly !== assemblyName) {
+      diag.droppedByAssembly++;
+    } else {
+      diag.kept++;
+    }
+  }
+  return diag;
 }
 
 /**

--- a/src/plugins/buildAndDeploy.ts
+++ b/src/plugins/buildAndDeploy.ts
@@ -9,6 +9,7 @@ import { PluginPackageMetadata, upsertDataversePluginPackage, waitForDataversePl
 import { PluginStepRegistration, registerPluginSteps } from "../general/dataverse/registerPluginSteps";
 import { findPrimaryPluginCsproj, hasDeployablePluginTypes } from "./projectPaths";
 import { activeComponentRoot } from "../components/componentDiscovery";
+import { prefixedPackageId, pluginPackageUniqueName } from "./pluginPackageNaming";
 import { registerWorkflowActivities, WorkflowActivityRegistration } from "../general/dataverse/registerWorkflowActivities";
 
 interface ExecResult {
@@ -214,34 +215,8 @@ async function findBuiltPackagePath(workspacePath: string, csprojPath: string, p
   return withStats.sort((a, b) => b.mtimeMs - a.mtimeMs)[0].filePath;
 }
 
-function sanitizeUniqueNameSegment(value: string): string {
-  return value
-    .replace(/[^A-Za-z0-9_]/g, "_")
-    .replace(/_+/g, "_") // collapse runs first, so the trims below only ever see a single underscore (avoids polynomial backtracking)
-    .replace(/^_/, "")
-    .replace(/_$/, "");
-}
-
-function normalizeCustomizationPrefix(prefix: string | undefined): string {
-  // `[^A-Za-z0-9]` already removes underscores, so no separate trailing-underscore trim is needed.
-  const sanitized = (prefix || "").trim().replace(/[^A-Za-z0-9]/g, "");
-
-  if (!sanitized) {
-    return "dpt";
-  }
-
-  if (!/^[A-Za-z]/.test(sanitized)) {
-    return `p${sanitized}`;
-  }
-
-  return sanitized;
-}
-
 function getPrefixedPackageId(context: DataversePowerToolsContext, csprojPath: string): string {
-  const normalizedPrefix = normalizeCustomizationPrefix(context.projectSettings.prefix);
-  const configuredName = sanitizeUniqueNameSegment(context.projectSettings.pluginPackageName || "");
-  const projectName = configuredName || sanitizeUniqueNameSegment(path.basename(csprojPath, ".csproj")) || "Plugin";
-  return `${normalizedPrefix}_${projectName}`;
+  return prefixedPackageId(context.projectSettings.prefix, context.projectSettings.pluginPackageName, path.basename(csprojPath, ".csproj"));
 }
 
 function getConfiguredPluginPackageVersion(context: DataversePowerToolsContext): string {
@@ -254,16 +229,32 @@ function getConfiguredPluginPackageVersion(context: DataversePowerToolsContext):
 }
 
 function buildPluginPackageUniqueName(context: DataversePowerToolsContext, packageName: string): string {
-  const normalizedPrefix = normalizeCustomizationPrefix(context.projectSettings.prefix);
-  const segment = sanitizeUniqueNameSegment(packageName);
-  const baseSegment = segment.length > 0 ? segment : "pluginpackage";
+  return pluginPackageUniqueName(context.projectSettings.prefix, packageName);
+}
 
-  let uniqueName = /^[A-Za-z][A-Za-z0-9]*_/.test(baseSegment) ? baseSegment : `${normalizedPrefix}_${baseSegment}`;
-  if (uniqueName.length > 128) {
-    uniqueName = uniqueName.substring(0, 128);
+/** Delete stale *.nupkg/*.snupkg under the project's bin before packing, so pack leaves
+ * exactly one, correctly named package for findBuiltPackagePath to select (#134 — otherwise
+ * an old unprefixed/stale package from a previous run can be picked and deployed). */
+async function removeStalePackages(context: DataversePowerToolsContext, projectDirectory: string): Promise<void> {
+  const binDirectory = path.join(projectDirectory, "bin");
+  if (!fs.existsSync(binDirectory)) {
+    return;
   }
-
-  return uniqueName;
+  let removed = 0;
+  for (const file of await walkDirectory(binDirectory)) {
+    const lower = file.toLowerCase();
+    if (lower.endsWith(".nupkg") || lower.endsWith(".snupkg")) {
+      try {
+        await fs.promises.rm(file, { force: true });
+        removed++;
+      } catch {
+        /* best effort — a locked file just gets superseded by mtime in findBuiltPackagePath */
+      }
+    }
+  }
+  if (removed > 0) {
+    context.channel.appendLine(`Cleared ${removed} stale package file(s) from ${binDirectory} before pack.`);
+  }
 }
 
 function parsePackageMetadata(context: DataversePowerToolsContext, csprojPath: string, packagePath: string): PluginPackageMetadata {
@@ -573,10 +564,12 @@ export async function buildAndDeploy(context: DataversePowerToolsContext): Promi
       const csprojPathForPack = await findPrimaryPluginCsproj(workspacePath, context.projectSettings.pluginProjectName);
       let expectedPackageId: string | undefined;
       if (csprojPathForPack) {
-        const prefixedPackageId = getPrefixedPackageId(context, csprojPathForPack);
+        // Clear stale packages first so pack yields exactly one, deterministically named .nupkg.
+        await removeStalePackages(context, path.dirname(csprojPathForPack));
+        const packageId = getPrefixedPackageId(context, csprojPathForPack);
         const configuredPackageVersion = getConfiguredPluginPackageVersion(context);
-        expectedPackageId = prefixedPackageId;
-        packArgs.push(`-p:PackageId=${prefixedPackageId}`);
+        expectedPackageId = packageId;
+        packArgs.push(`-p:PackageId=${packageId}`);
         packArgs.push(`-p:Version=${configuredPackageVersion}`);
         context.channel.appendLine(`Using PackageId override for pack: ${prefixedPackageId}`);
         context.channel.appendLine(`Using package Version override for pack: ${configuredPackageVersion}`);

--- a/src/plugins/pluginPackageNaming.spec.ts
+++ b/src/plugins/pluginPackageNaming.spec.ts
@@ -1,0 +1,57 @@
+import { describe, it, expect } from "vitest";
+import { normalizeCustomizationPrefix, sanitizeUniqueNameSegment, prefixedPackageId, pluginPackageUniqueName } from "./pluginPackageNaming";
+
+describe("normalizeCustomizationPrefix", () => {
+  it("keeps a normal alpha prefix", () => {
+    expect(normalizeCustomizationPrefix("dvpt")).toBe("dvpt");
+  });
+  it("defaults to dpt when empty/blank", () => {
+    expect(normalizeCustomizationPrefix(undefined)).toBe("dpt");
+    expect(normalizeCustomizationPrefix("   ")).toBe("dpt");
+    expect(normalizeCustomizationPrefix("__")).toBe("dpt");
+  });
+  it("prepends p when the prefix starts with a digit", () => {
+    expect(normalizeCustomizationPrefix("123")).toBe("p123");
+  });
+});
+
+describe("sanitizeUniqueNameSegment", () => {
+  it("replaces illegal chars and collapses/trims underscores", () => {
+    expect(sanitizeUniqueNameSegment("My Plugin!")).toBe("My_Plugin");
+    expect(sanitizeUniqueNameSegment("__a..b__")).toBe("a_b");
+  });
+});
+
+describe("prefixedPackageId (#134 — deterministic package id)", () => {
+  it("is always prefixed, using the configured package name", () => {
+    expect(prefixedPackageId("dvpt", "MyPkg", "Plugin")).toBe("dvpt_MyPkg");
+  });
+  it("falls back to the csproj base name when no package name is configured", () => {
+    expect(prefixedPackageId("dvpt", "", "Plugin")).toBe("dvpt_Plugin");
+    expect(prefixedPackageId("dvpt", undefined, "Plugin")).toBe("dvpt_Plugin");
+  });
+  it("uses the default prefix when none is set — never an unprefixed id", () => {
+    // The bug: sometimes the package was "Plugin.1.0.0.nupkg" (no prefix). The id must
+    // ALWAYS carry a prefix so Build and Build & Deploy agree.
+    expect(prefixedPackageId(undefined, "", "Plugin")).toBe("dpt_Plugin");
+    expect(prefixedPackageId("", "", "Plugin").includes("_")).toBe(true);
+  });
+  it("is stable across the varying inputs (prefix, name, csproj)", () => {
+    expect(prefixedPackageId("dvpt", "MyPkg", "SomethingElse")).toBe("dvpt_MyPkg");
+  });
+});
+
+describe("pluginPackageUniqueName", () => {
+  it("prefixes an unprefixed package name", () => {
+    expect(pluginPackageUniqueName("dvpt", "MyPkg")).toBe("dvpt_MyPkg");
+  });
+  it("leaves an already-prefixed name untouched", () => {
+    expect(pluginPackageUniqueName("dvpt", "dvpt_MyPkg")).toBe("dvpt_MyPkg");
+  });
+  it("falls back to pluginpackage for an empty name", () => {
+    expect(pluginPackageUniqueName("dvpt", "")).toBe("dvpt_pluginpackage");
+  });
+  it("truncates to 128 chars", () => {
+    expect(pluginPackageUniqueName("dvpt", "a".repeat(200)).length).toBe(128);
+  });
+});

--- a/src/plugins/pluginPackageNaming.ts
+++ b/src/plugins/pluginPackageNaming.ts
@@ -1,0 +1,52 @@
+// Pure plugin-package naming (#134). Deterministic PackageId / unique-name derivation, kept
+// vscode-free and unit-tested so the package is named the same way every run regardless of
+// which input varies (prefix, configured package name, or csproj file name) — the
+// "Plugin.1.0.0 vs dvpt_Plugin.1.0.0" inconsistency came from these rules living inline and
+// only being applied on some code paths.
+
+/** Normalise a customization prefix to a pac-safe leading segment; defaults to `dpt`. */
+export function normalizeCustomizationPrefix(prefix: string | undefined): string {
+  // `[^A-Za-z0-9]` already removes underscores, so no separate trailing-underscore trim is needed.
+  const sanitized = (prefix || "").trim().replace(/[^A-Za-z0-9]/g, "");
+  if (!sanitized) {
+    return "dpt";
+  }
+  if (!/^[A-Za-z]/.test(sanitized)) {
+    return `p${sanitized}`;
+  }
+  return sanitized;
+}
+
+/** Sanitise a single unique-name segment (letters, digits, single underscores). */
+export function sanitizeUniqueNameSegment(value: string): string {
+  return value
+    .replace(/[^A-Za-z0-9_]/g, "_")
+    .replace(/_+/g, "_") // collapse runs first, so the trims below only ever see a single underscore (avoids polynomial backtracking)
+    .replace(/^_/, "")
+    .replace(/_$/, "");
+}
+
+/**
+ * The PackageId passed to `dotnet pack -p:PackageId=...`, which also names the produced
+ * `<id>.<version>.nupkg`. Always prefixed, so Build and Build & Deploy agree.
+ */
+export function prefixedPackageId(prefix: string | undefined, pluginPackageName: string | undefined, csprojBaseName: string): string {
+  const normalizedPrefix = normalizeCustomizationPrefix(prefix);
+  const configuredName = sanitizeUniqueNameSegment(pluginPackageName || "");
+  const projectName = configuredName || sanitizeUniqueNameSegment(csprojBaseName) || "Plugin";
+  return `${normalizedPrefix}_${projectName}`;
+}
+
+/** The Dataverse pluginpackage unique name for a packed package's base name. */
+export function pluginPackageUniqueName(prefix: string | undefined, packageName: string): string {
+  const normalizedPrefix = normalizeCustomizationPrefix(prefix);
+  const segment = sanitizeUniqueNameSegment(packageName);
+  const baseSegment = segment.length > 0 ? segment : "pluginpackage";
+
+  // An already-prefixed name (`<letters>_...`) is left as-is; otherwise prepend the prefix.
+  let uniqueName = /^[A-Za-z][A-Za-z0-9]*_/.test(baseSegment) ? baseSegment : `${normalizedPrefix}_${baseSegment}`;
+  if (uniqueName.length > 128) {
+    uniqueName = uniqueName.substring(0, 128);
+  }
+  return uniqueName;
+}


### PR DESCRIPTION
Milestone **0.11.0: Plugins — Profiling, trace & build**. Two build/profiling bug fixes; the larger panel features (#137, #139) are deferred.

## Changes
- **#134 — deterministic package name + fresh DLLs.** *Build Package & Deploy* clears stale `*.nupkg`/`*.snupkg` from the project `bin` before `dotnet pack`, so exactly one, correctly prefixed `<prefix>_<name>.<version>.nupkg` is produced and selected — fixing the intermittent `Plugin.1.0.0` vs `dvpt_Plugin.1.0.0` naming and stale-package/DLL deploys. Naming rules extracted to a pure, unit-tested `pluginPackageNaming` module (12 tests) so every path agrees.
- **#135 — diagnosable "no profilable steps".** `getProfilableSteps` now logs a per-reason breakdown when everything is filtered out (no resolved plugin type / system / already-profiled / other assembly). Pure `profilableStepsDiagnostics` + tests. The underlying empty-`plugintype`-expand case for a live step stays open; this makes it diagnosable rather than a dead-end message.

## Not in this release
- **#137** (trace-log status tag) and **#139** (per-step profiling toggle UX) are larger panel/webview features tracked for a following release.

## Verification
- Verify loop green: tsc, lint, webpack, `test:coverage` (exit 0), 417 unit tests, integration.
- Full `npm run test:e2e` on the VM: running (Build Package & Deploy path exercised) — will confirm before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)