### PR TITLE
0.14.2 (pre-release) — profiling & trace: finds steps (#135), trace-log tag (#137), profiling UX (#139)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 All notable changes to the "dataverse-powertools" extension will be documented in this file.
 
+## 0.14.2 (pre-release)
+
+Completes the **Plugins — Profiling, trace & build** milestone (#135, #137, #139).
+
+- **Profiling now finds your registered steps (#135).** *Profile a step* was reporting "No registered plugin steps to profile" for steps that were registered and firing. Root cause: the step→type query used the polymorphic `eventhandler` lookup, which doesn't resolve a plugin type for a normal step, so every step was filtered out. It now reads the step's type via the dedicated `plugintypeid` navigation (per the Dataverse docs) and excludes webhook/service-endpoint steps server-side — so your plugin steps show up.
+- **Plug-in trace log status tag in the panel (#137).** A coloured pill next to the connected org shows the org-wide trace-log level — 🟢 *Trace: Off*, 🟠 *Trace: Errors*, 🔴 *Trace: All*. Click it to change the level (Off / Exception only / All) without leaving the editor; switching to *All* asks for confirmation (it has a storage/perf cost). Works under both auth types.
+- **Per-step profiling toggle + Active profiles list (#139).** A **Profile: Off / On** CodeLens now sits on each `[CrmPluginRegistration(…)]` step attribute (next to *Update Filtering Attributes*) — one click enables/disables server-side profiling for *that* step, so "one class, many steps" just works. The plugin card gains an **Active profiles** block (like Form Registrations) listing every currently-profiled step with a trash-can to stop it, so it's always obvious when profiling is on. The old class-level "Profile & debug…" guide moved to the plugin card's overflow menu ("How to profile & debug…"). Enable/disable/stop use the bundled net48 tool on Windows; other platforms fall back to the guide / Web-API delete.
+
 ## 0.14.1 (pre-release)
 
 Interactive (OAuth) auth becomes first-class for `pac` commands — fixes a whole class of "works under service principal, broken under OAuth" bugs (#128, #129, #159).

--- a/media/menuPanel.css
+++ b/media/menuPanel.css
@@ -103,6 +103,35 @@ h3.inline {
   background: transparent;
 }
 
+/* Plug-in trace-log tag (#137): a clickable pill coloured by level. */
+.tracepill {
+  flex: none;
+  font-size: 10px;
+  font-weight: 700;
+  letter-spacing: 0.05em;
+  padding: 1px 7px;
+  border-radius: 9px;
+  border: 1px solid currentColor;
+  background: transparent;
+  color: var(--vscode-descriptionForeground);
+}
+
+.tracepill.trace-green {
+  color: var(--vscode-charts-green, var(--vscode-testing-iconPassed));
+}
+
+.tracepill.trace-orange {
+  color: var(--vscode-charts-orange, var(--vscode-editorWarning-foreground));
+}
+
+.tracepill.trace-red {
+  color: var(--vscode-charts-red, var(--vscode-errorForeground));
+}
+
+.tracepill:hover {
+  background-color: var(--vscode-toolbar-hoverBackground, rgba(128, 128, 128, 0.15));
+}
+
 .dot {
   flex: none;
   width: 8px;

--- a/media/menuPanel.js
+++ b/media/menuPanel.js
@@ -161,6 +161,18 @@
     if (card.label) {
       row.appendChild(el("span", "badge env", card.label.toUpperCase()));
     }
+    // Plug-in trace-log tag (#137): coloured pill, click opens the level picker.
+    if (card.traceLog) {
+      var pill = el("button", "tracepill trace-" + card.traceLog.colour, card.traceLog.label);
+      pill.type = "button";
+      pill.setAttribute("aria-label", card.traceLog.label + " — click to change");
+      pill.title = "Plug-in trace logging — click to change";
+      pill.addEventListener("click", function () {
+        closeOverflow();
+        execute(card.traceLog.action);
+      });
+      row.appendChild(pill);
+    }
     row.appendChild(el("span", "grow"));
     row.appendChild(button(card.switchAction, "iconbtn text"));
     const anchor = el("span", "menu-anchor");
@@ -514,6 +526,48 @@
       note = "Download a captured run, or drop a profile file in profiles/ and Replay to debug it as a test.";
     }
     c.appendChild(el("div", "small", note));
+    c.appendChild(activeProfilesBlock(block.activeProfiles || []));
+    return c;
+  }
+
+  // Active profiles (#139): the always-visible list of server-side-profiled steps. Mirrors the
+  // Form Registrations block — a header with a refresh affordance and a row + trash per step.
+  function activeProfilesBlock(rows) {
+    const c = el("div", "registrations");
+    const head = el("div", "head");
+    head.appendChild(el("h3", "inline", "Active profiles"));
+    head.appendChild(el("span", "grow"));
+    const refresh = el("button", "iconbtn text", "⟳");
+    refresh.type = "button";
+    refresh.title = "Refresh active profiles";
+    refresh.setAttribute("aria-label", "Refresh active profiles");
+    refresh.addEventListener("click", function () {
+      closeOverflow();
+      vscode.postMessage({ type: "refreshProfiles" });
+    });
+    head.appendChild(refresh);
+    c.appendChild(head);
+    if (rows.length === 0) {
+      c.appendChild(el("p", "status", "No steps are being profiled."));
+    } else {
+      const list = el("ul", "feed");
+      for (const row of rows) {
+        const li = el("li");
+        li.appendChild(el("span", "grow-text", row.label));
+        li.appendChild(el("span", "t", row.detail));
+        const stop = el("button", "iconbtn", "🗑");
+        stop.type = "button";
+        stop.title = "Stop profiling";
+        stop.setAttribute("aria-label", "Stop profiling " + row.label);
+        stop.addEventListener("click", function () {
+          closeOverflow();
+          vscode.postMessage({ type: "stopProfile", index: row.index });
+        });
+        li.appendChild(stop);
+        list.appendChild(li);
+      }
+      c.appendChild(list);
+    }
     return c;
   }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "dataverse-powertools",
-  "version": "0.14.1",
+  "version": "0.14.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "dataverse-powertools",
-      "version": "0.14.1",
+      "version": "0.14.2",
       "hasInstallScript": true,
       "dependencies": {
         "@azure/msal-node": "^5.4.0",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "type": "git",
     "url": "https://github.com/pete-mc/dataverse-powertools"
   },
-  "version": "0.14.1",
+  "version": "0.14.2",
   "engines": {
     "vscode": "^1.93.0"
   },
@@ -320,6 +320,11 @@
       {
         "command": "dataverse-powertools.refreshConnection",
         "title": "Dataverse PowerTools: Refresh Dataverse Connection",
+        "enablement": "dataverse-powertools.showLoaded"
+      },
+      {
+        "command": "dataverse-powertools.setTraceLogLevel",
+        "title": "Dataverse PowerTools: Set Plugin Trace Log Level",
         "enablement": "dataverse-powertools.showLoaded"
       },
       {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -8,9 +8,9 @@ import { componentScopedContext } from "./components/componentDiscovery";
 import { componentsToInitialise } from "./components/discovery";
 import { clearStoredCredentials } from "./general/connectionStringManager";
 import { checkConfigRevision } from "./general/configRefresh";
-import { registerProfilerCodeLens } from "./plugins/profilerCodeLens";
 import { registerDecorationCodeLens } from "./plugins/decorationsCodeLens";
 import { registerMenuPanel } from "./panel/menuPanel";
+import { refreshPanelData } from "./panel/panelDataCache";
 import { registerSystemRequirementCommands } from "./general/systemRequirements";
 import { initInteractiveTokenCache } from "./general/dataverse/tokenAcquisition";
 
@@ -28,9 +28,7 @@ export async function activate(vscodeContext: vscode.ExtensionContext) {
   // Every project type's commands register ONCE here; handlers resolve which
   // component an invocation targets (#47) — no per-type registration anymore.
   registerAllComponentCommands(context);
-  // Profiler toggle CodeLens on [CrmPluginRegistration] classes (#112).
-  registerProfilerCodeLens(context);
-  // Class-decoration / filtering-attribute CodeLens on plugin .cs files. Registered
+  // Class-decoration / filtering-attribute / per-step-profiling CodeLens on plugin .cs files. Registered
   // ONCE here (its commands + provider are global) — never per plugin component, or a
   // second plugin component's initialise throws "command … already exists" (#47).
   registerDecorationCodeLens(context);
@@ -80,4 +78,8 @@ export async function initialise(context: DataversePowerToolsContext) {
     }
   }
   context.refreshPanel?.();
+  // Fetch the Dataverse-derived panel data (trace-log level #137, active profiles #139) from the
+  // silently-established connection and cache it, then re-render. Fire-and-forget — the panel
+  // renders immediately and updates when the data lands.
+  void refreshPanelData(context);
 }

--- a/src/general/connectionStringManager.ts
+++ b/src/general/connectionStringManager.ts
@@ -8,6 +8,7 @@ import { getSolutions } from "./dataverse/getSolutions";
 import { DataverseAuthType, parseAuthType } from "./dataverse/authTypes";
 import { buildAuthConnectionString, getOrganizationUrl, normalizeOrganizationUrl, parseConnectionString } from "./connectionString";
 import { discoverEnvironments, discoverEnvironmentsWithSecret } from "./dataverse/globalDiscovery";
+import { refreshPanelData, clearPanelDataCache } from "../panel/panelDataCache";
 
 export async function updateConnectionString(context: DataversePowerToolsContext) {
   let connectionString = await createServicePrincipalString(context, true);
@@ -98,6 +99,10 @@ export async function switchEnvironment(context: DataversePowerToolsContext): Pr
   // Re-render the panel so the environment + solution reflect the switch
   // immediately — previously stale until a reload (#102).
   context.refreshPanel?.();
+  // The old org's trace-log level + active profiles no longer apply — drop them, then
+  // re-fetch for the new environment (#137/#139).
+  clearPanelDataCache();
+  void refreshPanelData(context);
   window.showInformationMessage(`Switched to ${pick.label}`);
 }
 
@@ -149,6 +154,8 @@ export async function refreshConnection(context: DataversePowerToolsContext): Pr
   const connected = await context.dataverse.initialize(true);
   if (connected) {
     context.setStatusBar(getOrganizationUrl(context.connectionString));
+    // Refresh the cached Dataverse-derived panel data now the connection is live (#137/#139).
+    void refreshPanelData(context);
     window.showInformationMessage("Reconnected to Dataverse.");
   } else {
     window.showErrorMessage("Could not reconnect to Dataverse. See the output for details.");

--- a/src/general/dataverse/parseProfilableSteps.spec.ts
+++ b/src/general/dataverse/parseProfilableSteps.spec.ts
@@ -1,8 +1,6 @@
 import { describe, it, expect } from "vitest";
 import { parseProfilableSteps, profilableStepsDiagnostics } from "./pluginProfiles";
 
-/* eslint-disable @typescript-eslint/naming-convention -- Dataverse OData navigation/field names */
-
 // The pure shape+filter behind getProfilableSteps — the code path behind #135
 // ("No registered plugin steps to profile" for a step that IS registered). Extracted
 // from the HTTP handler so the filtering is unit-testable without a live org
@@ -15,7 +13,7 @@ const validRow = {
   statecode: 0,
   sdkmessageid: { name: "Create" },
   sdkmessagefilterid: { primaryobjecttypecode: "account" },
-  eventhandler_plugintype: { typename: "My.Plugins.AccountCreate", pluginassemblyid: { name: "MyPlugins" } },
+  plugintypeid: { typename: "My.Plugins.AccountCreate", pluginassemblyid: { name: "MyPlugins" } },
 };
 
 describe("parseProfilableSteps", () => {
@@ -26,7 +24,7 @@ describe("parseProfilableSteps", () => {
   });
 
   it("scopes to the requested assembly when given", () => {
-    const other = { ...validRow, sdkmessageprocessingstepid: "step-2", eventhandler_plugintype: { typename: "Other.Plugin", pluginassemblyid: { name: "OtherAsm" } } };
+    const other = { ...validRow, sdkmessageprocessingstepid: "step-2", plugintypeid: { typename: "Other.Plugin", pluginassemblyid: { name: "OtherAsm" } } };
     expect(parseProfilableSteps({ value: [validRow, other] }, "MyPlugins").map((s) => s.stepId)).toEqual(["step-1"]);
     expect(parseProfilableSteps({ value: [validRow, other] }, "OtherAsm").map((s) => s.stepId)).toEqual(["step-2"]);
     // No assembly filter → both.
@@ -34,18 +32,18 @@ describe("parseProfilableSteps", () => {
   });
 
   it("drops system (Microsoft.*) steps and the profiler's own (Profiled) clones", () => {
-    const microsoft = { ...validRow, sdkmessageprocessingstepid: "ms", eventhandler_plugintype: { typename: "Microsoft.Crm.X", pluginassemblyid: { name: "Microsoft" } } };
+    const microsoft = { ...validRow, sdkmessageprocessingstepid: "ms", plugintypeid: { typename: "Microsoft.Crm.X", pluginassemblyid: { name: "Microsoft" } } };
     const profiled = { ...validRow, sdkmessageprocessingstepid: "prof", name: "My.Plugins.AccountCreate (Profiled): Create of account" };
     expect(parseProfilableSteps({ value: [validRow, microsoft, profiled] }).map((s) => s.stepId)).toEqual(["step-1"]);
   });
 
-  it("#135 characterisation: a step whose plugintype expand didn't populate is dropped (typeName empty)", () => {
-    // The suspected #135 failure mode: eventhandler_plugintype comes back null for a real,
-    // active step, so typeName is "" and the `step.typeName && …` filter drops it — the
-    // handler then reports "No registered plugin steps to profile". This pins that
-    // behaviour; when #135 is diagnosed (resolve the type a different way), update it here.
-    expect(parseProfilableSteps({ value: [{ ...validRow, eventhandler_plugintype: null }] })).toEqual([]);
-    expect(parseProfilableSteps({ value: [{ ...validRow, eventhandler_plugintype: { pluginassemblyid: { name: "MyPlugins" } } }] })).toEqual([]);
+  it("#135: a row with no plugin type (null plugintypeid) is dropped — that's a webhook/service-endpoint step, not a plugin", () => {
+    // #135 root cause + fix: the query now expands the dedicated `plugintypeid` lookup (was
+    // the polymorphic `eventhandler_plugintype`, which didn't populate `typename` for normal
+    // plugin steps → every row dropped). A null plugintypeid now legitimately means "not a
+    // plugin step" (e.g. a webhook eventhandler), so dropping it is correct.
+    expect(parseProfilableSteps({ value: [{ ...validRow, plugintypeid: null }] })).toEqual([]);
+    expect(parseProfilableSteps({ value: [{ ...validRow, plugintypeid: { pluginassemblyid: { name: "MyPlugins" } } }] })).toEqual([]);
   });
 
   it("tolerates a missing/empty result set and missing optional expands", () => {
@@ -53,28 +51,28 @@ describe("parseProfilableSteps", () => {
     expect(parseProfilableSteps({})).toEqual([]);
     expect(parseProfilableSteps(undefined)).toEqual([]);
     // message/primaryEntity are optional — a step with no filter/message still shapes.
-    const minimal = { sdkmessageprocessingstepid: "m", name: "n", eventhandler_plugintype: { typename: "A.B", pluginassemblyid: { name: "Asm" } } };
+    const minimal = { sdkmessageprocessingstepid: "m", name: "n", plugintypeid: { typename: "A.B", pluginassemblyid: { name: "Asm" } } };
     expect(parseProfilableSteps({ value: [minimal] })).toEqual([{ stepId: "m", name: "n", typeName: "A.B", message: undefined, primaryEntity: undefined, mode: undefined }]);
   });
 });
 
 describe("profilableStepsDiagnostics (#135 — explain an empty result)", () => {
   it("counts each drop reason so a 'no steps' outcome is diagnosable", () => {
-    const microsoft = { ...validRow, sdkmessageprocessingstepid: "ms", eventhandler_plugintype: { typename: "Microsoft.Crm.X", pluginassemblyid: { name: "Microsoft" } } };
+    const microsoft = { ...validRow, sdkmessageprocessingstepid: "ms", plugintypeid: { typename: "Microsoft.Crm.X", pluginassemblyid: { name: "Microsoft" } } };
     const profiled = { ...validRow, sdkmessageprocessingstepid: "prof", name: "My.Plugins.AccountCreate (Profiled): Create of account" };
-    const noType = { ...validRow, sdkmessageprocessingstepid: "nt", eventhandler_plugintype: null };
+    const noType = { ...validRow, sdkmessageprocessingstepid: "nt", plugintypeid: null };
     const diag = profilableStepsDiagnostics({ value: [validRow, microsoft, profiled, noType] });
     expect(diag).toEqual({ total: 4, kept: 1, droppedNoType: 1, droppedSystem: 1, droppedProfiled: 1, droppedByAssembly: 0 });
   });
 
   it("attributes the whole result to the empty-plugintype bucket when that's the cause", () => {
-    const noType = { ...validRow, eventhandler_plugintype: null };
+    const noType = { ...validRow, plugintypeid: null };
     const diag = profilableStepsDiagnostics({ value: [noType] });
     expect(diag).toEqual({ total: 1, kept: 0, droppedNoType: 1, droppedSystem: 0, droppedProfiled: 0, droppedByAssembly: 0 });
   });
 
   it("counts assembly-scoped drops", () => {
-    const other = { ...validRow, sdkmessageprocessingstepid: "o", eventhandler_plugintype: { typename: "Other.Plugin", pluginassemblyid: { name: "OtherAsm" } } };
+    const other = { ...validRow, sdkmessageprocessingstepid: "o", plugintypeid: { typename: "Other.Plugin", pluginassemblyid: { name: "OtherAsm" } } };
     expect(profilableStepsDiagnostics({ value: [validRow, other] }, "MyPlugins")).toMatchObject({ total: 2, kept: 1, droppedByAssembly: 1 });
   });
 });

--- a/src/general/dataverse/pluginProfiles.spec.ts
+++ b/src/general/dataverse/pluginProfiles.spec.ts
@@ -1,5 +1,13 @@
 import { describe, expect, it } from "vitest";
-import { profilerInstalledQuery, pluginProfilesQuery, pluginProfileContentQuery } from "./pluginProfiles";
+import {
+  profilerInstalledQuery,
+  pluginProfilesQuery,
+  pluginProfileContentQuery,
+  activeProfilesQuery,
+  parseActiveProfiles,
+  profiledStepTypeLabel,
+  findMatchingStep,
+} from "./pluginProfiles";
 
 describe("plugin profile queries", () => {
   it("detects the profiler by its solution unique name", () => {
@@ -17,5 +25,53 @@ describe("plugin profile queries", () => {
   it("fetches one profile's report by GUID only", () => {
     expect(pluginProfileContentQuery("11111111-2222-3333-4444-555555555555")).toBe("mbs_pluginprofiles(11111111-2222-3333-4444-555555555555)?$select=mbs_profile");
     expect(() => pluginProfileContentQuery("1 or true")).toThrow(/Not a plugin profile id/);
+  });
+});
+
+describe("active plugin profiles (#139)", () => {
+  it("filters to the profiler's (Profiled) clones server-side and re-checks the marker", () => {
+    const q = activeProfilesQuery();
+    expect(q).toContain("sdkmessageprocessingsteps?$select=sdkmessageprocessingstepid,name,mode");
+    expect(q).toContain("contains(name,'(Profiled)')");
+    expect(q).toContain("statecode eq 0");
+  });
+
+  it("parses profiled clones, keeping only the marked rows", () => {
+    const rows = parseActiveProfiles({
+      value: [
+        {
+          sdkmessageprocessingstepid: "11111111-1111-1111-1111-111111111111",
+          name: "Acme.UpdatePlugin: Update of account (Profiled)",
+          mode: 0,
+          sdkmessageid: { name: "Update" },
+          sdkmessagefilterid: { primaryobjecttypecode: "account" },
+        },
+        { sdkmessageprocessingstepid: "22222222-2222-2222-2222-222222222222", name: "Acme.OtherPlugin: Create of contact", mode: 1 },
+      ],
+    });
+    expect(rows).toHaveLength(1);
+    expect(rows[0]).toEqual({
+      profilerStepId: "11111111-1111-1111-1111-111111111111",
+      typeName: "Acme.UpdatePlugin",
+      message: "Update",
+      primaryEntity: "account",
+      mode: 0,
+    });
+  });
+
+  it("labels a profiled clone by its type part, tolerating no colon", () => {
+    expect(profiledStepTypeLabel("Acme.Plugin: Update of account (Profiled)")).toBe("Acme.Plugin");
+    expect(profiledStepTypeLabel("Just A Name (Profiled)")).toBe("Just A Name");
+  });
+
+  it("matches a registration to a step by message + entity, disambiguating by type", () => {
+    const steps = [
+      { message: "Update", primaryEntity: "account", typeName: "Acme.AccountPlugin" },
+      { message: "Update", primaryEntity: "account", typeName: "Acme.OtherPlugin" },
+      { message: "Create", primaryEntity: "contact", typeName: "Acme.ContactPlugin" },
+    ];
+    expect(findMatchingStep(steps, { message: "Create", primaryEntity: "contact" })?.typeName).toBe("Acme.ContactPlugin");
+    expect(findMatchingStep(steps, { message: "Update", primaryEntity: "account", typeName: "OtherPlugin" })?.typeName).toBe("Acme.OtherPlugin");
+    expect(findMatchingStep(steps, { message: "Delete", primaryEntity: "account" })).toBeUndefined();
   });
 });

--- a/src/general/dataverse/pluginProfiles.ts
+++ b/src/general/dataverse/pluginProfiles.ts
@@ -57,9 +57,14 @@ export interface ProfilableStep {
  * assembly. Joins step -> plugintype -> pluginassembly and drops the profiler's own
  * "(Profiled)" clones. Read-only. Undefined on failure. */
 export async function getProfilableSteps(context: DataversePowerToolsContext, assemblyName?: string): Promise<ProfilableStep[] | undefined> {
-  const expand =
-    "$expand=sdkmessageid($select=name),sdkmessagefilterid($select=primaryobjecttypecode),eventhandler_plugintype($select=typename;$expand=pluginassemblyid($select=name))";
-  const resource = `sdkmessageprocessingsteps?$select=name,mode,statecode&${expand}&$filter=statecode eq 0&$top=200`;
+  // #135: expand the DEDICATED `plugintypeid` lookup — NOT the polymorphic `eventhandler`
+  // (which targets plugintype OR serviceendpoint and doesn't populate `typename` for a
+  // normally-registered plugin step, so every row was dropped). The Microsoft docs query a
+  // step's plugin type via `plugintypeid($select=...)` and a webhook's via
+  // `eventhandler_serviceendpoint`. `_plugintypeid_value ne null` keeps plugin steps and
+  // excludes webhook/service-endpoint steps server-side.
+  const expand = "$expand=sdkmessageid($select=name),sdkmessagefilterid($select=primaryobjecttypecode),plugintypeid($select=typename;$expand=pluginassemblyid($select=name))";
+  const resource = `sdkmessageprocessingsteps?$select=name,mode,statecode&${expand}&$filter=statecode eq 0 and _plugintypeid_value ne null&$top=200`;
   const body = await getJson(context, "List profilable plugin steps", resource);
   if (!body) {
     return undefined;
@@ -99,7 +104,7 @@ export function profilableStepsDiagnostics(body: any, assemblyName?: string): Pr
   const rows: any[] = body?.value ?? [];
   const diag: ProfilableStepsDiagnostics = { total: rows.length, kept: 0, droppedNoType: 0, droppedSystem: 0, droppedProfiled: 0, droppedByAssembly: 0 };
   for (const row of rows) {
-    const type = row.eventhandler_plugintype;
+    const type = row.plugintypeid;
     const typeName = (type?.typename as string) ?? "";
     const name = (row.name as string) ?? "";
     const stepAssembly = (type?.pluginassemblyid?.name as string) ?? "";
@@ -120,16 +125,16 @@ export function profilableStepsDiagnostics(body: any, assemblyName?: string): Pr
 
 /**
  * Shape + filter the sdkmessageprocessingsteps response into profilable steps (pure,
- * unit-tested). Drops steps whose plugintype expand didn't resolve a typeName, system
- * (Microsoft.*) steps, and the profiler's own "(Profiled)" clones; optionally scopes to
- * one assembly. NB: an active, registered step whose `eventhandler_plugintype` expand
- * comes back empty is dropped here (typeName ""), the suspected #135 failure mode.
+ * unit-tested). Reads the step's plugin type from the dedicated `plugintypeid` expand
+ * (#135 — the polymorphic `eventhandler_plugintype` didn't populate `typename` for normal
+ * plugin steps). Drops rows without a resolved typeName, system (Microsoft.*) steps, and
+ * the profiler's own "(Profiled)" clones; optionally scopes to one assembly.
  */
 export function parseProfilableSteps(body: any, assemblyName?: string): ProfilableStep[] {
   const rows: any[] = body?.value ?? [];
   return rows
     .map((row) => {
-      const type = row.eventhandler_plugintype;
+      const type = row.plugintypeid;
       return {
         stepId: row.sdkmessageprocessingstepid as string,
         name: (row.name as string) ?? "",

--- a/src/general/dataverse/pluginProfiles.ts
+++ b/src/general/dataverse/pluginProfiles.ts
@@ -150,6 +150,134 @@ export function parseProfilableSteps(body: any, assemblyName?: string): Profilab
     .map(({ assemblyName: _assemblyName, ...step }) => step);
 }
 
+// --- Active (server-side-enabled) plug-in profiles (#139) ---
+//
+// When a step is profiled, the Plugin Profiler registers a CLONE of the step whose name
+// carries a "(Profiled)" marker (the same marker parseProfilableSteps drops so the clone
+// isn't offered for profiling again). That clone's OWN sdkmessageprocessingstepid is the
+// `profiler-step` the net48 tool's `disable` takes, so an active profile row = a profiled
+// clone. Read-only; works under both auth types.
+
+const PROFILED_MARKER = /\s*\(Profiled\)\s*$/;
+
+export interface ActiveProfileStep {
+  /** The profiler clone's step id — the `--profiler-step` disable/delete targets. */
+  profilerStepId: string;
+  /** Cleaned type/label parsed from the clone's name (the "(Profiled)" suffix stripped). */
+  typeName: string;
+  message?: string;
+  primaryEntity?: string;
+  /** 0 = synchronous, 1 = asynchronous. */
+  mode?: number;
+}
+
+/** Currently-profiled steps: the profiler's "(Profiled)" clones. `contains` narrows server-side;
+ * parseActiveProfiles re-checks the marker so a permissive server filter can't leak non-clones. */
+export function activeProfilesQuery(): string {
+  const expand = "$expand=sdkmessageid($select=name),sdkmessagefilterid($select=primaryobjecttypecode)";
+  return `sdkmessageprocessingsteps?$select=sdkmessageprocessingstepid,name,mode,statecode&${expand}&$filter=statecode eq 0 and contains(name,'(Profiled)')&$top=200`;
+}
+
+/** Human label from a profiled clone's name: strip the "(Profiled)" suffix and, when the
+ * name is the "Type: Message of entity" convention, keep the type part before the colon. Pure. */
+export function profiledStepTypeLabel(name: string): string {
+  const cleaned = (name ?? "").replace(PROFILED_MARKER, "").trim();
+  const colon = cleaned.indexOf(":");
+  return (colon > 0 ? cleaned.slice(0, colon) : cleaned).trim();
+}
+
+/** Shape the sdkmessageprocessingsteps response into active-profile rows (pure, unit-tested).
+ * Keeps only rows still carrying the "(Profiled)" marker. */
+export function parseActiveProfiles(body: any): ActiveProfileStep[] {
+  const rows: any[] = body?.value ?? [];
+  return rows
+    .filter((row) => PROFILED_MARKER.test((row.name as string) ?? ""))
+    .map((row) => ({
+      profilerStepId: row.sdkmessageprocessingstepid as string,
+      typeName: profiledStepTypeLabel((row.name as string) ?? ""),
+      message: row.sdkmessageid?.name as string | undefined,
+      primaryEntity: row.sdkmessagefilterid?.primaryobjecttypecode as string | undefined,
+      mode: row.mode as number | undefined,
+    }));
+}
+
+/** A step-attribute's identity, parsed from the source registration, used to match it to a
+ * deployed server step (profilable original) or an active profiler clone (#139). */
+export interface RegistrationKey {
+  message?: string;
+  primaryEntity?: string;
+  /** Full type name (namespace.Class) or bare class name — matched leniently. */
+  typeName?: string;
+}
+
+function norm(value: string | undefined): string {
+  return (value ?? "").trim().toLowerCase();
+}
+
+function messageEntityMatch(step: { message?: string; primaryEntity?: string }, key: RegistrationKey): boolean {
+  if (key.message && norm(step.message) !== norm(key.message)) {
+    return false;
+  }
+  // An empty entity on either side matches (some messages have no primary entity).
+  if (key.primaryEntity && step.primaryEntity && norm(step.primaryEntity) !== norm(key.primaryEntity)) {
+    return false;
+  }
+  return true;
+}
+
+function typeMatch(stepType: string | undefined, keyType: string | undefined): boolean {
+  if (!stepType || !keyType) {
+    return false;
+  }
+  const a = norm(stepType);
+  const b = norm(keyType);
+  return a === b || a.endsWith(b) || b.endsWith(a) || a.includes(b) || b.includes(a);
+}
+
+/** Match a registration to a step by message + entity, disambiguating by type when several
+ * share the same message/entity (pure, unit-tested). Undefined when nothing matches. */
+export function findMatchingStep<T extends { message?: string; primaryEntity?: string; typeName?: string }>(steps: T[], key: RegistrationKey): T | undefined {
+  const candidates = steps.filter((step) => messageEntityMatch(step, key));
+  if (candidates.length <= 1) {
+    return candidates[0];
+  }
+  const typed = candidates.filter((step) => typeMatch(step.typeName, key.typeName));
+  return typed[0] ?? candidates[0];
+}
+
+/** Active profiler clones in the org, newest-agnostic. Undefined on failure/not connected. */
+export async function getActiveProfiles(context: DataversePowerToolsContext): Promise<ActiveProfileStep[] | undefined> {
+  const body = await getJson(context, "List active plugin profiles", activeProfilesQuery());
+  return body ? parseActiveProfiles(body) : undefined;
+}
+
+/** Delete a profiler clone step via the Web API — the non-Windows fallback for "Stop"
+ * (the net48 disable tool is Windows-only). Returns true on success. */
+export async function deleteProfilerStep(context: DataversePowerToolsContext, profilerStepId: string): Promise<boolean> {
+  if (!GUID.test(profilerStepId)) {
+    return false;
+  }
+  const dataverse = context.dataverse;
+  if (!dataverse || !canCallDataverseApi({ organizationUrl: dataverse.organizationUrl, isValid: dataverse.isValid })) {
+    return false;
+  }
+  try {
+    const url = dataverseApiUrl(dataverse.organizationUrl, `sdkmessageprocessingsteps(${profilerStepId})`);
+    const response = await fetch(url, {
+      method: "DELETE",
+      headers: { Authorization: "Bearer " + (await dataverse.getAuthorizationToken()), "Content-Type": "application/json" },
+    });
+    if (!response.ok) {
+      await logDataverseHttpError(context.channel, "delete the profiler step", response);
+      return false;
+    }
+    return true;
+  } catch (error) {
+    logDataverseError(context.channel, "delete the profiler step", error);
+    return false;
+  }
+}
+
 async function getJson(context: DataversePowerToolsContext, operation: string, resourcePath: string): Promise<any | undefined> {
   const dataverse = context.dataverse;
   if (!dataverse || !canCallDataverseApi({ organizationUrl: dataverse.organizationUrl, isValid: dataverse.isValid })) {

--- a/src/general/dataverse/traceLogSetting.spec.ts
+++ b/src/general/dataverse/traceLogSetting.spec.ts
@@ -1,0 +1,14 @@
+import { describe, expect, it } from "vitest";
+import { traceLogLabel, organizationTraceLogQuery } from "./traceLogSetting";
+
+describe("trace log setting", () => {
+  it("labels + colours each level (green → orange → red)", () => {
+    expect(traceLogLabel(0)).toEqual({ label: "Trace: Off", colour: "green" });
+    expect(traceLogLabel(1)).toEqual({ label: "Trace: Errors", colour: "orange" });
+    expect(traceLogLabel(2)).toEqual({ label: "Trace: All", colour: "red" });
+  });
+
+  it("reads the org id + setting from the single organization row", () => {
+    expect(organizationTraceLogQuery()).toBe("organizations?$select=organizationid,plugintracelogsetting");
+  });
+});

--- a/src/general/dataverse/traceLogSetting.ts
+++ b/src/general/dataverse/traceLogSetting.ts
@@ -1,0 +1,105 @@
+/* eslint-disable @typescript-eslint/naming-convention -- record fields are Dataverse logical names */
+import type DataversePowerToolsContext from "../../context";
+import { dataverseApiUrl, logDataverseError, logDataverseHttpError } from "./webApi";
+import { canCallDataverseApi } from "./connectionReady";
+
+// The org-wide plug-in trace-log level (#137): the `plugintracelogsetting` column on the
+// single `organization` row. 0 = Off, 1 = Exception (errors only), 2 = All. Read on
+// connect/refresh (cached by the panel) and written from the panel's trace-log tag.
+// Works under BOTH auth types — the access token authorises the call, never gate on tenantId.
+// `import type` on the context keeps this module `vscode`-free so the pure `traceLogLabel`
+// can be imported by the panel view-model without pulling in the editor API.
+
+export type TraceLogLevel = 0 | 1 | 2;
+
+export interface TraceLogLabel {
+  label: string;
+  /** Pill colour by severity — green (off) → orange (errors) → red (all, has a cost). */
+  colour: "green" | "orange" | "red";
+}
+
+/** Map a trace-log level to its pill label + colour (pure, unit-tested). */
+export function traceLogLabel(value: TraceLogLevel): TraceLogLabel {
+  switch (value) {
+    case 1:
+      return { label: "Trace: Errors", colour: "orange" };
+    case 2:
+      return { label: "Trace: All", colour: "red" };
+    case 0:
+    default:
+      return { label: "Trace: Off", colour: "green" };
+  }
+}
+
+/** The org row carrying the trace-log setting + the id needed to PATCH it (pure). */
+export function organizationTraceLogQuery(): string {
+  return "organizations?$select=organizationid,plugintracelogsetting";
+}
+
+interface OrganizationTraceRow {
+  organizationid: string;
+  plugintracelogsetting: TraceLogLevel;
+}
+
+async function getOrganizationTraceRow(context: DataversePowerToolsContext): Promise<OrganizationTraceRow | undefined> {
+  const dataverse = context.dataverse;
+  if (!dataverse || !canCallDataverseApi({ organizationUrl: dataverse.organizationUrl, isValid: dataverse.isValid })) {
+    return undefined;
+  }
+  try {
+    const url = dataverseApiUrl(dataverse.organizationUrl, organizationTraceLogQuery());
+    const response = await fetch(url, {
+      method: "GET",
+      headers: { Authorization: "Bearer " + (await dataverse.getAuthorizationToken()), "Content-Type": "application/json" },
+    });
+    if (!response.ok) {
+      await logDataverseHttpError(context.channel, "read the plug-in trace log setting", response);
+      return undefined;
+    }
+    const body: any = await response.json();
+    const row = body?.value?.[0];
+    if (!row || typeof row.organizationid !== "string") {
+      return undefined;
+    }
+    const level = Number(row.plugintracelogsetting);
+    return { organizationid: row.organizationid, plugintracelogsetting: (level === 1 || level === 2 ? level : 0) as TraceLogLevel };
+  } catch (error) {
+    logDataverseError(context.channel, "read the plug-in trace log setting", error);
+    return undefined;
+  }
+}
+
+/** Current org-wide plug-in trace-log level, or undefined when not connected / on failure. */
+export async function getTraceLogSetting(context: DataversePowerToolsContext): Promise<TraceLogLevel | undefined> {
+  const row = await getOrganizationTraceRow(context);
+  return row ? row.plugintracelogsetting : undefined;
+}
+
+/** Set the org-wide plug-in trace-log level via PATCH organizations(<id>). Returns true on success. */
+export async function setTraceLogSetting(context: DataversePowerToolsContext, value: TraceLogLevel): Promise<boolean> {
+  const dataverse = context.dataverse;
+  if (!dataverse || !canCallDataverseApi({ organizationUrl: dataverse.organizationUrl, isValid: dataverse.isValid })) {
+    return false;
+  }
+  const row = await getOrganizationTraceRow(context);
+  if (!row) {
+    context.channel.appendLine("Could not resolve the organization row to set the plug-in trace log level — see the output.");
+    return false;
+  }
+  try {
+    const url = dataverseApiUrl(dataverse.organizationUrl, `organizations(${row.organizationid})`);
+    const response = await fetch(url, {
+      method: "PATCH",
+      headers: { Authorization: "Bearer " + (await dataverse.getAuthorizationToken()), "Content-Type": "application/json" },
+      body: JSON.stringify({ plugintracelogsetting: value }),
+    });
+    if (!response.ok) {
+      await logDataverseHttpError(context.channel, "set the plug-in trace log setting", response);
+      return false;
+    }
+    return true;
+  } catch (error) {
+    logDataverseError(context.channel, "set the plug-in trace log setting", error);
+    return false;
+  }
+}

--- a/src/general/initialiseExtension.ts
+++ b/src/general/initialiseExtension.ts
@@ -7,6 +7,7 @@ import { createServicePrincipalString, updateConnectionString, switchEnvironment
 import { openEnvironment, openAdminCenter, openMakerPortal } from "./openPortals";
 import { createNewProject } from "./generateTemplates";
 import { restoreDependencies } from "./restoreDependencies";
+import { setTraceLogLevel } from "./setTraceLogLevel";
 import { DataverseContext } from "./dataverse/dataverseContext";
 import { scanSystemRequirements } from "./systemRequirements";
 
@@ -32,6 +33,7 @@ export async function generalInitialise(context: DataversePowerToolsContext) {
     context.vscode.subscriptions.push(vscode.commands.registerCommand("dataverse-powertools.updateConnectionString", () => updateConnectionString(context)));
     context.vscode.subscriptions.push(vscode.commands.registerCommand("dataverse-powertools.switchEnvironment", () => switchEnvironment(context)));
     context.vscode.subscriptions.push(vscode.commands.registerCommand("dataverse-powertools.refreshConnection", () => refreshConnection(context)));
+    context.vscode.subscriptions.push(vscode.commands.registerCommand("dataverse-powertools.setTraceLogLevel", () => setTraceLogLevel(context)));
     context.vscode.subscriptions.push(vscode.commands.registerCommand("dataverse-powertools.clearPacCredentials", () => clearPacCredentials(context)));
     context.vscode.subscriptions.push(vscode.commands.registerCommand("dataverse-powertools.openEnvironment", () => openEnvironment(context)));
     context.vscode.subscriptions.push(vscode.commands.registerCommand("dataverse-powertools.openAdminCenter", () => openAdminCenter(context)));

--- a/src/general/setTraceLogLevel.ts
+++ b/src/general/setTraceLogLevel.ts
@@ -1,0 +1,58 @@
+import * as vscode from "vscode";
+import DataversePowerToolsContext from "../context";
+import { getTraceLogSetting, setTraceLogSetting, TraceLogLevel } from "./dataverse/traceLogSetting";
+import { canCallDataverseApi } from "./dataverse/connectionReady";
+import { getTraceLogCache, refreshPanelData } from "../panel/panelDataCache";
+
+// General command (#137): manage the org-wide plug-in trace-log level from the panel's org-header
+// tag. Needs a live connection (not a plugin component), so it's registered once with the other
+// general connection commands — never in the project-type registry. Works under both auth types.
+
+interface TraceLogPick extends vscode.QuickPickItem {
+  level: TraceLogLevel;
+}
+
+export async function setTraceLogLevel(context: DataversePowerToolsContext): Promise<void> {
+  const dataverse = context.dataverse;
+  if (!dataverse || !canCallDataverseApi({ organizationUrl: dataverse.organizationUrl, isValid: dataverse.isValid })) {
+    vscode.window.showErrorMessage("Connect to Dataverse first to change the plug-in trace log level.");
+    return;
+  }
+
+  // Prefer the cached level (already read on connect); fall back to a live read.
+  const current = getTraceLogCache() ?? (await getTraceLogSetting(context));
+
+  const base: TraceLogPick[] = [
+    { level: 0, label: "Off", description: "No plug-in trace logging" },
+    { level: 1, label: "Exception only", description: "Log traces only when a plug-in throws" },
+    { level: 2, label: "All", description: "Log every plug-in trace (perf/storage cost)" },
+  ];
+  // Mark the current level with a check + pre-select it.
+  const items: TraceLogPick[] = base.map((item) => (item.level === current ? { ...item, label: `$(check) ${item.label}`, picked: true } : item));
+
+  const pick = await vscode.window.showQuickPick(items, { placeHolder: "Set the plug-in trace log level", ignoreFocusOut: true });
+  if (!pick || pick.level === current) {
+    return;
+  }
+
+  // Switching to All has a perf/storage cost — confirm before turning the firehose on.
+  if (pick.level === 2) {
+    const confirm = await vscode.window.showWarningMessage(
+      "Set plug-in trace logging to All? Every plug-in execution writes a trace log — this has a performance and storage cost. Turn it off again when you're done.",
+      { modal: true },
+      "Set to All",
+    );
+    if (confirm !== "Set to All") {
+      return;
+    }
+  }
+
+  const ok = await setTraceLogSetting(context, pick.level);
+  if (!ok) {
+    vscode.window.showErrorMessage("Could not update the plug-in trace log level — see the output.");
+    return;
+  }
+  context.channel.appendLine(`[Trace] Plug-in trace log level set to ${pick.level} (${pick.label.replace(/^\$\(check\)\s*/, "")}).`);
+  // Re-read + re-render so the org-header tag re-colours immediately.
+  await refreshPanelData(context);
+}

--- a/src/panel/menuModel.spec.ts
+++ b/src/panel/menuModel.spec.ts
@@ -150,6 +150,21 @@ describe("project cards", () => {
   });
 });
 
+describe("plug-in trace-log tag (#137)", () => {
+  it("hides the tag until the level is known", () => {
+    expect(card(state({ traceLog: undefined }), "environment").traceLog).toBeUndefined();
+  });
+
+  it("colours + labels the tag by level and wires the picker command", () => {
+    const tag = card(state({ traceLog: 2 }), "environment").traceLog!;
+    expect(tag.label).toBe("Trace: All");
+    expect(tag.colour).toBe("red");
+    expect(tag.action.command).toBe("dataverse-powertools.setTraceLogLevel");
+    expect(card(state({ traceLog: 0 }), "environment").traceLog!.colour).toBe("green");
+    expect(card(state({ traceLog: 1 }), "environment").traceLog!.colour).toBe("orange");
+  });
+});
+
 describe("plugin debugging block (#63)", () => {
   const pluginState = (over: Partial<ProjectCardState> = {}) => state({ projects: [project({ type: "plugin", ...over })] });
 
@@ -174,6 +189,18 @@ describe("plugin debugging block (#63)", () => {
   it("reports the downloaded-profile count from the local scan", () => {
     expect(card(pluginState({ downloadedProfiles: 0 }), "project").debugging!.downloadedProfiles).toBe(0);
     expect(card(pluginState({ downloadedProfiles: 3 }), "project").debugging!.downloadedProfiles).toBe(3);
+  });
+
+  it("carries the org-wide active-profiles list onto the plugin card (#139)", () => {
+    const rows = [{ label: "Acme.Plugin", detail: "Update · account", index: 0 }];
+    const withProfiles = state({ projects: [project({ type: "plugin" })], activeProfiles: rows });
+    expect(card(withProfiles, "project").debugging!.activeProfiles).toEqual(rows);
+    expect(card(pluginState(), "project").debugging!.activeProfiles).toEqual([]);
+  });
+
+  it("adds the profiling how-to to the plugin card overflow (#139)", () => {
+    const overflow = card(pluginState(), "project").overflow.map((a) => a.command);
+    expect(overflow).toContain("dataverse-powertools.guidePluginProfiling");
   });
 
   it("keeps the profiler commands out of the card overflow (they live in the block)", () => {

--- a/src/panel/menuModel.ts
+++ b/src/panel/menuModel.ts
@@ -8,6 +8,7 @@
 // in a per-card ⋯ overflow; requirements collapse to a footer line once green.
 import { MenuAction, ProjectMenuState, getProjectTypeDescriptor } from "../projectTypes/registry";
 import { normalizeFsPath, applyLayout, Layout } from "../components/discovery";
+import { traceLogLabel, TraceLogLevel } from "../general/dataverse/traceLogSetting";
 
 export interface RequirementRow {
   id: "dotnet" | "node" | "pac";
@@ -48,6 +49,16 @@ export interface RegistrationsBlock {
   note?: string;
 }
 
+/** One currently-profiled step in the plugin card's Active-profiles block (#139). */
+export interface ActiveProfileRow {
+  /** Primary label — the step's type (e.g. Acme.UpdatePlugin). */
+  label: string;
+  /** Secondary line — "message · entity". */
+  detail: string;
+  /** Index into the host-side active-profiles cache; the trash-can sends it to stop that step. */
+  index: number;
+}
+
 /** The profiler/debugging block embedded in a plugin project card (#63). Local
  * data only (a scan of profiles/), so the panel stays network-free. Capture is
  * Windows-only (a net48 tool); download + replay-from-file work everywhere. */
@@ -63,6 +74,9 @@ export interface DebuggingBlock {
   download: MenuAction;
   /** Generate + debug a replay test from a downloaded/dropped profile (file picker). */
   replay: MenuAction;
+  /** Currently server-side-profiled steps, org-wide (#139) — the always-visible "one is on"
+   * list, each row's trash-can stops it. Empty when nothing is profiled. */
+  activeProfiles: ActiveProfileRow[];
 }
 
 /** Registrations shown before collapsing into a "+N more" note (big repos can have hundreds). */
@@ -83,6 +97,9 @@ export type Card =
       label?: string;
       connected: boolean;
       switchAction: MenuAction;
+      /** Plug-in trace-log tag (#137): label + colour + the click action that opens the picker.
+       * Undefined until the level has been read from the org (on connect / refresh). */
+      traceLog?: { label: string; colour: string; action: MenuAction };
       overflow: MenuAction[];
     }
   | {
@@ -156,6 +173,12 @@ export interface PanelState {
   environmentLabel?: string;
   /** Live Dataverse connection established (token acquired). */
   connected: boolean;
+  /** Org-wide plug-in trace-log level (#137), cached from the last connect/refresh. Undefined
+   * until read (or when not connected) — the org-header tag is hidden then. */
+  traceLog?: TraceLogLevel;
+  /** Currently server-side-profiled steps (#139), org-wide, cached from the last connect/refresh.
+   * Pre-indexed into the host cache so the trash-can can stop a specific one. */
+  activeProfiles?: ActiveProfileRow[];
   /** A web-resource debug session (webpack watch + browser) is running. */
   debugSessionActive: boolean;
   /** Scanned RegisterEvent decorations, pre-formatted for display. */
@@ -258,6 +281,11 @@ function environmentCard(state: PanelState): Card {
     label: state.environmentLabel,
     connected: state.connected,
     switchAction: { command: "dataverse-powertools.switchEnvironment", label: "Switch" },
+    // Plug-in trace-log tag (#137): shown once the level is known; click opens the picker.
+    traceLog:
+      state.traceLog !== undefined
+        ? { ...traceLogLabel(state.traceLog), action: { command: "dataverse-powertools.setTraceLogLevel", label: "Set plugin trace log level" } }
+        : undefined,
     // Restore Dependencies lives on the PROJECT card — it restores the
     // project's packages, not the connection (manual-testing feedback).
     overflow: [
@@ -283,15 +311,17 @@ function registrationsFor(state: PanelState, project: ProjectCardState): Registr
   };
 }
 
-/** The profiler/debugging block for one plugin card. Status comes from a local
- * scan of profiles/, so no network is needed to render. */
-function debuggingFor(project: ProjectCardState): DebuggingBlock {
+/** The profiler/debugging block for one plugin card. The downloaded count comes from a local
+ * scan of profiles/; the active-profiles list comes from the cached org query (#139) — neither
+ * hits the network at render time. Active profiles are org-wide, so every plugin card shows them. */
+function debuggingFor(project: ProjectCardState, state: PanelState): DebuggingBlock {
   return {
     downloadedProfiles: project.downloadedProfiles ?? 0,
     capture: forComponent({ command: "dataverse-powertools.capturePluginRun", label: "Profile next run" }, project),
     captureSupported: project.captureSupported ?? false,
     download: forComponent({ command: "dataverse-powertools.downloadPluginProfiles", label: "Download a run" }, project),
     replay: forComponent({ command: "dataverse-powertools.generatePluginReplayTest", label: "Replay & debug" }, project),
+    activeProfiles: state.activeProfiles ?? [],
   };
 }
 
@@ -387,8 +417,8 @@ export function buildMenuModel(state: PanelState): MenuModel {
       status: statusFromActivity(state.activity, project),
       // Each web-resource card carries its OWN registrations (multiple components each).
       registrations: isWebresource ? registrationsFor(state, project) : undefined,
-      // Plugin cards carry the profiler/debugging workflow (#63).
-      debugging: descriptor.id === "plugin" ? debuggingFor(project) : undefined,
+      // Plugin cards carry the profiler/debugging workflow (#63) + active-profiles list (#139).
+      debugging: descriptor.id === "plugin" ? debuggingFor(project, state) : undefined,
     };
   };
 

--- a/src/panel/menuPanel.ts
+++ b/src/panel/menuPanel.ts
@@ -6,6 +6,8 @@ import { computePanelState } from "./panelState";
 import { projectTypeRegistry } from "../projectTypes/registry";
 import { onDebugSessionChanged } from "../webresources/debug/debugWebresources";
 import { openScannedRegistration } from "./registrationsScanner";
+import { refreshPanelData } from "./panelDataCache";
+import { stopActiveProfileByIndex } from "../plugins/profilerToggle";
 
 // Commands the webview may ask the host to run. The webview is our own code
 // behind a strict CSP, but treat its messages as untrusted anyway.
@@ -17,6 +19,7 @@ const GENERAL_PANEL_COMMANDS = [
   "dataverse-powertools.refreshConnection",
   "dataverse-powertools.updateConnectionString",
   "dataverse-powertools.switchEnvironment",
+  "dataverse-powertools.setTraceLogLevel",
   "dataverse-powertools.openEnvironment",
   "dataverse-powertools.openAdminCenter",
   "dataverse-powertools.openMakerPortal",
@@ -80,6 +83,17 @@ export class MenuPanelViewProvider implements vscode.WebviewViewProvider {
         if (typeof message.index === "number") {
           await openScannedRegistration(message.index);
         }
+        break;
+      case "stopProfile":
+        // Trash-can on an Active-profiles row (#139): the webview sends only an index into the
+        // host-side active-profiles cache; the handler resolves the profiler step to stop.
+        if (typeof message.index === "number") {
+          await stopActiveProfileByIndex(this.context, message.index);
+        }
+        break;
+      case "refreshProfiles":
+        // Refresh affordance on the Active-profiles block (#139): re-fetch + re-render.
+        await refreshPanelData(this.context);
         break;
       case "execute":
         if (typeof message.command === "string" && allowedCommands.has(message.command)) {

--- a/src/panel/panelDataCache.ts
+++ b/src/panel/panelDataCache.ts
@@ -1,0 +1,59 @@
+import DataversePowerToolsContext from "../context";
+import { getTraceLogSetting, TraceLogLevel } from "../general/dataverse/traceLogSetting";
+import { getActiveProfiles, ActiveProfileStep } from "../general/dataverse/pluginProfiles";
+import { ProjectTypes } from "../projectTypes/registry";
+
+// The actions panel is network-free (#100): computePanelState is called on every refresh and
+// must not spawn network/process. Dataverse-derived panel data — the org trace-log level (#137)
+// and the active-profiled steps (#139) — is therefore fetched ONCE on connect / explicit refresh
+// and CACHED here; computePanelState (and the profiler CodeLens) read this cache synchronously.
+
+let traceLog: TraceLogLevel | undefined;
+let activeProfiles: ActiveProfileStep[] = [];
+
+export function getTraceLogCache(): TraceLogLevel | undefined {
+  return traceLog;
+}
+
+export function getActiveProfilesCache(): ActiveProfileStep[] {
+  return activeProfiles;
+}
+
+/** Reset the cache (e.g. before switching environments so the previous org's values don't linger). */
+export function clearPanelDataCache(): void {
+  traceLog = undefined;
+  activeProfiles = [];
+}
+
+function hasPluginComponent(context: DataversePowerToolsContext): boolean {
+  return (context.components ?? []).some((component) => component.settings.type === ProjectTypes.plugin) || context.projectSettings?.type === ProjectTypes.plugin;
+}
+
+/** Re-fetch just the active-profiler-step cache (after a toggle / stop / block refresh) and
+ * re-render the panel. Fetched only when a plugin component is present. */
+export async function refreshActiveProfiles(context: DataversePowerToolsContext): Promise<void> {
+  if (hasPluginComponent(context)) {
+    const profiles = await getActiveProfiles(context);
+    if (profiles !== undefined) {
+      activeProfiles = profiles;
+    }
+  }
+  context.refreshPanel?.();
+}
+
+/** Fetch all Dataverse-derived panel data on connect / explicit refresh and cache it, then
+ * re-render. Gated on a live connection inside each getter — a no-op (undefined) offline, so
+ * the previous good values survive a transient failure. Fire-and-forget from callers. */
+export async function refreshPanelData(context: DataversePowerToolsContext): Promise<void> {
+  const level = await getTraceLogSetting(context);
+  if (level !== undefined) {
+    traceLog = level;
+  }
+  if (hasPluginComponent(context)) {
+    const profiles = await getActiveProfiles(context);
+    if (profiles !== undefined) {
+      activeProfiles = profiles;
+    }
+  }
+  context.refreshPanel?.();
+}

--- a/src/panel/panelState.ts
+++ b/src/panel/panelState.ts
@@ -8,6 +8,7 @@ import { parseAuthType, DataverseAuthType } from "../general/dataverse/authTypes
 import { getSystemRequirementsStatus } from "../general/systemRequirements";
 import { getRecentOperations } from "./operationTracker";
 import { getScannedRegistrations } from "./registrationsScanner";
+import { getTraceLogCache, getActiveProfilesCache } from "./panelDataCache";
 import { isDebugSessionActive } from "../webresources/debug/debugWebresources";
 import { ComponentSettings } from "../components/discovery";
 
@@ -90,6 +91,14 @@ export function computePanelState(context: DataversePowerToolsContext): PanelSta
     authType: loaded && parseAuthType(parseConnectionString(context.connectionString).authType) === DataverseAuthType.oauth ? "oauth" : "clientsecret",
     environmentLabel: settings.environmentLabel,
     connected: !!context.dataverse?.isValid,
+    // Dataverse-derived values read from the cache refreshed on connect/refresh (#137/#139) —
+    // never fetched here (this function is called on every render and must stay network-free).
+    traceLog: getTraceLogCache(),
+    activeProfiles: getActiveProfilesCache().map((profile, index) => ({
+      label: profile.typeName || "Profiled step",
+      detail: [profile.message, profile.primaryEntity].filter(Boolean).join(" · "),
+      index,
+    })),
     debugSessionActive: isDebugSessionActive(),
     // Rows come from the per-component decoration scan of webresources_src (the
     // source of truth), not settings. index → openScannedRegistration go-to-file.

--- a/src/plugins/decorationsCodeLens.ts
+++ b/src/plugins/decorationsCodeLens.ts
@@ -1,6 +1,10 @@
 import * as vscode from "vscode";
 import DataversePowerToolsContext from "../context";
 import { addClassDecoration, updateFilteringAttributes } from "./decorations";
+import { parseRegistrationArgs } from "./registrationAttribute";
+import { findMatchingStep } from "../general/dataverse/pluginProfiles";
+import { getActiveProfilesCache } from "../panel/panelDataCache";
+import { findEnclosingClassType, toggleStepProfiling } from "./profilerToggle";
 
 function inheritsSupportedBase(inheritanceClause: string): boolean {
   return /\bPluginBase\b/.test(inheritanceClause) || /\bWorkflowBase\b/.test(inheritanceClause) || /\bCodeActivity\b/.test(inheritanceClause);
@@ -72,6 +76,24 @@ class DecorationCodeLensProvider implements vscode.CodeLensProvider {
             arguments: [document.uri, start.line],
           }),
         );
+        // Per-step profiling toggle (#139): on/off from the CACHED active-profiles list (the
+        // provider runs on every render — never query Dataverse here). Placing it per-attribute
+        // gives one toggle per step even when a class registers several.
+        const parsed = parseRegistrationArgs(argsText);
+        if (parsed) {
+          const isOn = !!findMatchingStep(getActiveProfilesCache(), {
+            message: parsed.message,
+            primaryEntity: parsed.primaryEntity,
+            typeName: findEnclosingClassType(fullText, start.line),
+          });
+          codeLenses.push(
+            new vscode.CodeLens(new vscode.Range(start.line, 0, start.line, 0), {
+              title: isOn ? "$(record) Profile: On" : "$(debug-alt) Profile: Off",
+              command: "dataverse-powertools.toggleStepProfilingAtLine",
+              arguments: [document.uri, start.line],
+            }),
+          );
+        }
       }
 
       match = decorationRegex.exec(fullText);
@@ -93,6 +115,14 @@ export function registerDecorationCodeLens(context: DataversePowerToolsContext):
     vscode.commands.registerCommand("dataverse-powertools.updateFilteringAttributesAtLine", async (uri: vscode.Uri, line: number) => {
       await focusDecorationTokenInEditor(uri, line);
       await updateFilteringAttributes(context, line);
+    }),
+  );
+
+  // Per-step profiling toggle command (#139). Registered ONCE here (global), like the other
+  // per-line decoration commands — never in a per-component initialise* (would collide).
+  context.vscode.subscriptions.push(
+    vscode.commands.registerCommand("dataverse-powertools.toggleStepProfilingAtLine", async (uri: vscode.Uri, line: number) => {
+      await toggleStepProfiling(context, uri, line);
     }),
   );
 

--- a/src/plugins/profilerCapture.ts
+++ b/src/plugins/profilerCapture.ts
@@ -26,6 +26,21 @@ export function stepPickLabel(step: ProfilableStep): { label: string; descriptio
 /** Install the Plugin Profiler managed solution (from the PRT NuGet) via ImportSolution
  * when it's missing — so capture is one-click instead of "go install it in PRT". Shown
  * with progress; returns true when the profiler is present afterwards. */
+/** Ensure the Plugin Profiler managed solution is installed (checking, then one-click importing
+ * when missing) so enable/disable can run. Returns true when the profiler is present afterwards;
+ * false (with an error surfaced) when the org couldn't be reached or the install failed. */
+export async function ensureProfilerInstalled(context: DataversePowerToolsContext): Promise<boolean> {
+  const installed = await isProfilerInstalled(context);
+  if (installed === undefined) {
+    vscode.window.showErrorMessage("Could not reach Dataverse to check for the Plugin Profiler — see the output.");
+    return false;
+  }
+  if (!installed) {
+    return installProfilerSolution(context);
+  }
+  return true;
+}
+
 async function installProfilerSolution(context: DataversePowerToolsContext): Promise<boolean> {
   const base64 = await getProfilerSolutionBase64(context);
   if (!base64) {
@@ -63,16 +78,8 @@ export async function capturePluginRun(context: DataversePowerToolsContext): Pro
     return;
   }
 
-  const installed = await isProfilerInstalled(context);
-  if (installed === undefined) {
-    vscode.window.showErrorMessage("Could not reach Dataverse to check for the Plugin Profiler — see the output.");
+  if (!(await ensureProfilerInstalled(context))) {
     return;
-  }
-  if (!installed) {
-    const ok = await installProfilerSolution(context);
-    if (!ok) {
-      return;
-    }
   }
 
   // Prefer this project's own assembly; fall back to any custom step if none match

--- a/src/plugins/profilerCodeLens.ts
+++ b/src/plugins/profilerCodeLens.ts
@@ -1,15 +1,9 @@
-import * as vscode from "vscode";
-import DataversePowerToolsContext from "../context";
-import { componentForPath } from "../components/discovery";
-import { runForComponent } from "../components/componentDiscovery";
-import { ProjectTypes } from "../projectTypes/registry";
-import { guidePluginProfiling } from "./profilerGuide";
-
-// CodeLens on [CrmPluginRegistration]-decorated plugin classes (#112): a single
-// "Profile & debug…" entry that guides capture (via the Plugin Registration
-// Tool) → Download → Replay-as-unit-test. Capturing itself isn't automated (the
-// profiler must be installed via PRT to be pipeline-executable); the value we
-// add is debugging the captured profile in VS Code.
+// Pure detection of [CrmPluginRegistration]-decorated plugin classes in C# source.
+//
+// The class-level "Profile & debug…" CodeLens was removed in #139 — profiling is now a per-STEP
+// toggle CodeLens (decorationsCodeLens.ts) plus the plugin card's Active-profiles block, and the
+// how-to guide moved to the plugin card's overflow menu (guidePluginProfiling). This module keeps
+// only the pure class finder, which the toggle uses to resolve an attribute's enclosing type.
 
 export interface PluginClassSite {
   /** Fully-qualified type name (namespace.Class). */
@@ -42,33 +36,4 @@ export function findPluginClasses(source: string): PluginClassSite[] {
     }
   }
   return sites;
-}
-
-class ProfilerCodeLensProvider implements vscode.CodeLensProvider {
-  constructor(private readonly context: DataversePowerToolsContext) {}
-
-  provideCodeLenses(document: vscode.TextDocument): vscode.CodeLens[] {
-    const component = componentForPath(this.context.components ?? [], document.uri.fsPath);
-    if (component?.settings.type !== ProjectTypes.plugin) {
-      return [];
-    }
-    return findPluginClasses(document.getText()).map(
-      (site) =>
-        new vscode.CodeLens(new vscode.Range(site.line, 0, site.line, 0), {
-          title: "$(debug-alt) Profile & debug…",
-          command: "dataverse-powertools.codelensProfileGuide",
-          arguments: [document.uri],
-        }),
-    );
-  }
-}
-
-/** Register the provider + the lens command ONCE at activation. */
-export function registerProfilerCodeLens(context: DataversePowerToolsContext): void {
-  context.vscode.subscriptions.push(
-    vscode.languages.registerCodeLensProvider({ language: "csharp", scheme: "file" }, new ProfilerCodeLensProvider(context)),
-    vscode.commands.registerCommand("dataverse-powertools.codelensProfileGuide", (uri: vscode.Uri) =>
-      runForComponent(context, ProjectTypes.plugin, uri, (scoped) => guidePluginProfiling(scoped)),
-    ),
-  );
 }

--- a/src/plugins/profilerToggle.ts
+++ b/src/plugins/profilerToggle.ts
@@ -1,0 +1,157 @@
+import * as vscode from "vscode";
+import DataversePowerToolsContext from "../context";
+import { runForComponent } from "../components/componentDiscovery";
+import { ProjectTypes } from "../projectTypes/registry";
+import { getOrganizationUrl } from "../general/connectionString";
+import { canCallDataverseApi } from "../general/dataverse/connectionReady";
+import { ActiveProfileStep, RegistrationKey, getProfilableSteps, findMatchingStep, deleteProfilerStep } from "../general/dataverse/pluginProfiles";
+import { parseRegistrationArgs } from "./registrationAttribute";
+import { findPluginClasses } from "./profilerCodeLens";
+import { isCaptureSupported, buildEnableArgs, buildDisableArgs, runProfilerTool } from "./profilerCaptureTool";
+import { ensureCaptureToolRuntime } from "./profilerAssets";
+import { ensureProfilerInstalled } from "./profilerCapture";
+import { guidePluginProfiling } from "./profilerGuide";
+import { refreshActiveProfiles, getActiveProfilesCache } from "../panel/panelDataCache";
+
+// Per-step profiling toggle (#139): flip server-side profiling on/off for the step whose
+// [CrmPluginRegistration(...)] attribute a CodeLens sits on. Enable/disable go through the
+// Windows-only net48 tool; on other OSes the enable falls back to the guide and the disable to a
+// Web-API delete of the profiler clone. State comes from the cached active-profiles list, never a
+// per-render query. Both auth types — gate on the live connection, never tenantId.
+
+const DEFAULT_MAX_PROFILED_EXECUTIONS = 100;
+
+/** The class type name whose declaration follows the attribute at `attributeLine`. Pure. */
+export function findEnclosingClassType(source: string, attributeLine: number): string | undefined {
+  let best: string | undefined;
+  let bestLine = Number.MAX_SAFE_INTEGER;
+  for (const site of findPluginClasses(source)) {
+    if (site.line >= attributeLine && site.line < bestLine) {
+      best = site.typeName;
+      bestLine = site.line;
+    }
+  }
+  return best;
+}
+
+/** Read the registration attribute at `line` and build the match key (message/entity/type). */
+async function keyForAttribute(uri: vscode.Uri, line: number): Promise<RegistrationKey | undefined> {
+  const document = await vscode.workspace.openTextDocument(uri);
+  const text = document.getText();
+  const regex = /\[CrmPluginRegistration\(([\s\S]*?)\)\]/g;
+  let match = regex.exec(text);
+  while (match) {
+    if (document.positionAt(match.index).line === line) {
+      const parsed = parseRegistrationArgs(match[1] || "");
+      if (!parsed) {
+        return undefined;
+      }
+      return { message: parsed.message, primaryEntity: parsed.primaryEntity, typeName: findEnclosingClassType(text, line) };
+    }
+    match = regex.exec(text);
+  }
+  return undefined;
+}
+
+/** CodeLens command handler: toggle profiling for the step at (uri, line). */
+export async function toggleStepProfiling(context: DataversePowerToolsContext, uri: vscode.Uri, line: number): Promise<void> {
+  const key = await keyForAttribute(uri, line);
+  if (!key) {
+    vscode.window.showWarningMessage("Could not read the plugin step registration on this line.");
+    return;
+  }
+  await runForComponent(context, ProjectTypes.plugin, uri, async (scoped) => {
+    if (!canCallDataverseApi({ organizationUrl: scoped.dataverse?.organizationUrl, isValid: scoped.dataverse?.isValid })) {
+      vscode.window.showErrorMessage("Connect to Dataverse first to change plug-in profiling.");
+      return;
+    }
+    // Live on/off state comes from the cached active-profiles list — no per-render/-click query.
+    const active = findMatchingStep(getActiveProfilesCache(), key);
+    if (active) {
+      await stopProfilingStep(scoped, active);
+    } else {
+      await startProfilingStep(scoped, key);
+    }
+    await refreshActiveProfiles(scoped);
+  });
+}
+
+async function startProfilingStep(context: DataversePowerToolsContext, key: RegistrationKey): Promise<void> {
+  if (!isCaptureSupported()) {
+    await guidePluginProfiling(context);
+    return;
+  }
+  const assemblyName = context.projectSettings.pluginProjectName as string | undefined;
+  let steps = await getProfilableSteps(context, assemblyName);
+  if (steps && steps.length === 0 && assemblyName) {
+    steps = await getProfilableSteps(context);
+  }
+  if (!steps) {
+    context.channel.appendLine("[Profiler] Could not list profilable steps (query failed) — see the output.");
+    return;
+  }
+  const step = findMatchingStep(steps, key);
+  if (!step) {
+    vscode.window.showInformationMessage(
+      `No deployed step matches ${key.message ?? "this message"}${key.primaryEntity ? " of " + key.primaryEntity : ""}. Deploy the plugin and register the step first.`,
+    );
+    return;
+  }
+  if (!(await ensureProfilerInstalled(context))) {
+    return;
+  }
+  const runtimeDir = await ensureCaptureToolRuntime(context);
+  if (!runtimeDir) {
+    return;
+  }
+  const organizationUrl = getOrganizationUrl(context.connectionString);
+  const result = await runProfilerTool(context, buildEnableArgs(organizationUrl, step.stepId, DEFAULT_MAX_PROFILED_EXECUTIONS), runtimeDir);
+  if (!result.ok || !result.profilerStepId) {
+    vscode.window.showErrorMessage(`Could not start profiling: ${result.error ?? "unknown error"}`);
+    context.channel.show();
+    return;
+  }
+  context.channel.appendLine(`[Profiler] Profiling ON for ${step.typeName} (${step.message ?? "?"} ${step.primaryEntity ?? ""}).`);
+  vscode.window.showInformationMessage(`Profiling on: ${step.typeName}. Trigger it, then Download a run to debug.`);
+}
+
+/** Stop profiling a step: net48 disable on Windows, Web-API delete of the profiler clone elsewhere. */
+export async function stopProfilingStep(context: DataversePowerToolsContext, profile: ActiveProfileStep): Promise<void> {
+  const label = [profile.typeName, profile.message, profile.primaryEntity].filter(Boolean).join(" · ");
+  if (!isCaptureSupported()) {
+    const ok = await deleteProfilerStep(context, profile.profilerStepId);
+    if (ok) {
+      context.channel.appendLine(`[Profiler] Stopped profiling (deleted profiler step) for ${label}.`);
+      context.channel.appendLine("[Profiler] Note: on non-Windows the original step may need re-enabling in the Plugin Registration Tool.");
+    } else {
+      vscode.window.showErrorMessage("Could not stop profiling — see the output.");
+    }
+    return;
+  }
+  const runtimeDir = await ensureCaptureToolRuntime(context);
+  if (!runtimeDir) {
+    return;
+  }
+  const organizationUrl = getOrganizationUrl(context.connectionString);
+  const result = await runProfilerTool(context, buildDisableArgs(organizationUrl, profile.profilerStepId), runtimeDir);
+  if (result.ok) {
+    context.channel.appendLine(`[Profiler] Profiling OFF for ${label}.`);
+  } else {
+    vscode.window.showErrorMessage(`Could not stop profiling: ${result.error ?? "unknown error"}`);
+    context.channel.show();
+  }
+}
+
+/** Stop the profiled step at `index` in the active-profiles cache — the panel trash-can (#139). */
+export async function stopActiveProfileByIndex(context: DataversePowerToolsContext, index: number): Promise<void> {
+  const profile = getActiveProfilesCache()[index];
+  if (!profile) {
+    return;
+  }
+  if (!canCallDataverseApi({ organizationUrl: context.dataverse?.organizationUrl, isValid: context.dataverse?.isValid })) {
+    vscode.window.showErrorMessage("Connect to Dataverse first to stop profiling.");
+    return;
+  }
+  await stopProfilingStep(context, profile);
+  await refreshActiveProfiles(context);
+}

--- a/src/plugins/registrationAttribute.spec.ts
+++ b/src/plugins/registrationAttribute.spec.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from "vitest";
+import { parseRegistrationArgs, splitTopLevelArgs } from "./registrationAttribute";
+
+describe("CrmPluginRegistration attribute parsing", () => {
+  it("splits args respecting strings and nested parens", () => {
+    expect(splitTopLevelArgs('MessageNameEnum.Update, "account", StageEnum.PostOperation, "a,b", "Step, Name"')).toEqual([
+      "MessageNameEnum.Update",
+      '"account"',
+      "StageEnum.PostOperation",
+      '"a,b"',
+      '"Step, Name"',
+    ]);
+  });
+
+  it("pulls message + entity + stage from a plugin step registration", () => {
+    const parsed = parseRegistrationArgs(
+      'MessageNameEnum.Update, "account", StageEnum.PostOperation, ExecutionModeEnum.Synchronous, "name,telephone1", "Update account", 1, IsolationModeEnum.Sandbox, Id = "abc"',
+    );
+    expect(parsed).toEqual({ message: "Update", primaryEntity: "account", stage: "PostOperation" });
+  });
+
+  it("returns undefined for a non-plugin-step (workflow) registration", () => {
+    expect(parseRegistrationArgs('"WorkflowActivity", "My Workflow", "desc", "group", IsolationModeEnum.Sandbox')).toBeUndefined();
+  });
+});

--- a/src/plugins/registrationAttribute.ts
+++ b/src/plugins/registrationAttribute.ts
@@ -1,0 +1,75 @@
+// Pure parsing of `[CrmPluginRegistration(...)]` plugin-step attributes (#139), kept
+// `vscode`-free so the source-registration → server-step matcher is unit-testable. Plugin
+// steps are positional: (MessageNameEnum.X, "entity", StageEnum.Y, ExecutionModeEnum.Z,
+// "filtering", "stepName", order, IsolationModeEnum.W, ...).
+
+export interface ParsedRegistration {
+  message?: string;
+  primaryEntity?: string;
+  stage?: string;
+}
+
+/** Split a top-level comma-separated argument list, respecting C# strings and nested parens. Pure. */
+export function splitTopLevelArgs(argsText: string): string[] {
+  const args: string[] = [];
+  let depth = 0;
+  let inString = false;
+  let escaped = false;
+  let start = 0;
+  for (let i = 0; i < argsText.length; i++) {
+    const char = argsText[i];
+    if (inString) {
+      if (escaped) {
+        escaped = false;
+      } else if (char === "\\") {
+        escaped = true;
+      } else if (char === '"') {
+        inString = false;
+      }
+      continue;
+    }
+    if (char === '"') {
+      inString = true;
+    } else if (char === "(") {
+      depth++;
+    } else if (char === ")") {
+      depth = Math.max(0, depth - 1);
+    } else if (char === "," && depth === 0) {
+      args.push(argsText.slice(start, i).trim());
+      start = i + 1;
+    }
+  }
+  args.push(argsText.slice(start).trim());
+  return args;
+}
+
+function unquote(arg: string | undefined): string | undefined {
+  const trimmed = (arg ?? "").trim();
+  if (trimmed.startsWith('"') && trimmed.endsWith('"')) {
+    try {
+      return JSON.parse(trimmed);
+    } catch {
+      return trimmed.slice(1, -1);
+    }
+  }
+  return undefined;
+}
+
+function enumMember(arg: string | undefined, enumName: string): string | undefined {
+  const trimmed = (arg ?? "").trim();
+  const token = `${enumName}.`;
+  const index = trimmed.indexOf(token);
+  return index >= 0 ? trimmed.slice(index + token.length).trim() : undefined;
+}
+
+/** Parse a plugin-step registration's args text (inside the parens). Undefined for a
+ * non-plugin-step attribute (e.g. a WorkflowActivity registration). Pure. */
+export function parseRegistrationArgs(argsText: string): ParsedRegistration | undefined {
+  const args = splitTopLevelArgs(argsText);
+  const message = enumMember(args[0], "MessageNameEnum");
+  const stage = enumMember(args[2], "StageEnum");
+  if (!message || !stage) {
+    return undefined;
+  }
+  return { message, primaryEntity: unquote(args[1]), stage };
+}

--- a/src/projectTypes/registry.ts
+++ b/src/projectTypes/registry.ts
@@ -137,6 +137,9 @@ export const projectTypeRegistry: readonly ProjectTypeDescriptor[] = [
                 { command: `${prefix}addClassDecoration`, label: "Add class decoration" },
               ]),
           { command: `${prefix}buildDeployWorkflow`, label: "Build & deploy workflow" },
+          // The profiling how-to lives here now (#139) — per-step Profile toggles + the card's
+          // Active-profiles block replaced the class-level guide CodeLens.
+          { command: `${prefix}guidePluginProfiling`, label: "How to profile & debug…" },
         ],
       };
     },


### PR DESCRIPTION
Completes the **0.11.0: Plugins — Profiling, trace & build** milestone.

Closes #135
Closes #137
Closes #139

## #135 — profiling finds registered steps
`getProfilableSteps` expanded the **polymorphic** `eventhandler` lookup (plugintype OR serviceendpoint), which doesn't resolve `typename` for a normal plugin step → every row dropped → "No registered plugin steps to profile". Now reads the step's type via the dedicated **`plugintypeid`** navigation (per the Dataverse docs) and filters `_plugintypeid_value ne null` server-side. Parser + diagnostics + tests updated (8 passing).

## #137 — trace-log status tag
Coloured pill next to the connected org (🟢 Off / 🟠 Errors / 🔴 All) reading `organization.plugintracelogsetting`; click → quick pick to change (confirm on **All**). New `getTraceLogSetting`/`setTraceLogSetting` helpers + `setTraceLogLevel` general command. Both auth types (gates on the live connection).

## #139 — profiling UX
- **Per-step `Profile: Off/On` CodeLens** on each `[CrmPluginRegistration(…)]` attribute (next to Update Filtering Attributes) — enables/disables that server step; per-attribute placement solves "one class, many steps". Registered once globally like the other `*AtLine` lenses.
- **"Active profiles" card block** (mirrors Form Registrations): a row per profiled step + trash-can to stop.
- Moved the class-level guide to the plugin **overflow** ("How to profile & debug…").
- Windows-gated net48 enable/disable/stop; guide / Web-API delete fallback elsewhere.

**Panel stays network-free:** trace-log + active-profiles are fetched on connect/refresh into `panelDataCache` and only *read* by `computePanelState` (no per-render Dataverse calls; CodeLens state cached too).

## Verification
- Verify loop green: lint, tsc, webpack, `test:coverage` (**474 unit tests** — trace-log label, registration-attribute parser, active-profiles query/parse/match), `test:integration` (9 passing; the global-CodeLens-command guard covers the new toggle). No e2e references the removed class-level guide lens (checked).
- Full VM e2e: running.

🤖 Generated with [Claude Code](https://claude.com/claude-code)