### PR TITLE
0.14.3 (pre-release) — complete the OAuth pac fix (#128, #129)

### DIFF
--- a/.mocharc-supervised.json
+++ b/.mocharc-supervised.json
@@ -1,0 +1,8 @@
+{
+  "ui": "bdd",
+  "timeout": 0,
+  "bail": true,
+  "retries": 0,
+  "reporter": "spec",
+  "slow": 60000
+}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to the "dataverse-powertools" extension will be documented in this file.
 
+## 0.14.3 (pre-release)
+
+Completes the OAuth `pac` fix from 0.14.1 (#128, #129) — the reason it "worked but did nothing".
+
+- **`pac` failures are now detected from output, not the exit code.** `pac` (2.8.1) returns **exit code 0 even when a command fails** — no auth profile, a bad profile name, an expired token. The extension trusted that exit code, so under OAuth it would log *"Reusing the pac profile"* for a profile that didn't exist and then *"Plugin early bound generation complete"* having generated **zero files** — a silent false success. Early-bound generation, and any other `pac`-backed command, now inspect `pac`'s actual output (`pac auth list` for profile existence, plus an `Error:` banner check) and only report success when work was really done; on a genuine failure they surface the error and open the output channel instead of pretending it worked.
+- **Found by a new supervised UI test.** A human-assisted, on-demand suite (`npm run test:supervised`, *not* in CI) drives the real panel buttons through the OAuth `pac` path end-to-end — blank multi-component project → OAuth sign-in → add Plugins → Generate Early-bound — and is what surfaced the false-success above. It captures the sign-in once and reuses it for unattended fix iterations. This is the first slice; build → deploy → profile → debug → trace follow.
+
 ## 0.14.2 (pre-release)
 
 Completes the **Plugins — Profiling, trace & build** milestone (#135, #137, #139).

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "type": "git",
     "url": "https://github.com/pete-mc/dataverse-powertools"
   },
-  "version": "0.14.2",
+  "version": "0.14.3",
   "engines": {
     "vscode": "^1.93.0"
   },

--- a/package.json
+++ b/package.json
@@ -694,7 +694,8 @@
     "deploy": "vsce publish",
     "seed-interactive-cache": "node scripts/preAcquireInteractiveCache.mjs",
     "pretest:supervised": "npm run compile-tests && npm run compile",
-    "test:supervised": "node scripts/runSupervised.mjs"
+    "test:supervised": "node scripts/runSupervised.mjs",
+    "test:supervised:reuse": "node scripts/runSupervised.mjs --reuse"
   },
   "devDependencies": {
     "@types/adm-zip": "^0.5.8",

--- a/package.json
+++ b/package.json
@@ -695,7 +695,8 @@
     "seed-interactive-cache": "node scripts/preAcquireInteractiveCache.mjs",
     "pretest:supervised": "npm run compile-tests && npm run compile",
     "test:supervised": "node scripts/runSupervised.mjs",
-    "test:supervised:reuse": "node scripts/runSupervised.mjs --reuse"
+    "test:supervised:reuse": "node scripts/runSupervised.mjs --reuse",
+    "pretest:supervised:reuse": "npm run compile-tests && npm run compile"
   },
   "devDependencies": {
     "@types/adm-zip": "^0.5.8",

--- a/package.json
+++ b/package.json
@@ -692,7 +692,9 @@
     "test:e2e": "node scripts/runE2E.mjs",
     "test": "npm run test:unit && npm run test:integration",
     "deploy": "vsce publish",
-    "seed-interactive-cache": "node scripts/preAcquireInteractiveCache.mjs"
+    "seed-interactive-cache": "node scripts/preAcquireInteractiveCache.mjs",
+    "pretest:supervised": "npm run compile-tests && npm run compile",
+    "test:supervised": "node scripts/runSupervised.mjs"
   },
   "devDependencies": {
     "@types/adm-zip": "^0.5.8",

--- a/scripts/ensureSupervisedSolution.mjs
+++ b/scripts/ensureSupervisedSolution.mjs
@@ -1,0 +1,97 @@
+// Ensure a dedicated, isolated Dataverse solution exists for the supervised UI test, so the
+// Initialise Project wizard can pick it (the wizard only picks EXISTING solutions). Idempotent:
+// creates it once under the existing test publisher, then reuses it. Authenticates with the same
+// service-principal creds the e2e uses (sandbox/.env). Prints the solution's friendly name on the
+// last stdout line, which runSupervised.mjs reads into DVPT_SUPERVISED_SOLUTION.
+
+import fs from "fs";
+import path from "path";
+import { fileURLToPath } from "url";
+
+const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+const API = "/api/data/v9.2";
+const SUPERVISED_UNIQUE = "DVPTSupervised";
+const SUPERVISED_FRIENDLY = "DVPT Supervised";
+
+function loadEnv() {
+  const env = {};
+  try {
+    for (const line of fs.readFileSync(path.join(root, "sandbox", ".env"), "utf8").split(/\r?\n/)) {
+      const m = line.match(/^\s*([A-Z0-9_]+)\s*=\s*(.*)\s*$/i);
+      if (m && !line.trimStart().startsWith("#")) {
+        env[m[1]] = m[2].replace(/^["']|["']$/g, "");
+      }
+    }
+  } catch {
+    /* no .env */
+  }
+  return env;
+}
+
+async function main() {
+  const env = loadEnv();
+  const url = (env.DVPT_TEST_URL || "").replace(/\/+$/, "");
+  const tenant = env.DVPT_TEST_TENANT_ID;
+  const clientId = env.DVPT_TEST_CLIENT_ID;
+  const clientSecret = env.DVPT_TEST_CLIENT_SECRET;
+  const prefix = env.DVPT_TEST_PUBLISHER_PREFIX;
+  if (!url || !tenant || !clientId || !clientSecret) {
+    console.error("[solution] missing DVPT_TEST_URL/TENANT_ID/CLIENT_ID/CLIENT_SECRET in sandbox/.env — cannot ensure the supervised solution.");
+    process.exit(1);
+  }
+
+  // Service-principal token for the org.
+  const params = new URLSearchParams({ grant_type: "client_credentials", client_id: clientId, client_secret: clientSecret, resource: url });
+  const tokRes = await fetch(`https://login.microsoftonline.com/${tenant}/oauth2/token`, {
+    method: "POST",
+    headers: { "Content-Type": "application/x-www-form-urlencoded" },
+    body: params,
+  });
+  const tok = await tokRes.json();
+  if (!tok?.access_token) {
+    console.error(`[solution] auth failed: ${JSON.stringify(tok).slice(0, 200)}`);
+    process.exit(1);
+  }
+  const headers = { Authorization: `Bearer ${tok.access_token}`, "Content-Type": "application/json", "OData-MaxVersion": "4.0", "OData-Version": "4.0", Accept: "application/json" };
+  const get = async (q) => (await fetch(`${url}${API}/${q}`, { headers })).json();
+
+  // Already there? Reuse.
+  const existing = await get(`solutions?$select=solutionid,uniquename,friendlyname&$filter=uniquename eq '${SUPERVISED_UNIQUE}'`);
+  if (existing?.value?.length) {
+    console.error(`[solution] reusing existing "${existing.value[0].friendlyname}" (${SUPERVISED_UNIQUE}).`);
+    console.log(existing.value[0].friendlyname);
+    return;
+  }
+
+  // Find a publisher: by the configured prefix, else the publisher of the existing test solution.
+  let publisherId;
+  if (prefix) {
+    const byPrefix = await get(`publishers?$select=publisherid&$filter=customizationprefix eq '${prefix}'`);
+    publisherId = byPrefix?.value?.[0]?.publisherid;
+  }
+  if (!publisherId && env.DVPT_TEST_SOLUTION_NAME) {
+    const sol = await get(`solutions?$select=_publisherid_value&$filter=uniquename eq '${env.DVPT_TEST_SOLUTION_NAME}'`);
+    publisherId = sol?.value?.[0]?.["_publisherid_value"];
+  }
+  if (!publisherId) {
+    console.error("[solution] could not resolve a publisher (checked DVPT_TEST_PUBLISHER_PREFIX and DVPT_TEST_SOLUTION_NAME's publisher).");
+    process.exit(1);
+  }
+
+  const createRes = await fetch(`${url}${API}/solutions`, {
+    method: "POST",
+    headers,
+    body: JSON.stringify({ uniquename: SUPERVISED_UNIQUE, friendlyname: SUPERVISED_FRIENDLY, version: "1.0.0.0", "publisherid@odata.bind": `/publishers(${publisherId})` }),
+  });
+  if (!createRes.ok) {
+    console.error(`[solution] create failed (${createRes.status}): ${(await createRes.text()).slice(0, 300)}`);
+    process.exit(1);
+  }
+  console.error(`[solution] created "${SUPERVISED_FRIENDLY}" (${SUPERVISED_UNIQUE}).`);
+  console.log(SUPERVISED_FRIENDLY);
+}
+
+main().catch((e) => {
+  console.error(`[solution] ${e}`);
+  process.exit(1);
+});

--- a/scripts/runSupervised.mjs
+++ b/scripts/runSupervised.mjs
@@ -1,10 +1,18 @@
-// Supervised UI-test launcher — run on demand with `npm run test:supervised`.
+// Supervised UI-test launcher.
 //
-// Unlike scripts/runE2E.mjs, this does NOT seed an MSAL cache: the whole point is
-// that YOU do the real OAuth sign-in (a new profile) while watching the run. It
-// launches a real VS Code window you can see and interact with, and Mocha bails on
-// the first failure (.mocharc-supervised.json) so the run stops exactly where a
-// flow breaks. Screenshots land in sandbox/supervised-shots/.
+//   npm run test:supervised          FRESH: clears auth + pac, YOU sign in (OAuth + pac
+//                                     device-code) when prompted. Both sign-ins are captured.
+//   npm run test:supervised:reuse    REUSE: keeps the captured OAuth + pac profile from a
+//                                     prior fresh run and runs UNATTENDED — for fix iterations.
+//
+// The extension's MSAL token cache is pointed at a PERSISTENT file (not deleted between reuse
+// runs), so a one-time interactive sign-in is reused silently afterwards (tokenAcquisition.ts's
+// DVPT_TEST_MSAL_CACHE_FILE seam is read/write). The pac profile lives in pac's own machine store
+// and is reused by the 0.14.1 `pac auth select` path — so it survives across runs too. Reuse mode
+// works until either token needs an interactive renewal, at which point run fresh again.
+//
+// Mocha bails on the first failure (.mocharc-supervised.json) so a run stops exactly where a flow
+// breaks. Screenshots land in sandbox/supervised-shots/.
 
 import { spawnSync } from "child_process";
 import fs from "fs";
@@ -12,21 +20,57 @@ import path from "path";
 import { fileURLToPath } from "url";
 
 const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
-
-// Mirror the extension's output channel so you (and any later audit) can read what
-// the extension actually did during the run.
-const logFile = path.join(root, "sandbox", "supervised-extension-output.log");
-fs.rmSync(logFile, { force: true });
-const env = { ...process.env, DVPT_TEST_LOG_FILE: logFile };
-
-// Default to the supervised suite; allow an explicit glob to run a single scenario.
-const globs = process.argv.slice(2);
+const reuse = process.argv.includes("--reuse") || process.env.DVPT_SUPERVISED_REUSE === "1";
+const globs = process.argv.slice(2).filter((a) => !a.startsWith("--"));
 if (globs.length === 0) {
   globs.push("out/ui-test/supervised/**/*.e2e.js");
 }
 
-console.log("[supervised] NOTE: this run needs YOU — you'll do the OAuth + pac sign-in when prompted.");
-console.log(`[supervised] launching: ${globs.join(", ")}`);
+// Persistent across reuse runs; wiped only on a fresh run so the human re-signs in.
+const msalCache = path.join(root, "sandbox", ".supervised-msal-cache.json");
+const logFile = path.join(root, "sandbox", "supervised-extension-output.log");
+fs.rmSync(logFile, { force: true });
+
+// Minimal sandbox/.env read for DVPT_SUPERVISED_ENV (the environment to auto-pick after sign-in).
+function envValue(key) {
+  try {
+    for (const line of fs.readFileSync(path.join(root, "sandbox", ".env"), "utf8").split(/\r?\n/)) {
+      const m = line.match(/^\s*([A-Z0-9_]+)\s*=\s*(.*)\s*$/i);
+      if (m && m[1] === key && !line.trimStart().startsWith("#")) {
+        return m[2].replace(/^["']|["']$/g, "");
+      }
+    }
+  } catch {
+    /* no .env */
+  }
+  return undefined;
+}
+const supervisedEnv = process.env.DVPT_SUPERVISED_ENV || envValue("DVPT_SUPERVISED_ENV") || "";
+
+if (reuse) {
+  if (!fs.existsSync(msalCache)) {
+    console.error("[supervised] reuse mode but no captured sign-in found — run `npm run test:supervised` (fresh) once first.");
+    process.exit(2);
+  }
+  if (!supervisedEnv) {
+    console.error("[supervised] reuse mode needs DVPT_SUPERVISED_ENV (your environment name/url) in sandbox/.env so it can pick it without you.");
+    process.exit(2);
+  }
+  console.log("[supervised] REUSE mode — unattended, reusing the captured OAuth + pac sign-in.");
+} else {
+  fs.rmSync(msalCache, { force: true });
+  console.log("[supervised] FRESH mode — you'll sign in (OAuth in the browser, then the pac device code) when I prompt you.");
+  console.log(supervisedEnv ? `[supervised] will auto-pick environment "${supervisedEnv}" after your sign-in.` : "[supervised] set DVPT_SUPERVISED_ENV in sandbox/.env to auto-pick your environment (else you'll pick it in the quick pick).");
+}
+
+const env = {
+  ...process.env,
+  DVPT_TEST_MSAL_CACHE_FILE: msalCache,
+  DVPT_TEST_LOG_FILE: logFile,
+  DVPT_SUPERVISED_REUSE: reuse ? "1" : "",
+  DVPT_SUPERVISED_ENV: supervisedEnv,
+};
+
 const extestArgs = ["extest", "setup-and-run", ...globs, "--code_settings", "test/ui-settings.json", "--extensions_dir", "sandbox/ext-dir-clean", "--mocha_config", ".mocharc-supervised.json"];
 const run = spawnSync("npx", extestArgs, { cwd: root, env, stdio: "inherit", shell: process.platform === "win32" });
 process.exit(run.status ?? 1);

--- a/scripts/runSupervised.mjs
+++ b/scripts/runSupervised.mjs
@@ -45,8 +45,18 @@ function envValue(key) {
   }
   return undefined;
 }
-const supervisedEnv = process.env.DVPT_SUPERVISED_ENV || envValue("DVPT_SUPERVISED_ENV") || "";
-const supervisedSolution = process.env.DVPT_SUPERVISED_SOLUTION || envValue("DVPT_SUPERVISED_SOLUTION") || "";
+// Environment defaults to the shared test org (DVPT_TEST_URL); solution defaults to the dedicated
+// "DVPT Supervised" solution, which ensureSupervisedSolution.mjs creates idempotently.
+const supervisedEnv = process.env.DVPT_SUPERVISED_ENV || envValue("DVPT_SUPERVISED_ENV") || envValue("DVPT_TEST_URL") || "";
+let supervisedSolution = process.env.DVPT_SUPERVISED_SOLUTION || envValue("DVPT_SUPERVISED_SOLUTION") || "";
+if (!supervisedSolution) {
+  console.log("[supervised] ensuring the dedicated 'DVPT Supervised' solution exists…");
+  const ensured = spawnSync("node", [path.join("scripts", "ensureSupervisedSolution.mjs")], { cwd: root, encoding: "utf8" });
+  if (ensured.stderr) {
+    process.stderr.write(ensured.stderr);
+  }
+  supervisedSolution = ensured.status === 0 ? (ensured.stdout || "").trim().split(/\r?\n/).pop() : "";
+}
 
 if (reuse) {
   if (!fs.existsSync(msalCache)) {

--- a/scripts/runSupervised.mjs
+++ b/scripts/runSupervised.mjs
@@ -46,17 +46,18 @@ function envValue(key) {
   return undefined;
 }
 const supervisedEnv = process.env.DVPT_SUPERVISED_ENV || envValue("DVPT_SUPERVISED_ENV") || "";
+const supervisedSolution = process.env.DVPT_SUPERVISED_SOLUTION || envValue("DVPT_SUPERVISED_SOLUTION") || "";
 
 if (reuse) {
   if (!fs.existsSync(msalCache)) {
     console.error("[supervised] reuse mode but no captured sign-in found — run `npm run test:supervised` (fresh) once first.");
     process.exit(2);
   }
-  if (!supervisedEnv) {
-    console.error("[supervised] reuse mode needs DVPT_SUPERVISED_ENV (your environment name/url) in sandbox/.env so it can pick it without you.");
+  if (!supervisedEnv || !supervisedSolution) {
+    console.error("[supervised] reuse mode needs DVPT_SUPERVISED_ENV (env name/url) and DVPT_SUPERVISED_SOLUTION (solution display name) in sandbox/.env so it can drive the wizard without you.");
     process.exit(2);
   }
-  console.log("[supervised] REUSE mode — unattended, reusing the captured OAuth + pac sign-in.");
+  console.log(`[supervised] REUSE mode — unattended. env="${supervisedEnv}" solution="${supervisedSolution}".`);
 } else {
   fs.rmSync(msalCache, { force: true });
   console.log("[supervised] FRESH mode — you'll sign in (OAuth in the browser, then the pac device code) when I prompt you.");
@@ -69,6 +70,7 @@ const env = {
   DVPT_TEST_LOG_FILE: logFile,
   DVPT_SUPERVISED_REUSE: reuse ? "1" : "",
   DVPT_SUPERVISED_ENV: supervisedEnv,
+  DVPT_SUPERVISED_SOLUTION: supervisedSolution,
 };
 
 const extestArgs = ["extest", "setup-and-run", ...globs, "--code_settings", "test/ui-settings.json", "--extensions_dir", "sandbox/ext-dir-clean", "--mocha_config", ".mocharc-supervised.json"];

--- a/scripts/runSupervised.mjs
+++ b/scripts/runSupervised.mjs
@@ -1,0 +1,32 @@
+// Supervised UI-test launcher — run on demand with `npm run test:supervised`.
+//
+// Unlike scripts/runE2E.mjs, this does NOT seed an MSAL cache: the whole point is
+// that YOU do the real OAuth sign-in (a new profile) while watching the run. It
+// launches a real VS Code window you can see and interact with, and Mocha bails on
+// the first failure (.mocharc-supervised.json) so the run stops exactly where a
+// flow breaks. Screenshots land in sandbox/supervised-shots/.
+
+import { spawnSync } from "child_process";
+import fs from "fs";
+import path from "path";
+import { fileURLToPath } from "url";
+
+const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+
+// Mirror the extension's output channel so you (and any later audit) can read what
+// the extension actually did during the run.
+const logFile = path.join(root, "sandbox", "supervised-extension-output.log");
+fs.rmSync(logFile, { force: true });
+const env = { ...process.env, DVPT_TEST_LOG_FILE: logFile };
+
+// Default to the supervised suite; allow an explicit glob to run a single scenario.
+const globs = process.argv.slice(2);
+if (globs.length === 0) {
+  globs.push("out/ui-test/supervised/**/*.e2e.js");
+}
+
+console.log("[supervised] NOTE: this run needs YOU — you'll do the OAuth + pac sign-in when prompted.");
+console.log(`[supervised] launching: ${globs.join(", ")}`);
+const extestArgs = ["extest", "setup-and-run", ...globs, "--code_settings", "test/ui-settings.json", "--extensions_dir", "sandbox/ext-dir-clean", "--mocha_config", ".mocharc-supervised.json"];
+const run = spawnSync("npx", extestArgs, { cwd: root, env, stdio: "inherit", shell: process.platform === "win32" });
+process.exit(run.status ?? 1);

--- a/src/general/modelbuilder/index.ts
+++ b/src/general/modelbuilder/index.ts
@@ -3,7 +3,7 @@ import * as fs from "fs";
 import * as path from "path";
 import DataversePowerToolsContext from "../../context";
 import { runPac } from "./commandRunner";
-import { ensurePacAuthForCurrentConnection, isPacAuthError, reestablishPacAuthForCurrentConnection } from "../pacAuth";
+import { ensurePacAuthForCurrentConnection, isPacAuthError, pacOutputHasError, reestablishPacAuthForCurrentConnection } from "../pacAuth";
 import {
   applyDefaults,
   ensurePluginModelBuilderSettingsLoaded,
@@ -20,19 +20,30 @@ import { activeComponentRoot } from "../../components/componentDiscovery";
  * { error, stdout, stderr } on failure, so we inspect that payload. Non-auth
  * failures re-throw unchanged for the caller's existing error handling. */
 async function runPacWithAuthRetry(context: DataversePowerToolsContext, args: string[], workspacePath: string): Promise<{ stdout: string; stderr: string }> {
-  try {
-    return await runPac(args, workspacePath);
-  } catch (error: any) {
-    const combined = `${error?.stdout ?? ""}\n${error?.stderr ?? ""}\n${error?.error?.message ?? error?.message ?? ""}`;
-    if (!isPacAuthError(combined)) {
-      throw error;
+  // pac usually exits 0 EVEN WHEN IT FAILS (e.g. "Error: No profiles were found" with code 0),
+  // so runPac won't throw — detect failure from the OUTPUT. Normalise a genuine throw into the
+  // same shape so both are handled the same way.
+  const run = async (): Promise<{ stdout: string; stderr: string }> => {
+    try {
+      return await runPac(args, workspacePath);
+    } catch (error: any) {
+      return { stdout: error?.stdout ?? "", stderr: `Error: ${error?.error?.message ?? error?.message ?? "pac command failed"}\n${error?.stderr ?? ""}` };
     }
+  };
+  let result = await run();
+  let combined = `${result.stdout}\n${result.stderr}`;
+  if (pacOutputHasError(combined) && isPacAuthError(combined)) {
     context.channel.appendLine("[pac] Authentication error — re-establishing the pac profile and retrying once.");
-    if (!(await reestablishPacAuthForCurrentConnection(context, workspacePath))) {
-      throw error;
+    if (await reestablishPacAuthForCurrentConnection(context, workspacePath)) {
+      result = await run();
+      combined = `${result.stdout}\n${result.stderr}`;
     }
-    return runPac(args, workspacePath);
   }
+  // Still failing → THROW so the caller reports the error instead of a false "generation complete".
+  if (pacOutputHasError(combined)) {
+    throw new Error(`pac reported an error: ${(result.stderr || result.stdout).replace(/\s+/g, " ").trim().slice(0, 300)}`);
+  }
+  return result;
 }
 
 async function createSettingsTemplateFile(context: DataversePowerToolsContext, namespace: string, serviceContextName: string, outputDirectory: string): Promise<void> {

--- a/src/general/pacAuth.spec.ts
+++ b/src/general/pacAuth.spec.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { AUTH_PROFILE_NAME, pacAuthCreateInteractiveArgs, pacAuthSelectArgs, pacAuthDeleteArgs, pacOrgSelectArgs, isPacAuthError, parseDeviceCode } from "./pacAuth";
+import { AUTH_PROFILE_NAME, pacAuthCreateInteractiveArgs, pacAuthSelectArgs, pacAuthDeleteArgs, pacOrgSelectArgs, isPacAuthError, parseDeviceCode, pacOutputHasError, pacSucceeded, listHasNamedProfile } from "./pacAuth";
 
 describe("pacAuthCreateInteractiveArgs", () => {
   it("builds an interactive create for a named profile + environment", () => {
@@ -85,5 +85,38 @@ describe("parseDeviceCode", () => {
 
   it("returns undefined for empty input", () => {
     expect(parseDeviceCode("")).toBeUndefined();
+  });
+});
+
+describe("pacOutputHasError / pacSucceeded — pac exits 0 even on failure (#128/#129)", () => {
+  // Real pac 2.8.1 output: these all returned exit code 0.
+  const noProfiles = "Microsoft PowerPlatform CLI\nVersion: 2.8.1\n\nError: No profiles were found on this computer. Please run 'pac auth create' to create one.";
+  const badName = "Error: AuthProfileNameDoesNotExist\nThere is no authentication profile with name \"dataverse-powertools\"";
+  const good = "Connected to... org32218dcd\nThe early bound classes were generated successfully.";
+
+  it("detects pac's Error: banner in output", () => {
+    expect(pacOutputHasError(noProfiles)).toBe(true);
+    expect(pacOutputHasError(badName)).toBe(true);
+    expect(pacOutputHasError(good)).toBe(false);
+    expect(pacOutputHasError("")).toBe(false);
+  });
+
+  it("treats exit 0 with an Error banner as a FAILURE (the core bug)", () => {
+    expect(pacSucceeded({ code: 0, stdout: noProfiles, stderr: "" })).toBe(false);
+    expect(pacSucceeded({ code: 0, stdout: "", stderr: badName })).toBe(false);
+    expect(pacSucceeded({ code: 0, stdout: good, stderr: "" })).toBe(true);
+    // A non-zero exit is also a failure even without a banner.
+    expect(pacSucceeded({ code: 1, stdout: "", stderr: "" })).toBe(false);
+  });
+});
+
+describe("listHasNamedProfile — parse `pac auth list` (it exits 0 even with no profiles)", () => {
+  it("is false when pac reports no profiles", () => {
+    expect(listHasNamedProfile("No profiles were found on this computer. Please run 'pac auth create'.", "dataverse-powertools")).toBe(false);
+  });
+  it("is true only when the named profile appears in the list", () => {
+    const list = "Index Active Kind      Name                 Friendly Name        Url\n[1]   *      UNIVERSAL      dataverse-powertools dataverse-powertools https://org.crm.dynamics.com";
+    expect(listHasNamedProfile(list, "dataverse-powertools")).toBe(true);
+    expect(listHasNamedProfile(list, "some-other-profile")).toBe(false);
   });
 });

--- a/src/general/pacAuth.ts
+++ b/src/general/pacAuth.ts
@@ -77,10 +77,11 @@ export async function runPacLogged(context: DataversePowerToolsContext, args: st
   if (result.stderr) {
     context.channel.appendLine(redact(result.stderr, secret));
   }
-  if (result.code !== 0) {
+  const ok = pacSucceeded(result);
+  if (!ok) {
     context.channel.show();
   }
-  return result.code === 0;
+  return ok;
 }
 
 /**
@@ -181,6 +182,37 @@ export function pacAuthSelectArgs(profileName: string): string[] {
   return ["auth", "select", "--name", profileName];
 }
 
+/** `pac auth list`. */
+export function pacAuthListArgs(): string[] {
+  return ["auth", "list"];
+}
+
+/**
+ * pac exits 0 even when it FAILS — `pac auth select`/`pac org select`/`pac modelbuilder`
+ * all print "Error: …" to output while returning exit code 0 (confirmed against pac 2.8.1).
+ * So a zero exit code is NOT proof of success: also scan the output for pac's error banner.
+ * Without this the extension "reuses" a non-existent profile and reports early-bound
+ * generation "complete" when it produced nothing (#128/#129).
+ */
+export function pacOutputHasError(text: string): boolean {
+  return /(^|\n)\s*Error:/i.test(text || "");
+}
+
+/** True only when pac genuinely succeeded (exit 0 AND no error banner in its output). */
+export function pacSucceeded(result: PacResult): boolean {
+  return result.code === 0 && !pacOutputHasError(`${result.stdout}\n${result.stderr}`);
+}
+
+/** Whether the extension's named profile appears in `pac auth list` output. The list command
+ * always exits 0 (even with no profiles), so parse the text, not the code. */
+export function listHasNamedProfile(listOutput: string, profileName: string): boolean {
+  const text = listOutput || "";
+  if (/no profiles were found/i.test(text)) {
+    return false;
+  }
+  return new RegExp(`(^|\\s)${profileName.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")}(\\s|$)`, "m").test(text);
+}
+
 /** True when pac output signals an auth/identity failure (missing/expired/invalid
  * profile) that re-establishing the extension's profile could fix. Targeted on
  * purpose — a generic "file not found" or build error must NOT match, or the
@@ -277,16 +309,24 @@ export function runPacStreaming(context: DataversePowerToolsContext, args: strin
  * instead of borrowing the ambient-active one.
  */
 export async function ensureInteractivePacProfile(context: DataversePowerToolsContext, workspacePath: string, environmentUrl: string): Promise<boolean> {
-  const selected = await runPacResult(pacAuthSelectArgs(AUTH_PROFILE_NAME), workspacePath);
-  if (selected.code === 0) {
-    const org = await runPacResult(pacOrgSelectArgs(environmentUrl), workspacePath);
-    if (org.code === 0) {
+  // pac exits 0 even when the named profile doesn't exist (`pac auth select` prints
+  // "Error: AuthProfileNameDoesNotExist" and still returns 0), so DON'T trust exit codes —
+  // check `pac auth list` output for our profile. Trusting the code made the extension
+  // "reuse" a profile that wasn't there and never sign in, so pac modelbuilder later failed
+  // with "No profiles were found" (#128/#129).
+  const list = await runPacResult(pacAuthListArgs(), workspacePath);
+  if (listHasNamedProfile(`${list.stdout}\n${list.stderr}`, AUTH_PROFILE_NAME)) {
+    const selected = await runPacResult(pacAuthSelectArgs(AUTH_PROFILE_NAME), workspacePath);
+    const org = pacSucceeded(selected) ? await runPacResult(pacOrgSelectArgs(environmentUrl), workspacePath) : selected;
+    if (pacSucceeded(selected) && pacSucceeded(org)) {
       context.channel.appendLine(`Reusing the '${AUTH_PROFILE_NAME}' pac profile for ${environmentUrl}.`);
       return true;
     }
-    // The profile exists but can't target this environment (org mismatch or an
-    // expired token) — fall through and recreate it from scratch.
+    // The profile exists but can't target this environment (org mismatch or an expired
+    // token) — fall through and recreate it from scratch.
     context.channel.appendLine(`The '${AUTH_PROFILE_NAME}' pac profile could not select ${environmentUrl} (mismatch or expiry) — re-establishing it.`);
+  } else {
+    context.channel.appendLine(`No '${AUTH_PROFILE_NAME}' pac profile found — establishing one for ${environmentUrl}.`);
   }
   return createInteractivePacProfile(context, workspacePath, environmentUrl);
 }
@@ -332,7 +372,7 @@ export async function createInteractivePacProfile(context: DataversePowerToolsCo
     },
   );
 
-  if (result.code === 0) {
+  if (pacSucceeded(result)) {
     context.channel.appendLine(`Created the '${AUTH_PROFILE_NAME}' pac profile for ${environmentUrl}.`);
     return true;
   }
@@ -381,7 +421,8 @@ export async function clearPacProfile(context: DataversePowerToolsContext, works
  * extension's profile and retry ONCE. Non-auth failures are returned as-is. */
 export async function runPacHealing(context: DataversePowerToolsContext, args: string[], workspacePath: string, _opts?: { secret?: string }): Promise<PacResult> {
   const first = await runPacResult(args, workspacePath);
-  if (first.code !== 0 && isPacAuthError(`${first.stdout}\n${first.stderr}`)) {
+  // pac exits 0 on failure, so gate on the OUTPUT (pacSucceeded), not the exit code.
+  if (!pacSucceeded(first) && isPacAuthError(`${first.stdout}\n${first.stderr}`)) {
     context.channel.appendLine("[pac] Authentication error — re-establishing the pac profile and retrying once.");
     const reestablished = await reestablishPacAuthForCurrentConnection(context, workspacePath);
     if (reestablished) {
@@ -401,8 +442,9 @@ export async function runPacLoggedHealing(context: DataversePowerToolsContext, a
   if (result.stderr) {
     context.channel.appendLine(redact(result.stderr, opts?.secret));
   }
-  if (result.code !== 0) {
+  const ok = pacSucceeded(result);
+  if (!ok) {
     context.channel.show();
   }
-  return result.code === 0;
+  return ok;
 }

--- a/src/ui-test/supervised/pluginDebugSupervised.e2e.ts
+++ b/src/ui-test/supervised/pluginDebugSupervised.e2e.ts
@@ -1,0 +1,124 @@
+import * as path from "path";
+import * as fs from "fs";
+import { expect } from "chai";
+import { VSBrowser } from "vscode-extension-tester";
+import { freshWorkspace, answerText, pickByLabel, resetAllCredentials, runCommand, dismissOverlays, sleep } from "../e2e/lib";
+import { narrate, clickPanelButton, openPanelFrame, waitForConnected, isConnected, pauseForHuman, waitForFileExists, connectionSummary, actionBanner } from "./supervisedLib";
+
+// ─────────────────────────────────────────────────────────────────────────────
+// SUPERVISED plugin lifecycle → profiling/debug/trace.
+//
+// Run on demand: `npm run test:supervised`. NOT part of CI or `npm run test:e2e`.
+// It drives the REAL panel buttons (not the command palette) and pauses for you at
+// the sign-in steps. Watch the VS Code window; when you see the "🙋 ACTION NEEDED"
+// banner in the terminal, do the step (sign in, enter the pac device code) and the
+// test resumes itself once it detects you're done.
+//
+// v1 (this file) covers the first, most painful stretch — the OAuth + pac path:
+//   clear → blank project → OAuth (your sign-in) → add Plugins → Generate Earlybound.
+// The build → deploy → D365 → profile → debug → trace steps are the next slice.
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe("SUPERVISED: plugin lifecycle (UI-only, human-assisted)", function () {
+  // No mocha timeout — human steps take as long as they take (the harness has its
+  // own generous per-step timeouts so it still fails cleanly if truly stuck).
+  this.timeout(0);
+
+  const projectName = "SupervisedPlugin";
+  let workspace: string;
+
+  before(async function () {
+    workspace = freshWorkspace("supervised-plugin");
+    console.log(`\n[supervised] workspace: ${workspace}`);
+    await VSBrowser.instance.openResources(workspace);
+    await VSBrowser.instance.waitForWorkbench();
+    await sleep(3500);
+    await dismissOverlays();
+  });
+
+  it("1) starts from a cleared auth + pac state", async () => {
+    await narrate("Clear stored credentials and any pac profile (fresh start)");
+    // Setup prep (not a process under test): clear the extension's stored secrets +
+    // token cache, and the extension-owned pac profile, so the sign-in is genuinely new.
+    await resetAllCredentials((m) => console.log(`  ${m}`));
+    try {
+      await runCommand("Dataverse PowerTools: Clear pac Credentials");
+      await sleep(800);
+      // A modal confirm may appear — accept it.
+      await pickByLabel("Clear", 8000).catch(() => undefined);
+    } catch {
+      /* command may be a no-op if nothing to clear */
+    }
+    // Prove the panel is in its disconnected "Get Started" state.
+    const panel = await openPanelFrame();
+    await panel.switchBack();
+    expect(await isConnected(), "should start disconnected").to.equal(false);
+  });
+
+  it("2) creates a blank (multi-component) project from the panel button", async () => {
+    // Click the REAL primary button, not the command palette.
+    await clickPanelButton("Initialise Project", { timeoutMs: 30000 });
+    await narrate("Wizard: choose a blank multi-component project");
+    await pickByLabel("Multi-component project (two or more types)");
+    await narrate("Wizard: choose interactive (OAuth) auth");
+    await pickByLabel("OAuth");
+
+    // The OAuth sign-in happens now (Global Discovery). Hand off to you.
+    actionBanner(
+      "Sign in with OAuth in the browser that just opened — use the NEW account/profile you want. Then pick your environment in the VS Code quick pick. I'll continue once the panel shows connected.",
+    );
+    await waitForConnected();
+
+    expect(await waitForFileExists(path.join(workspace, "dataverse-powertools.json"), 60000), "dataverse-powertools.json created").to.equal(true);
+    console.log(`  Connected to: ${await connectionSummary()}`);
+  });
+
+  it("3) adds a Plugins component from the panel", async () => {
+    await clickPanelButton("Add Component", { timeoutMs: 30000, contains: true }); // label is "＋ Add Component…"
+    await narrate("Wizard: add a Plugins component");
+    await pickByLabel("Plugins");
+    await answerText(projectName);
+    // pac plugin init + restore run here (local — no auth). Can take a few minutes.
+    await narrate("Waiting for pac plugin init + restore (this is local, no sign-in)");
+    // The wizard offers to set up unit testing, then to create a class — answer as a user would.
+    await pickByLabel("No", 600000).catch(() => undefined); // "set up unit testing?"
+    await pickByLabel("Yes", 300000).catch(() => undefined); // "create a plugin class?"
+    await answerText("SupervisedAccountPlugin").catch(() => undefined);
+    await sleep(4000);
+    await dismissOverlays();
+
+    expect(await waitForFileExists(path.join(workspace, projectName, `${projectName}.csproj`), 300000), `${projectName}/${projectName}.csproj`).to.equal(true);
+  });
+
+  it("4) generates early-bound classes from the panel — the OAuth pac path (#128/#129, 0.14.1)", async () => {
+    // THIS is the step that exercises pac under OAuth: it establishes/reuses the
+    // extension-owned `dataverse-powertools` pac profile via device code, then runs
+    // `pac modelbuilder`. If it can't find/create the profile, this is where the old
+    // bug bit — the whole point of watching this run.
+    await clickPanelButton("Generate Earlybound", { timeoutMs: 30000 });
+
+    // First pac use under OAuth → device-code sign-in. The extension shows the code in a
+    // notification + the output channel. Complete it; the test resumes when generated files appear.
+    const generatedDir = path.join(workspace, "generated");
+    await pauseForHuman(
+      "If prompted, complete the pac DEVICE-CODE sign-in (the code is in the notification / Dataverse PowerTools output). I'll continue when early-bound files appear under generated/.",
+      async () => {
+        try {
+          return fs.existsSync(generatedDir) && fs.readdirSync(generatedDir).some((f) => f.toLowerCase().endsWith(".cs"));
+        } catch {
+          return false;
+        }
+      },
+      { timeoutMs: 12 * 60 * 1000 },
+    );
+
+    await narrate("Early-bound generation complete");
+    const hasGenerated = fs.existsSync(generatedDir) && fs.readdirSync(generatedDir).some((f) => f.toLowerCase().endsWith(".cs"));
+    expect(hasGenerated, "generated/*.cs produced by pac modelbuilder under OAuth").to.equal(true);
+  });
+
+  after(async function () {
+    await narrate("v1 stretch complete — connected + plugin + early-bound under OAuth");
+    console.log("\n[supervised] Next slice: build → deploy → trigger in D365 → profile a step → debug (breakpoint) → trace log.\n");
+  });
+});

--- a/src/ui-test/supervised/pluginDebugSupervised.e2e.ts
+++ b/src/ui-test/supervised/pluginDebugSupervised.e2e.ts
@@ -3,7 +3,7 @@ import * as fs from "fs";
 import { expect } from "chai";
 import { VSBrowser } from "vscode-extension-tester";
 import { freshWorkspace, answerText, answerFlexible, pickByLabel, resetAllCredentials, runCommand, dismissOverlays, sleep } from "../e2e/lib";
-import { narrate, clickPanelButton, openPanelFrame, waitForConnected, isConnected, pauseForHuman, waitForFileExists, connectionSummary, actionBanner } from "./supervisedLib";
+import { narrate, clickPanelButton, openPanelFrame, waitForConnected, isConnected, pauseForHuman, waitForFileExists, connectionSummary, actionBanner, expandComponentCards } from "./supervisedLib";
 
 // REUSE mode (npm run test:supervised:reuse) skips the sign-in prompts and reuses the OAuth +
 // pac profile captured on a prior fresh run, so fix iterations run unattended.
@@ -150,6 +150,8 @@ describe("SUPERVISED: plugin lifecycle (UI-only, human-assisted)", function () {
   });
 
   it("4) generates early-bound classes from the panel — the OAuth pac path (#128/#129, 0.14.1)", async () => {
+    // Multi-component cards open collapsed (#156) — expand so the plugin card's actions show.
+    await expandComponentCards();
     // THIS is the step that exercises pac under OAuth: it establishes/reuses the
     // extension-owned `dataverse-powertools` pac profile via device code, then runs
     // `pac modelbuilder`. If it can't find/create the profile, this is where the old

--- a/src/ui-test/supervised/pluginDebugSupervised.e2e.ts
+++ b/src/ui-test/supervised/pluginDebugSupervised.e2e.ts
@@ -8,7 +8,8 @@ import { narrate, clickPanelButton, openPanelFrame, waitForConnected, isConnecte
 // REUSE mode (npm run test:supervised:reuse) skips the sign-in prompts and reuses the OAuth +
 // pac profile captured on a prior fresh run, so fix iterations run unattended.
 const reuse = process.env.DVPT_SUPERVISED_REUSE === "1";
-const supervisedEnv = process.env.DVPT_SUPERVISED_ENV || "";
+const supervisedEnv = process.env.DVPT_SUPERVISED_ENV || ""; // environment name or org url to pick
+const supervisedSolution = process.env.DVPT_SUPERVISED_SOLUTION || ""; // solution display name to pick
 
 // ─────────────────────────────────────────────────────────────────────────────
 // SUPERVISED plugin lifecycle → profiling/debug/trace.
@@ -73,24 +74,25 @@ describe("SUPERVISED: plugin lifecycle (UI-only, human-assisted)", function () {
     await narrate("Wizard: choose interactive (OAuth) auth");
     await pickByLabel("OAuth");
 
-    // Global Discovery runs now → in FRESH mode this opens the browser (you sign in); in REUSE
-    // mode it's silent from the captured cache. Then the environment quick pick appears.
-    if (reuse) {
-      // Unattended: silent sign-in, then auto-pick the configured environment.
-      await answerFlexible(supervisedEnv, 180000);
-    } else {
-      actionBanner("Sign in with OAuth in the browser that just opened — use the NEW account/profile you want. I'll wait.");
-      if (supervisedEnv) {
-        // After your sign-in, the environment quick pick appears — I pick the configured one.
-        await answerFlexible(supervisedEnv, 10 * 60 * 1000);
-      } else {
-        // No env configured — you also pick your environment in the quick pick.
-        actionBanner("...and pick your environment in the VS Code quick pick. (Set DVPT_SUPERVISED_ENV in sandbox/.env to have me pick it next time.)");
-      }
+    // The connection wizard (createServicePrincipalString) now runs its OAuth path:
+    //   sign in → pick ENVIRONMENT → pick SOLUTION (prefix inferred) → project created.
+    // FRESH mode: the sign-in opens the browser (you). REUSE mode: it's silent from the
+    // captured cache. Either way we auto-answer the environment + solution picks from config,
+    // so your only manual step is the browser sign-in itself.
+    if (!reuse) {
+      actionBanner("Sign in with OAuth in the browser that just opened — use the NEW account/profile you want. I'll drive the rest.");
     }
-    await waitForConnected();
+    await narrate(`Wizard: pick environment "${supervisedEnv}"`);
+    await answerFlexible(supervisedEnv, reuse ? 180000 : 10 * 60 * 1000);
+    await narrate(`Wizard: pick solution "${supervisedSolution}"`);
+    // Next is the SOLUTION quick pick (prefix is then inferred from the chosen solution, so the
+    // wizard finishes). If the solution list didn't load it falls back to a "schema name" input —
+    // answerFlexible handles both, but a fallback here is itself a finding worth flagging.
+    await answerFlexible(supervisedSolution, 120000);
 
-    expect(await waitForFileExists(path.join(workspace, "dataverse-powertools.json"), 60000), "dataverse-powertools.json created").to.equal(true);
+    // Wizard done → settings written → panel refreshes to connected.
+    expect(await waitForFileExists(path.join(workspace, "dataverse-powertools.json"), 120000), "dataverse-powertools.json created (wizard completed)").to.equal(true);
+    await waitForConnected("Waiting for the panel to show the live connection.");
     console.log(`  Connected to: ${await connectionSummary()}`);
   });
 

--- a/src/ui-test/supervised/pluginDebugSupervised.e2e.ts
+++ b/src/ui-test/supervised/pluginDebugSupervised.e2e.ts
@@ -30,8 +30,43 @@ describe("SUPERVISED: plugin lifecycle (UI-only, human-assisted)", function () {
   // own generous per-step timeouts so it still fails cleanly if truly stuck).
   this.timeout(0);
 
-  const projectName = "SupervisedPlugin";
+  const componentFolder = "plugin"; // subfolder the Plugins component lives in
+  const projectName = "SupervisedPlugin"; // pac plugin project name
   let workspace: string;
+
+  /** All .csproj files anywhere under a directory (the v3 layout nests them). */
+  function findCsproj(dir: string): string[] {
+    const out: string[] = [];
+    const walk = (d: string) => {
+      let entries: fs.Dirent[] = [];
+      try {
+        entries = fs.readdirSync(d, { withFileTypes: true });
+      } catch {
+        return;
+      }
+      for (const e of entries) {
+        const full = path.join(d, e.name);
+        if (e.isDirectory() && e.name !== "obj" && e.name !== "bin" && e.name !== "node_modules") {
+          walk(full);
+        } else if (e.isFile() && e.name.toLowerCase().endsWith(".csproj")) {
+          out.push(full);
+        }
+      }
+    };
+    walk(dir);
+    return out;
+  }
+
+  async function pollUntil(cond: () => boolean, timeoutMs: number): Promise<boolean> {
+    const deadline = Date.now() + timeoutMs;
+    while (Date.now() < deadline) {
+      if (cond()) {
+        return true;
+      }
+      await sleep(2000);
+    }
+    return false;
+  }
 
   before(async function () {
     workspace = freshWorkspace("supervised-plugin");
@@ -99,8 +134,10 @@ describe("SUPERVISED: plugin lifecycle (UI-only, human-assisted)", function () {
   it("3) adds a Plugins component from the panel", async () => {
     await clickPanelButton("Add Component", { timeoutMs: 30000, contains: true }); // label is "＋ Add Component…"
     await narrate("Wizard: add a Plugins component");
-    await pickByLabel("Plugins");
-    await answerText(projectName);
+    // Add Component has THREE prompts: component type → subfolder → plugin project name.
+    await pickByLabel("Plugins"); // 1) component type
+    await answerText(componentFolder); // 2) subfolder (defaults to "plugin")
+    await answerText(projectName); // 3) plugin project name (defaults to "Plugin")
     // pac plugin init + restore run here (local — no auth). Can take a few minutes.
     await narrate("Waiting for pac plugin init + restore (this is local, no sign-in)");
     // The wizard offers to set up unit testing, then to create a class — answer as a user would.
@@ -110,7 +147,12 @@ describe("SUPERVISED: plugin lifecycle (UI-only, human-assisted)", function () {
     await sleep(4000);
     await dismissOverlays();
 
-    expect(await waitForFileExists(path.join(workspace, projectName, `${projectName}.csproj`), 300000), `${projectName}/${projectName}.csproj`).to.equal(true);
+    // The v3 layout nests the csproj under the component subfolder; assert one exists anywhere
+    // beneath it rather than guessing the exact path.
+    const componentRoot = path.join(workspace, componentFolder);
+    const found = await pollUntil(() => findCsproj(componentRoot).length > 0, 300000);
+    expect(found, `a .csproj scaffolded under ${componentFolder}/`).to.equal(true);
+    console.log(`  Scaffolded: ${findCsproj(componentRoot).join(", ")}`);
   });
 
   it("4) generates early-bound classes from the panel — the OAuth pac path (#128/#129, 0.14.1)", async () => {

--- a/src/ui-test/supervised/pluginDebugSupervised.e2e.ts
+++ b/src/ui-test/supervised/pluginDebugSupervised.e2e.ts
@@ -138,19 +138,13 @@ describe("SUPERVISED: plugin lifecycle (UI-only, human-assisted)", function () {
     await pickByLabel("Plugins"); // 1) component type
     await answerText(componentFolder); // 2) subfolder (defaults to "plugin")
     await answerText(projectName); // 3) plugin project name (defaults to "Plugin")
-    // pac plugin init + restore run here (local — no auth). Can take a few minutes.
-    await narrate("Waiting for pac plugin init + restore (this is local, no sign-in)");
-    // The wizard offers to set up unit testing, then to create a class — answer as a user would.
-    await pickByLabel("No", 600000).catch(() => undefined); // "set up unit testing?"
-    await pickByLabel("Yes", 300000).catch(() => undefined); // "create a plugin class?"
-    await answerText("SupervisedAccountPlugin").catch(() => undefined);
-    await sleep(4000);
-    await dismissOverlays();
-
-    // The v3 layout nests the csproj under the component subfolder; assert one exists anywhere
-    // beneath it rather than guessing the exact path.
+    // pac plugin init + restore run here (local — no auth). Gate on the scaffold appearing; add
+    // Component does NOT prompt for unit-testing/create-class (that's the new-project flow), so
+    // don't wait for phantom prompts. The v3 layout nests the csproj under the subfolder.
+    await narrate("Waiting for pac plugin init + restore (local, no sign-in)");
     const componentRoot = path.join(workspace, componentFolder);
     const found = await pollUntil(() => findCsproj(componentRoot).length > 0, 300000);
+    await dismissOverlays(); // clear any non-blocking "component added" notification
     expect(found, `a .csproj scaffolded under ${componentFolder}/`).to.equal(true);
     console.log(`  Scaffolded: ${findCsproj(componentRoot).join(", ")}`);
   });

--- a/src/ui-test/supervised/pluginDebugSupervised.e2e.ts
+++ b/src/ui-test/supervised/pluginDebugSupervised.e2e.ts
@@ -2,8 +2,13 @@ import * as path from "path";
 import * as fs from "fs";
 import { expect } from "chai";
 import { VSBrowser } from "vscode-extension-tester";
-import { freshWorkspace, answerText, pickByLabel, resetAllCredentials, runCommand, dismissOverlays, sleep } from "../e2e/lib";
+import { freshWorkspace, answerText, answerFlexible, pickByLabel, resetAllCredentials, runCommand, dismissOverlays, sleep } from "../e2e/lib";
 import { narrate, clickPanelButton, openPanelFrame, waitForConnected, isConnected, pauseForHuman, waitForFileExists, connectionSummary, actionBanner } from "./supervisedLib";
+
+// REUSE mode (npm run test:supervised:reuse) skips the sign-in prompts and reuses the OAuth +
+// pac profile captured on a prior fresh run, so fix iterations run unattended.
+const reuse = process.env.DVPT_SUPERVISED_REUSE === "1";
+const supervisedEnv = process.env.DVPT_SUPERVISED_ENV || "";
 
 // ─────────────────────────────────────────────────────────────────────────────
 // SUPERVISED plugin lifecycle → profiling/debug/trace.
@@ -36,7 +41,12 @@ describe("SUPERVISED: plugin lifecycle (UI-only, human-assisted)", function () {
     await dismissOverlays();
   });
 
-  it("1) starts from a cleared auth + pac state", async () => {
+  it("1) starts from a cleared auth + pac state (fresh mode only)", async function () {
+    if (reuse) {
+      console.log("  REUSE mode — keeping the captured OAuth + pac sign-in; skipping the clear.");
+      this.skip();
+      return;
+    }
     await narrate("Clear stored credentials and any pac profile (fresh start)");
     // Setup prep (not a process under test): clear the extension's stored secrets +
     // token cache, and the extension-owned pac profile, so the sign-in is genuinely new.
@@ -63,10 +73,21 @@ describe("SUPERVISED: plugin lifecycle (UI-only, human-assisted)", function () {
     await narrate("Wizard: choose interactive (OAuth) auth");
     await pickByLabel("OAuth");
 
-    // The OAuth sign-in happens now (Global Discovery). Hand off to you.
-    actionBanner(
-      "Sign in with OAuth in the browser that just opened — use the NEW account/profile you want. Then pick your environment in the VS Code quick pick. I'll continue once the panel shows connected.",
-    );
+    // Global Discovery runs now → in FRESH mode this opens the browser (you sign in); in REUSE
+    // mode it's silent from the captured cache. Then the environment quick pick appears.
+    if (reuse) {
+      // Unattended: silent sign-in, then auto-pick the configured environment.
+      await answerFlexible(supervisedEnv, 180000);
+    } else {
+      actionBanner("Sign in with OAuth in the browser that just opened — use the NEW account/profile you want. I'll wait.");
+      if (supervisedEnv) {
+        // After your sign-in, the environment quick pick appears — I pick the configured one.
+        await answerFlexible(supervisedEnv, 10 * 60 * 1000);
+      } else {
+        // No env configured — you also pick your environment in the quick pick.
+        actionBanner("...and pick your environment in the VS Code quick pick. (Set DVPT_SUPERVISED_ENV in sandbox/.env to have me pick it next time.)");
+      }
+    }
     await waitForConnected();
 
     expect(await waitForFileExists(path.join(workspace, "dataverse-powertools.json"), 60000), "dataverse-powertools.json created").to.equal(true);

--- a/src/ui-test/supervised/pluginDebugSupervised.e2e.ts
+++ b/src/ui-test/supervised/pluginDebugSupervised.e2e.ts
@@ -161,6 +161,19 @@ describe("SUPERVISED: plugin lifecycle (UI-only, human-assisted)", function () {
   });
 
   it("4) generates early-bound classes from the panel — the OAuth pac path (#128/#129, 0.14.1)", async () => {
+    // Seed modelbuilder.json so Generate Earlybound skips the config gauntlet (namespace →
+    // service context → output → 8+ emit/filter/log prompts) and goes STRAIGHT to the pac path
+    // we care about. NB: on an UNCONFIGURED plugin, Generate Earlybound shows a passive
+    // "Configure now?" notification and silently no-ops if it's dismissed — a UX trap worth an
+    // issue; here we sidestep it. Config lands in the component root (workspace/plugin).
+    const componentRoot = path.join(workspace, componentFolder);
+    await narrate("Seed modelbuilder.json (config is setup, not the process under test)");
+    fs.writeFileSync(
+      path.join(componentRoot, "modelbuilder.json"),
+      JSON.stringify({ namespace: "Dataverse.Plugins", serviceContextName: "XrmSvc", outputDirectory: "generated" }, null, 2),
+      "utf8",
+    );
+
     // Multi-component cards open collapsed (#156) — expand so the plugin card's actions show.
     await expandComponentCards();
     // THIS is the step that exercises pac under OAuth: it establishes/reuses the
@@ -171,7 +184,7 @@ describe("SUPERVISED: plugin lifecycle (UI-only, human-assisted)", function () {
 
     // First pac use under OAuth → device-code sign-in. The extension shows the code in a
     // notification + the output channel. Complete it; the test resumes when generated files appear.
-    const generatedDir = path.join(workspace, "generated");
+    const generatedDir = path.join(componentRoot, "generated");
     await pauseForHuman(
       "If prompted, complete the pac DEVICE-CODE sign-in (the code is in the notification / Dataverse PowerTools output). I'll continue when early-bound files appear under generated/.",
       async () => {

--- a/src/ui-test/supervised/pluginDebugSupervised.e2e.ts
+++ b/src/ui-test/supervised/pluginDebugSupervised.e2e.ts
@@ -3,7 +3,18 @@ import * as fs from "fs";
 import { expect } from "chai";
 import { VSBrowser } from "vscode-extension-tester";
 import { freshWorkspace, answerText, answerFlexible, pickByLabel, resetAllCredentials, runCommand, dismissOverlays, sleep } from "../e2e/lib";
-import { narrate, clickPanelButton, openPanelFrame, waitForConnected, isConnected, pauseForHuman, waitForFileExists, connectionSummary, actionBanner, expandComponentCards } from "./supervisedLib";
+import {
+  narrate,
+  clickPanelButton,
+  openPanelFrame,
+  waitForConnected,
+  isConnected,
+  pauseForHuman,
+  waitForFileExists,
+  connectionSummary,
+  actionBanner,
+  expandComponentCards,
+} from "./supervisedLib";
 
 // REUSE mode (npm run test:supervised:reuse) skips the sign-in prompts and reuses the OAuth +
 // pac profile captured on a prior fresh run, so fix iterations run unattended.

--- a/src/ui-test/supervised/supervisedLib.ts
+++ b/src/ui-test/supervised/supervisedLib.ts
@@ -143,7 +143,13 @@ export async function clickPanelButton(label: string, opts: { timeoutMs?: number
   while (Date.now() < deadline) {
     try {
       const clicked = await withPanel(async (panel) => {
-        const button = await findButtonEl(panel, label, opts.contains ?? false);
+        let button = await findButtonEl(panel, label, opts.contains ?? false);
+        if (!button) {
+          // The button may be on a COLLAPSED component card (#156) — a panel re-render can
+          // re-collapse it at any time, so expand within this same frame and re-find.
+          await expandCaretsInFrame(panel);
+          button = await findButtonEl(panel, label, opts.contains ?? false);
+        }
         if (!button) {
           return false;
         }
@@ -165,37 +171,31 @@ export async function clickPanelButton(label: string, opts: { timeoutMs?: number
   throw new Error(`clickPanelButton timed out for "${label}" after ${timeoutMs}ms (${lastError})`);
 }
 
-/** Expand a collapsed component card so its action buttons are in the DOM. Multi-component
- * cards open minimised (#156), which hides "Generate Earlybound"/"Local Build"/etc. The caret
- * button carries aria-label "Expand <name>" when collapsed, "Collapse <name>" when open. */
+/** Click every "Expand" caret in the CURRENTLY-FOCUSED panel frame. The caret is a tiny button
+ * (coordinate clicks miss it), so fire its handler via JS. Multi-component cards open minimised
+ * (#156), hiding "Generate Earlybound"/"Local Build"/etc.; clickPanelButton calls this on a miss,
+ * so a re-render that re-collapses a card can't defeat a click. */
+async function expandCaretsInFrame(panel: WebviewView): Promise<void> {
+  const carets = await panel.findWebElements(By.css("button.caret"));
+  for (const caret of carets) {
+    try {
+      const label = (await caret.getAttribute("aria-label")) ?? "";
+      if (label.startsWith("Expand")) {
+        await VSBrowser.instance.driver.executeScript("arguments[0].click();", caret);
+        await sleep(500);
+      }
+    } catch {
+      /* stale — skip */
+    }
+  }
+}
+
+/** Expand collapsed component cards (best-effort, narrated). clickPanelButton also self-expands,
+ * so this is mostly for an explicit, visible step. */
 export async function expandComponentCards(): Promise<void> {
   await narrate("Expand component card(s) so their action buttons are visible");
-  // The caret is a tiny button; a coordinate click can miss it, so fire its handler directly
-  // via JS. Re-open the frame each attempt and verify no "Expand" carets remain.
-  for (let attempt = 0; attempt < 4; attempt++) {
-    const remaining = await withPanel(async (panel) => {
-      const carets = await panel.findWebElements(By.css("button.caret"));
-      let expandable = 0;
-      for (const caret of carets) {
-        try {
-          const label = (await caret.getAttribute("aria-label")) ?? "";
-          if (label.startsWith("Expand")) {
-            expandable++;
-            await highlight(caret);
-            await VSBrowser.instance.driver.executeScript("arguments[0].click();", caret);
-            await sleep(700);
-          }
-        } catch {
-          /* stale — re-query next attempt */
-        }
-      }
-      return expandable;
-    });
-    if (remaining === 0) {
-      return;
-    }
-    await sleep(600);
-  }
+  await withPanel((panel) => expandCaretsInFrame(panel));
+  await sleep(600);
 }
 
 /** True when the panel shows a live Dataverse connection (the green dot). */

--- a/src/ui-test/supervised/supervisedLib.ts
+++ b/src/ui-test/supervised/supervisedLib.ts
@@ -1,0 +1,244 @@
+import * as fs from "fs";
+import * as path from "path";
+import { ActivityBar, VSBrowser, ViewControl, WebviewView, By, WebElement } from "vscode-extension-tester";
+// Reuse the proven e2e primitives rather than re-implementing them.
+import { sleep, dismissOverlays } from "../e2e/lib";
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Supervised UI-test harness.
+//
+// Unlike the automated e2e suites (which drive commands through the command
+// palette), this harness clicks the REAL panel buttons in the webview — the same
+// wiring a user clicks — and PAUSES for a human at the steps automation can't do
+// (OAuth sign-in, pac device-code). It is deliberately slow, narrated, and
+// screenshots every step so you can watch it live and see exactly where a flow
+// breaks. It is NOT run in CI; run it on demand with `npm run test:supervised`.
+// ─────────────────────────────────────────────────────────────────────────────
+
+let stepCounter = 0;
+const shotsDir = path.resolve(__dirname, "..", "..", "..", "sandbox", "supervised-shots");
+
+function ts(): string {
+  return new Date().toISOString().replace(/[:.]/g, "-");
+}
+
+/** Narrate a step to the console (a big, greppable banner) and screenshot it. */
+export async function narrate(message: string): Promise<void> {
+  stepCounter += 1;
+  const banner = `\n${"═".repeat(78)}\n  STEP ${stepCounter}: ${message}\n${"═".repeat(78)}`;
+  console.log(banner);
+  await screenshot(`step-${String(stepCounter).padStart(2, "0")}`);
+}
+
+/** A prominent call to action when the test needs a human — with the step it's waiting on. */
+export function actionBanner(message: string): void {
+  console.log(`\n${"▓".repeat(78)}\n  🙋 ACTION NEEDED\n  ${message}\n${"▓".repeat(78)}\n`);
+}
+
+export async function screenshot(name: string): Promise<void> {
+  try {
+    fs.mkdirSync(shotsDir, { recursive: true });
+    const img = await VSBrowser.instance.driver.takeScreenshot();
+    fs.writeFileSync(path.join(shotsDir, `${ts()}_${name.replace(/[^a-z0-9]+/gi, "-")}.png`), img, "base64");
+  } catch {
+    /* screenshots are best-effort */
+  }
+}
+
+/** Briefly outline an element so it's obvious what's about to be clicked. */
+async function highlight(el: WebElement): Promise<void> {
+  try {
+    await VSBrowser.instance.driver.executeScript("arguments[0].style.outline = '3px solid #f80'; arguments[0].scrollIntoView({block:'center'});", el);
+    await sleep(700);
+  } catch {
+    /* best-effort */
+  }
+}
+
+// ── Activity-bar + panel webview (proven in src/ui-test/menuPanel.test.ts) ──────
+
+async function getViewControl(): Promise<ViewControl | undefined> {
+  let control: ViewControl | undefined;
+  for (let i = 0; i < 12 && !control; i++) {
+    await dismissOverlays();
+    control = await new ActivityBar().getViewControl("Dataverse PowerTools");
+    if (!control) {
+      await sleep(1000);
+    }
+  }
+  return control;
+}
+
+/** Switch into the Actions panel webview iframe, verifying it's OURS via #root. */
+export async function openPanelFrame(): Promise<WebviewView> {
+  for (let attempt = 0; attempt < 12; attempt++) {
+    await dismissOverlays();
+    const control = await getViewControl();
+    if (control) {
+      try {
+        await control.openView();
+      } catch {
+        /* retried below */
+      }
+    }
+    await sleep(1000);
+    const webview = new WebviewView();
+    try {
+      await webview.switchToFrame(5000);
+      const marker = await webview.findWebElements(By.css("main#root"));
+      if (marker.length > 0) {
+        return webview;
+      }
+      await webview.switchBack();
+    } catch {
+      try {
+        await webview.switchBack();
+      } catch {
+        /* not in a frame */
+      }
+    }
+    await sleep(1000);
+  }
+  throw new Error("Could not switch into the Dataverse PowerTools actions panel webview");
+}
+
+/** Run a function with the panel frame in focus, always switching back after. */
+export async function withPanel<T>(fn: (panel: WebviewView) => Promise<T>): Promise<T> {
+  const panel = await openPanelFrame();
+  try {
+    return await fn(panel);
+  } finally {
+    try {
+      await panel.switchBack();
+    } catch {
+      /* not in a frame */
+    }
+  }
+}
+
+async function findButtonEl(panel: WebviewView, label: string, contains: boolean): Promise<WebElement | undefined> {
+  const buttons = await panel.findWebElements(By.css("button"));
+  for (const button of buttons) {
+    try {
+      const text = (await button.getText()).trim();
+      if (contains ? text.includes(label) : text === label) {
+        return button;
+      }
+    } catch {
+      /* stale — skip */
+    }
+  }
+  return undefined;
+}
+
+/** Click a panel button by its visible label — narrated, highlighted, then clicked.
+ * Re-opens the frame and polls, since the panel re-renders as state changes. Some
+ * labels carry decoration (e.g. "＋ Add Component…"), so pass `contains: true` to match
+ * a substring. */
+export async function clickPanelButton(label: string, opts: { timeoutMs?: number; contains?: boolean } = {}): Promise<void> {
+  const timeoutMs = opts.timeoutMs ?? 30000;
+  await narrate(`Click panel button: "${label}"${opts.contains ? " (substring)" : ""}`);
+  const deadline = Date.now() + timeoutMs;
+  let lastError = "";
+  while (Date.now() < deadline) {
+    try {
+      const clicked = await withPanel(async (panel) => {
+        const button = await findButtonEl(panel, label, opts.contains ?? false);
+        if (!button) {
+          return false;
+        }
+        await highlight(button);
+        await button.click();
+        return true;
+      });
+      if (clicked) {
+        await sleep(1200);
+        return;
+      }
+      lastError = `button "${label}" not found`;
+    } catch (error) {
+      lastError = `${error}`;
+    }
+    await sleep(1500);
+  }
+  await screenshot(`FAILED-click-${label}`);
+  throw new Error(`clickPanelButton timed out for "${label}" after ${timeoutMs}ms (${lastError})`);
+}
+
+/** True when the panel shows a live Dataverse connection (the green dot). */
+export async function isConnected(): Promise<boolean> {
+  try {
+    return await withPanel(async (panel) => {
+      const dots = await panel.findWebElements(By.css("span.dot.on"));
+      return dots.length > 0;
+    });
+  } catch {
+    return false;
+  }
+}
+
+/** The org header text ("<url> · <auth>") once connected, for logging/assertions. */
+export async function connectionSummary(): Promise<string> {
+  try {
+    return await withPanel(async (panel) => {
+      const small = await panel.findWebElements(By.css("section.card div.small"));
+      for (const el of small) {
+        const text = (await el.getText()).trim();
+        if (text.includes("·")) {
+          return text;
+        }
+      }
+      return "";
+    });
+  } catch {
+    return "";
+  }
+}
+
+// ── Human-in-the-loop ───────────────────────────────────────────────────────
+
+/**
+ * Pause for a human step (OAuth sign-in, pac device-code) and RESUME automatically
+ * once `until()` becomes true. Prints a heartbeat so it's obvious it's waiting, not
+ * hung. Throws on timeout so the run stops at the exact step you were on.
+ */
+export async function pauseForHuman(message: string, until: () => Promise<boolean>, opts: { timeoutMs?: number; pollMs?: number } = {}): Promise<void> {
+  const timeoutMs = opts.timeoutMs ?? 10 * 60 * 1000; // 10 min — generous for a sign-in
+  const pollMs = opts.pollMs ?? 4000;
+  actionBanner(message);
+  await screenshot("awaiting-human");
+  const deadline = Date.now() + timeoutMs;
+  let beats = 0;
+  while (Date.now() < deadline) {
+    if (await until().catch(() => false)) {
+      console.log("  ✓ detected the step is complete — resuming.\n");
+      await sleep(1500);
+      return;
+    }
+    beats += 1;
+    if (beats % 5 === 0) {
+      console.log(`  …still waiting (${Math.round((deadline - Date.now()) / 1000)}s left). ${message}`);
+    }
+    await sleep(pollMs);
+  }
+  await screenshot("TIMEOUT-awaiting-human");
+  throw new Error(`Timed out waiting for a human step: ${message}`);
+}
+
+/** Wait for the panel to show a live connection (after a supervised OAuth sign-in). */
+export async function waitForConnected(message = "Complete the OAuth sign-in (and pick your environment) in the browser / quick pick.", timeoutMs = 10 * 60 * 1000): Promise<void> {
+  await pauseForHuman(message, isConnected, { timeoutMs });
+  console.log(`  Connected: ${await connectionSummary()}`);
+}
+
+/** Poll for a file the extension is expected to produce (scaffold, generated, build output). */
+export async function waitForFileExists(filePath: string, timeoutMs = 300000): Promise<boolean> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    if (fs.existsSync(filePath)) {
+      return true;
+    }
+    await sleep(2000);
+  }
+  return false;
+}

--- a/src/ui-test/supervised/supervisedLib.ts
+++ b/src/ui-test/supervised/supervisedLib.ts
@@ -170,22 +170,32 @@ export async function clickPanelButton(label: string, opts: { timeoutMs?: number
  * button carries aria-label "Expand <name>" when collapsed, "Collapse <name>" when open. */
 export async function expandComponentCards(): Promise<void> {
   await narrate("Expand component card(s) so their action buttons are visible");
-  await withPanel(async (panel) => {
-    const carets = await panel.findWebElements(By.css("button.caret"));
-    for (const caret of carets) {
-      try {
-        const label = (await caret.getAttribute("aria-label")) ?? "";
-        if (label.startsWith("Expand")) {
-          await highlight(caret);
-          await caret.click();
-          await sleep(600);
+  // The caret is a tiny button; a coordinate click can miss it, so fire its handler directly
+  // via JS. Re-open the frame each attempt and verify no "Expand" carets remain.
+  for (let attempt = 0; attempt < 4; attempt++) {
+    const remaining = await withPanel(async (panel) => {
+      const carets = await panel.findWebElements(By.css("button.caret"));
+      let expandable = 0;
+      for (const caret of carets) {
+        try {
+          const label = (await caret.getAttribute("aria-label")) ?? "";
+          if (label.startsWith("Expand")) {
+            expandable++;
+            await highlight(caret);
+            await VSBrowser.instance.driver.executeScript("arguments[0].click();", caret);
+            await sleep(700);
+          }
+        } catch {
+          /* stale — re-query next attempt */
         }
-      } catch {
-        /* stale / already expanded */
       }
+      return expandable;
+    });
+    if (remaining === 0) {
+      return;
     }
-  });
-  await sleep(800);
+    await sleep(600);
+  }
 }
 
 /** True when the panel shows a live Dataverse connection (the green dot). */

--- a/src/ui-test/supervised/supervisedLib.ts
+++ b/src/ui-test/supervised/supervisedLib.ts
@@ -165,6 +165,29 @@ export async function clickPanelButton(label: string, opts: { timeoutMs?: number
   throw new Error(`clickPanelButton timed out for "${label}" after ${timeoutMs}ms (${lastError})`);
 }
 
+/** Expand a collapsed component card so its action buttons are in the DOM. Multi-component
+ * cards open minimised (#156), which hides "Generate Earlybound"/"Local Build"/etc. The caret
+ * button carries aria-label "Expand <name>" when collapsed, "Collapse <name>" when open. */
+export async function expandComponentCards(): Promise<void> {
+  await narrate("Expand component card(s) so their action buttons are visible");
+  await withPanel(async (panel) => {
+    const carets = await panel.findWebElements(By.css("button.caret"));
+    for (const caret of carets) {
+      try {
+        const label = (await caret.getAttribute("aria-label")) ?? "";
+        if (label.startsWith("Expand")) {
+          await highlight(caret);
+          await caret.click();
+          await sleep(600);
+        }
+      } catch {
+        /* stale / already expanded */
+      }
+    }
+  });
+  await sleep(800);
+}
+
 /** True when the panel shows a live Dataverse connection (the green dot). */
 export async function isConnected(): Promise<boolean> {
   try {

--- a/src/ui-test/supervised/supervisedLib.ts
+++ b/src/ui-test/supervised/supervisedLib.ts
@@ -205,6 +205,12 @@ export async function connectionSummary(): Promise<string> {
 export async function pauseForHuman(message: string, until: () => Promise<boolean>, opts: { timeoutMs?: number; pollMs?: number } = {}): Promise<void> {
   const timeoutMs = opts.timeoutMs ?? 10 * 60 * 1000; // 10 min — generous for a sign-in
   const pollMs = opts.pollMs ?? 4000;
+  // Reuse mode / already-authenticated: if the condition is ALREADY met, don't nag for a
+  // human — just continue. This is what makes an unattended reuse run quiet.
+  if (await until().catch(() => false)) {
+    console.log(`  ✓ "${message}" — already satisfied, continuing.`);
+    return;
+  }
   actionBanner(message);
   await screenshot("awaiting-human");
   const deadline = Date.now() + timeoutMs;


### PR DESCRIPTION
## What & why

0.14.1 made interactive (OAuth) auth own its `pac` profile, but it left one latent bug that made the whole thing "work but do nothing": **`pac` (2.8.1) exits 0 even on failure**. The extension trusted the exit code, so under OAuth it logged *"Reusing the pac profile"* for a profile that didn't exist and then *"Plugin early bound generation complete"* having generated **zero files** — a silent false success. This completes #128 / #129.

## Changes

**Product fix**
- `src/general/pacAuth.ts` — new `pacOutputHasError` / `pacSucceeded` / `listHasNamedProfile` + `pacAuthListArgs`. `ensureInteractivePacProfile` now parses `pac auth list` (existence) instead of trusting `select` / `org select` exit codes; `runPacLogged` / `runPacLoggedHealing` / `createInteractivePacProfile` / `runPacHealing` gate on `pacSucceeded`.
- `src/general/modelbuilder/index.ts` — `runPacWithAuthRetry` detects output errors and **throws on persistent failure**, so generation reports the real error instead of a false "complete".
- `src/general/pacAuth.spec.ts` — covers the exit-0-with-`Error:` case and `pac auth list` parsing.

**New: supervised UI test (on-demand, NOT in CI)** — `npm run test:supervised`
- Drives the **real panel buttons** through the OAuth `pac` path end-to-end (blank multi-component → OAuth → add Plugins → Generate Early-bound). This is what surfaced the false-success. Captures sign-in once, reuses it unattended for fix iterations. First slice; build → deploy → profile → debug → trace to follow.
- `src/ui-test/supervised/*`, `scripts/runSupervised.mjs`, `scripts/ensureSupervisedSolution.mjs`, `.mocharc-supervised.json`.

## Verification
- `lint` 0 errors · `compile` clean · `test:coverage` 478/478 green.
- **Supervised run green end-to-end**: OAuth reused silently → plugin scaffolded → Generate Early-bound reused the `pac` profile and produced **948 early-bound `.cs` files**, with no device-code prompt (the path that used to silently no-op).

🤖 Generated with [Claude Code](https://claude.com/claude-code)