### PR TITLE
0.12.0 (pre-release) — PCF controls (foundational slice, #141)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 All notable changes to the "dataverse-powertools" extension will be documented in this file.
 
+## 0.12.0 (pre-release)
+
+New component type: **PCF (Power Apps Component Framework) controls** — foundational slice (#141).
+
+- **Create a PCF Control project/component.** "PCF Control" is now offered in the project-type picker and as a component you can add to a multi-component workspace. Scaffolds via `pac pcf init` and slots into the same discovery / per-component model as plugins and web resources.
+- **Lifecycle commands on the PCF card:** **Push** (`pac pcf push` — the one-click dev inner loop, authenticates from the connection under both service-principal and interactive auth), **Local Build** (`npm run build`), **Refresh Types** (`npm run refreshTypes`), and **Add to Solution** (hands off to the Solution feature / `pac solution add-reference`).
+- Pure, unit-tested `pac pcf` argument builders; registry ↔ package.json parity and command registration covered by the integration suite.
+
+> **Foundational slice — please verify the live scaffold before relying on it.** Deferred to a fast-follow (per #141): live-form debug/hot-reload, the opinionated React + Fluent service-layer template with a seeded vertical slice, scaffold-time field/dataset × framework quick-pick, and Jest Test Explorer wiring. The `pac pcf init` scaffold and `pac pcf push` paths are wired but have not been run against a live environment in CI — try them and revert this pre-release if the scaffold needs additional flags (e.g. `--name`/`--namespace`).
+
 ## 0.11.0 (pre-release)
 
 Plugins — deterministic packaging and diagnosable profiling.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "dataverse-powertools",
-  "version": "0.11.0",
+  "version": "0.12.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "dataverse-powertools",
-      "version": "0.11.0",
+      "version": "0.12.0",
       "hasInstallScript": true,
       "dependencies": {
         "@azure/msal-node": "^5.4.0",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "type": "git",
     "url": "https://github.com/pete-mc/dataverse-powertools"
   },
-  "version": "0.11.0",
+  "version": "0.12.0",
   "engines": {
     "vscode": "^1.93.0"
   },
@@ -580,6 +580,26 @@
         "command": "dataverse-powertools.refreshConfigFiles",
         "title": "Dataverse PowerTools: Refresh Project Config Files",
         "enablement": "dataverse-powertools.showLoaded && dataverse-powertools.isWebResource"
+      },
+      {
+        "command": "dataverse-powertools.buildPcf",
+        "title": "Dataverse PowerTools: Build PCF Control",
+        "enablement": "dataverse-powertools.showLoaded && dataverse-powertools.isPcf"
+      },
+      {
+        "command": "dataverse-powertools.pushPcf",
+        "title": "Dataverse PowerTools: Push PCF Control",
+        "enablement": "dataverse-powertools.showLoaded && dataverse-powertools.isPcf"
+      },
+      {
+        "command": "dataverse-powertools.deployPcf",
+        "title": "Dataverse PowerTools: Add PCF Control to Solution",
+        "enablement": "dataverse-powertools.showLoaded && dataverse-powertools.isPcf"
+      },
+      {
+        "command": "dataverse-powertools.refreshPcfTypes",
+        "title": "Dataverse PowerTools: Refresh PCF Types",
+        "enablement": "dataverse-powertools.showLoaded && dataverse-powertools.isPcf"
       },
       {
         "command": "dataverse-powertools.clearCredentials",

--- a/src/general/restoreDependencies.ts
+++ b/src/general/restoreDependencies.ts
@@ -165,6 +165,9 @@ const ALLOWED_ARGV: ReadonlyArray<ReadonlyArray<string>> = [
   ["dotnet", "paket", "install"],
   ["dotnet", "add", "package", "Microsoft.CrmSdk.Workflow"],
   ["pac", "plugin", "init", "--skip-signing"],
+  // PCF scaffold (#141): pac pcf init writes the project into the component root
+  // directly (no nesting, so no resolveInitCommand special-casing needed).
+  ["pac", "pcf", "init", "--template", "field", "--framework", "none"],
   ["npm", "install", "--loglevel=error"],
   // Pin to TypeScript 5.x: @typescript-eslint/* v8 (installed below) peers on
   // typescript ">=4.8.4 <6.1.0", and a bare install now resolves to TypeScript 7,

--- a/src/panel/menuModel.spec.ts
+++ b/src/panel/menuModel.spec.ts
@@ -69,7 +69,7 @@ describe("top-level states", () => {
   });
 
   it("flags an unsupported project type instead of rendering a project card", () => {
-    const model = buildMenuModel(state({ projects: [project({ type: "pcf" })] }));
+    const model = buildMenuModel(state({ projects: [project({ type: "notarealtype" })] }));
     expect(model.cards[1].kind).toBe("notice");
     expect((model.cards[1] as { text: string }).text).toMatch(/not supported/);
   });

--- a/src/pcf/buildPcf.ts
+++ b/src/pcf/buildPcf.ts
@@ -1,0 +1,8 @@
+import DataversePowerToolsContext from "../context";
+import { runPcfNpmScript } from "./runNpmScript";
+
+// Local build of a PCF control: `npm run build` (pcf-scripts) in the component
+// root. Mirrors src/plugins/buildProject.ts.
+export async function buildPcf(context: DataversePowerToolsContext): Promise<void> {
+  await runPcfNpmScript(context, "build", "Building PCF control...", "PCF build completed successfully.", "Error building PCF control. See output for details.");
+}

--- a/src/pcf/deployPcf.ts
+++ b/src/pcf/deployPcf.ts
@@ -1,0 +1,109 @@
+import * as vscode from "vscode";
+import * as fs from "fs";
+import * as path from "path";
+import DataversePowerToolsContext from "../context";
+import { runPac } from "../general/modelbuilder/commandRunner";
+import { activeComponentRoot } from "../components/componentDiscovery";
+
+const SOLUTION_DOCS_URL = "https://learn.microsoft.com/power-apps/developer/component-framework/import-custom-controls";
+
+/** Find the first `.cdsproj` (a pac solution project) in a directory. */
+function findCdsproj(directory: string): string | undefined {
+  let entries: fs.Dirent[];
+  try {
+    entries = fs.readdirSync(directory, { withFileTypes: true });
+  } catch {
+    return undefined;
+  }
+  const cdsproj = entries.find((entry) => entry.isFile() && entry.name.toLowerCase().endsWith(".cdsproj"));
+  return cdsproj ? path.join(directory, cdsproj.name) : undefined;
+}
+
+/** Locate a solution project (`.cdsproj`) directory in the workspace: root folders
+ * plus their immediate subfolders (the usual monorepo / multi-component layout). */
+function findSolutionProjectDir(): string | undefined {
+  for (const folder of vscode.workspace.workspaceFolders ?? []) {
+    const root = folder.uri.fsPath;
+    if (findCdsproj(root)) {
+      return root;
+    }
+    let subdirs: fs.Dirent[];
+    try {
+      subdirs = fs.readdirSync(root, { withFileTypes: true });
+    } catch {
+      continue;
+    }
+    for (const entry of subdirs) {
+      if (entry.isDirectory()) {
+        const child = path.join(root, entry.name);
+        if (findCdsproj(child)) {
+          return child;
+        }
+      }
+    }
+  }
+  return undefined;
+}
+
+// A PCF control ships INSIDE a solution. For a release build you add the control's
+// pcfproj as a reference to a solution project (`.cdsproj`) and pack/import that.
+// For v1 (#141) this command guides the user to the Solution component and, when a
+// solution project already exists in the workspace, best-effort wires the reference
+// via `pac solution add-reference --path <pcfComponentRoot>` (a local, auth-free op).
+// Deeper solution integration is a fast-follow — `pac pcf push` remains the one-click
+// inner loop.
+export async function deployPcf(context: DataversePowerToolsContext): Promise<void> {
+  const componentRoot = activeComponentRoot(context);
+  if (!componentRoot) {
+    vscode.window.showErrorMessage("No workspace folder is open.");
+    return;
+  }
+
+  const solutionDir = findSolutionProjectDir();
+  if (!solutionDir) {
+    context.channel.appendLine(
+      "A PCF control ships inside a solution. Add a Solution component to this workspace (Add Component → Solution), then run this again to reference the control — or use Push to deploy it directly to the environment for development.",
+    );
+    const choice = await vscode.window.showInformationMessage(
+      "A PCF control ships inside a solution. Add a Solution component (or use Push for a quick dev deploy), then add the control as a reference.",
+      "Learn more",
+    );
+    if (choice === "Learn more") {
+      void vscode.env.openExternal(vscode.Uri.parse(SOLUTION_DOCS_URL));
+    }
+    return;
+  }
+
+  const confirm = await vscode.window.showInformationMessage(
+    `Add this PCF control as a reference to the solution project in ${path.basename(solutionDir)}?`,
+    "Add reference",
+    "Cancel",
+  );
+  if (confirm !== "Add reference") {
+    return;
+  }
+
+  try {
+    // `pac solution add-reference` runs inside the cdsproj folder and records a
+    // reference to the pcfproj — no Dataverse auth required.
+    const { stdout, stderr } = await runPac(["solution", "add-reference", "--path", componentRoot], solutionDir);
+    if (stdout) {
+      context.channel.appendLine(stdout);
+    }
+    if (stderr) {
+      context.channel.appendLine(stderr);
+    }
+    context.channel.appendLine("PCF control added as a solution reference. Deploy the solution to push it to the environment.");
+    vscode.window.showInformationMessage("PCF control added to the solution. Deploy the solution to publish it.");
+  } catch (error: any) {
+    if (error?.stdout) {
+      context.channel.appendLine(error.stdout);
+    }
+    if (error?.stderr) {
+      context.channel.appendLine(error.stderr);
+    }
+    context.channel.appendLine(`Error running pac solution add-reference: ${error?.error?.message || error?.message || "Unknown error"}`);
+    context.channel.show();
+    vscode.window.showErrorMessage("Could not add the PCF control to the solution. See output for details.");
+  }
+}

--- a/src/pcf/initialisePcf.ts
+++ b/src/pcf/initialisePcf.ts
@@ -1,0 +1,14 @@
+import * as vscode from "vscode";
+import DataversePowerToolsContext from "../context";
+
+// Per-type setup for PCF control components: just the context key that gates the
+// PCF UI in package.json. Commands register ONCE globally in
+// projectTypes/activation.ts (#47) — never here, or a second PCF component's
+// initialise re-registers and VS Code throws "command … already exists".
+//
+// No global singletons and no TestController in v1 (Jest Test Explorer wiring is
+// an explicit fast-follow, #141).
+export async function initialisePcf(context: DataversePowerToolsContext): Promise<void> {
+  void context;
+  await vscode.commands.executeCommand("setContext", "dataverse-powertools.isPcf", true);
+}

--- a/src/pcf/pcfArgs.spec.ts
+++ b/src/pcf/pcfArgs.spec.ts
@@ -1,0 +1,30 @@
+import { describe, it, expect } from "vitest";
+import { pcfInitArgs, pcfPushArgs } from "./pcfArgs";
+
+describe("pcfInitArgs", () => {
+  it("builds field + none", () => {
+    expect(pcfInitArgs({ template: "field", framework: "none" })).toEqual(["pcf", "init", "--template", "field", "--framework", "none"]);
+  });
+
+  it("builds field + react", () => {
+    expect(pcfInitArgs({ template: "field", framework: "react" })).toEqual(["pcf", "init", "--template", "field", "--framework", "react"]);
+  });
+
+  it("builds dataset + none", () => {
+    expect(pcfInitArgs({ template: "dataset", framework: "none" })).toEqual(["pcf", "init", "--template", "dataset", "--framework", "none"]);
+  });
+
+  it("builds dataset + react", () => {
+    expect(pcfInitArgs({ template: "dataset", framework: "react" })).toEqual(["pcf", "init", "--template", "dataset", "--framework", "react"]);
+  });
+});
+
+describe("pcfPushArgs", () => {
+  it("builds push with a publisher prefix", () => {
+    expect(pcfPushArgs("dev")).toEqual(["pcf", "push", "--publisher-prefix", "dev"]);
+  });
+
+  it("passes the exact prefix through", () => {
+    expect(pcfPushArgs("contoso")).toEqual(["pcf", "push", "--publisher-prefix", "contoso"]);
+  });
+});

--- a/src/pcf/pcfArgs.ts
+++ b/src/pcf/pcfArgs.ts
@@ -1,0 +1,33 @@
+// Pure builders for `pac pcf` CLI argument arrays. No `vscode` import — keep it
+// unit-testable, and keep the exact flags visible in one place so they're easy to
+// verify against the pac reference:
+// https://learn.microsoft.com/power-platform/developer/cli/reference/pcf
+//
+// Mirrors src/solution/pacArgs.ts.
+
+/** Manifest-level template shape (`<property>` vs `<data-set>` in ControlManifest). */
+export type PcfTemplate = "field" | "dataset";
+/** Rendering framework: `none` (vanilla HTML/TS) or `react` (virtual/platform control). */
+export type PcfFramework = "none" | "react";
+
+export interface PcfInitOptions {
+  template: PcfTemplate;
+  framework: PcfFramework;
+}
+
+/**
+ * `pac pcf init` — initialise a directory with a new PCF project.
+ * `--template field|dataset`, `--framework none|react`. No auth required.
+ */
+export function pcfInitArgs({ template, framework }: PcfInitOptions): string[] {
+  return ["pcf", "init", "--template", template, "--framework", framework];
+}
+
+/**
+ * `pac pcf push` — import the PCF project into the current Dataverse organization
+ * (fast, ephemeral dev inner loop). `--publisher-prefix` is the customization prefix.
+ * Requires an active auth profile / selected environment.
+ */
+export function pcfPushArgs(publisherPrefix: string): string[] {
+  return ["pcf", "push", "--publisher-prefix", publisherPrefix];
+}

--- a/src/pcf/pushPcf.ts
+++ b/src/pcf/pushPcf.ts
@@ -1,0 +1,65 @@
+import * as vscode from "vscode";
+import DataversePowerToolsContext from "../context";
+import { runPac } from "../general/modelbuilder/commandRunner";
+import { ensurePacAuthForCurrentConnection } from "../general/pacAuth";
+import { activeComponentRoot } from "../components/componentDiscovery";
+import { pcfPushArgs } from "./pcfArgs";
+
+// `pac pcf push` — the fast, one-click dev inner loop that imports the control into
+// the connected environment (a temporary PowerAppsTools solution). Mirrors how
+// generateEarlyBoundV3 authenticates the extension's pac profile from the current
+// connection first, then runs pac.
+//
+// Auth: gate on the live connection via ensurePacAuthForCurrentConnection — NEVER on
+// tenantId (interactive/OAuth connections carry no tenantId; see CLAUDE.md #90/#91).
+export async function pushPcf(context: DataversePowerToolsContext): Promise<void> {
+  const workspacePath = activeComponentRoot(context);
+  if (!workspacePath) {
+    vscode.window.showErrorMessage("No workspace folder is open.");
+    return;
+  }
+
+  const prefix = context.projectSettings.prefix;
+  if (!prefix) {
+    context.channel.appendLine("Cannot push PCF control: no publisher prefix is configured for this project.");
+    context.channel.show();
+    vscode.window.showErrorMessage("No publisher prefix configured; cannot push the PCF control. Set a prefix on the connection and retry.");
+    return;
+  }
+
+  await vscode.window.withProgress(
+    {
+      location: vscode.ProgressLocation.Notification,
+      title: "Pushing PCF control with pac pcf push...",
+    },
+    async () => {
+      try {
+        // pac pcf push imports into the connection's environment — authenticate the
+        // extension's pac profile from the connection string first (works under both
+        // service-principal and interactive auth).
+        if (!(await ensurePacAuthForCurrentConnection(context, workspacePath))) {
+          return;
+        }
+        const { stdout, stderr } = await runPac(pcfPushArgs(prefix), workspacePath);
+        if (stdout) {
+          context.channel.appendLine(stdout);
+        }
+        if (stderr) {
+          context.channel.appendLine(stderr);
+        }
+        context.channel.appendLine("PCF push complete.");
+        vscode.window.showInformationMessage("PCF control pushed to the environment.");
+      } catch (error: any) {
+        if (error?.stdout) {
+          context.channel.appendLine(error.stdout);
+        }
+        if (error?.stderr) {
+          context.channel.appendLine(error.stderr);
+        }
+        context.channel.appendLine(`Error running pac pcf push: ${error?.error?.message || error?.message || "Unknown error"}`);
+        context.channel.show();
+        vscode.window.showErrorMessage("Error pushing PCF control. See output for details.");
+      }
+    },
+  );
+}

--- a/src/pcf/refreshPcfTypes.ts
+++ b/src/pcf/refreshPcfTypes.ts
@@ -1,0 +1,9 @@
+import DataversePowerToolsContext from "../context";
+import { runPcfNpmScript } from "./runNpmScript";
+
+// Regenerate the control's manifest typings: `npm run refreshTypes` (pcf-scripts)
+// in the component root. PCF has its OWN manifest typings, unrelated to the XDT
+// web-resource typings path. Mirrors buildPcf.
+export async function refreshPcfTypes(context: DataversePowerToolsContext): Promise<void> {
+  await runPcfNpmScript(context, "refreshTypes", "Refreshing PCF types...", "PCF types refreshed successfully.", "Error refreshing PCF types. See output for details.");
+}

--- a/src/pcf/runNpmScript.ts
+++ b/src/pcf/runNpmScript.ts
@@ -1,0 +1,58 @@
+import * as vscode from "vscode";
+import DataversePowerToolsContext from "../context";
+import { activeComponentRoot } from "../components/componentDiscovery";
+
+// Run an npm script in the active PCF component root. `exec` spawns through a shell
+// (cmd.exe on Windows), so the `npm` .cmd shim resolves — the same reason the
+// webresource build goes through `exec` rather than spawning `npm` directly (the
+// EINVAL trap). The project's LOCAL bin is used because pcf-scripts lives in the
+// scaffolded control's devDependencies, never as a global.
+export async function runPcfNpmScript(
+  context: DataversePowerToolsContext,
+  script: string,
+  progressTitle: string,
+  successMessage: string,
+  failureMessage: string,
+): Promise<boolean> {
+  const componentRoot = activeComponentRoot(context);
+  if (!componentRoot) {
+    vscode.window.showErrorMessage("No workspace folder is open.");
+    return false;
+  }
+
+  const util = require("util");
+  const exec = util.promisify(require("child_process").exec);
+
+  return vscode.window.withProgress(
+    {
+      location: vscode.ProgressLocation.Notification,
+      title: progressTitle,
+    },
+    async () => {
+      try {
+        const { stdout, stderr } = await exec(`npm run ${script}`, { cwd: componentRoot });
+        if (stdout) {
+          context.channel.appendLine(String(stdout));
+        }
+        if (stderr) {
+          context.channel.appendLine(String(stderr));
+        }
+        context.channel.appendLine(successMessage);
+        vscode.window.showInformationMessage(successMessage);
+        return true;
+      } catch (error: any) {
+        if (error?.stdout) {
+          context.channel.appendLine(String(error.stdout));
+        }
+        if (error?.stderr) {
+          context.channel.appendLine(String(error.stderr));
+        }
+        const message = error?.error?.message || error?.message || "Unknown error";
+        context.channel.appendLine(`${failureMessage}: ${message}`);
+        context.channel.show();
+        vscode.window.showErrorMessage(failureMessage);
+        return false;
+      }
+    },
+  );
+}

--- a/src/projectTypes/activation.ts
+++ b/src/projectTypes/activation.ts
@@ -45,6 +45,11 @@ import { extractSolution } from "../solution/extractSolution";
 import { packSolution } from "../solution/packSolution";
 import { deploySolution } from "../solution/deploySolution";
 import { connectPortal } from "../portals/connectPortal";
+import { initialisePcf } from "../pcf/initialisePcf";
+import { buildPcf } from "../pcf/buildPcf";
+import { pushPcf } from "../pcf/pushPcf";
+import { deployPcf } from "../pcf/deployPcf";
+import { refreshPcfTypes } from "../pcf/refreshPcfTypes";
 
 type CommandImpl = (context: DataversePowerToolsContext, resourceUri?: vscode.Uri) => unknown;
 
@@ -280,6 +285,15 @@ export const projectTypeActivations: Record<ProjectTypes, ProjectTypeActivation>
       "dataverse-powertools.connectPortal": tracked("Connect portal", (context) => connectPortal(context, "connect")),
       "dataverse-powertools.downloadPortal": tracked("Download portal", (context) => connectPortal(context, "download")),
       "dataverse-powertools.uploadPortal": tracked("Upload portal", (context) => connectPortal(context, "upload")),
+    },
+  },
+  [ProjectTypes.pcf]: {
+    initialise: (context) => initialisePcf(context),
+    commands: {
+      "dataverse-powertools.buildPcf": tracked("Build", buildPcf),
+      "dataverse-powertools.pushPcf": tracked("Push", pushPcf),
+      "dataverse-powertools.deployPcf": tracked("Add to solution", deployPcf),
+      "dataverse-powertools.refreshPcfTypes": (context) => refreshPcfTypes(context),
     },
   },
 };

--- a/src/projectTypes/registry.ts
+++ b/src/projectTypes/registry.ts
@@ -13,6 +13,7 @@ export enum ProjectTypes {
   webresource = "webresources",
   solution = "solution",
   portal = "portal",
+  pcf = "pcf",
 }
 
 /** A button in the actions panel (#100). `command` is executed with `args` when clicked. */
@@ -234,6 +235,31 @@ export const projectTypeRegistry: readonly ProjectTypeDescriptor[] = [
         secondary: [
           { command: `${prefix}uploadPortal`, label: "Upload" },
           { command: `${prefix}connectPortal`, label: "Select site" },
+        ],
+        overflow: [],
+      };
+    },
+  },
+  {
+    id: ProjectTypes.pcf,
+    displayName: "PCF Control",
+    templateFolder: "pcf",
+    defaultTemplateVersion: 1,
+    contextKey: "isPcf",
+    configRevision: 0,
+    refreshableFiles: [],
+    // Foundational slice (#141): scaffold + build + push + deploy (hand-to-solution) +
+    // refresh-types. Debug/hot-reload, service-layer template and Jest Test Explorer are
+    // explicit fast-follows.
+    commandIds: [`${prefix}buildPcf`, `${prefix}pushPcf`, `${prefix}deployPcf`, `${prefix}refreshPcfTypes`],
+    menu() {
+      return {
+        // Push (pac pcf push) is the one-click dev inner loop.
+        primary: { command: `${prefix}pushPcf`, label: "Push to {environment}" },
+        secondary: [
+          { command: `${prefix}buildPcf`, label: "Local Build" },
+          { command: `${prefix}refreshPcfTypes`, label: "Refresh Types" },
+          { command: `${prefix}deployPcf`, label: "Add to Solution" },
         ],
         overflow: [],
       };

--- a/templates/pcf/template.json
+++ b/templates/pcf/template.json
@@ -1,0 +1,17 @@
+[
+  {
+    "version": 1,
+    "files": [],
+    "placeholders": [],
+    "initCommands": [
+      {
+        "command": "pac pcf init --template field --framework none"
+      }
+    ],
+    "restoreCommands": [
+      {
+        "command": "npm install --loglevel=error"
+      }
+    ]
+  }
+]


### PR DESCRIPTION
Milestone **0.12.0: PCF controls**. New `pcf` component type — foundational slice. Closes the core of #141; debug/hot-reload, service-layer template, scaffold-time quick-pick, and Jest Test Explorer are explicit fast-follows.

## Changes
- New **PCF Control** project type wired across the registry pattern: enum + descriptor, activation entry, `src/pcf/` module (initialise, build, push, deploy-handoff, refresh-types), `templates/pcf/template.json` (`pac pcf init`), `restoreDependencies` allowlist, and `package.json` commands gated on `isPcf`.
- Lifecycle commands: **Push** (`pac pcf push`, one-click dev loop, auth via `ensurePacAuthForCurrentConnection` — works under both auth types, never gates on tenantId), **Local Build**, **Refresh Types**, **Add to Solution**.
- Pure unit-tested `pcfArgs` builders (flags verified against the pac reference); registry↔package.json parity + command registration covered by the integration suite.

## Verification
- Verify loop green: lint, tsc, webpack, `test:coverage` (423 unit tests, floor OK), `test:integration` (9 passing — parity + registration now cover the 4 PCF commands).
- Full `npm run test:e2e` on the VM (confirms the shared registry/activation changes don't regress the plugin/webresource lifecycles): running — will confirm before merge.

## ⚠️ Needs live verification
The `pac pcf init` scaffold and `pac pcf push` have **not** been run against a live environment in CI. If `pac pcf init` requires `--name`/`--namespace` non-interactively, the template command needs those flags (+ an allowlist entry). Please try the scaffold and revert this pre-release if it needs adjustment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)