### PR TITLE
0.14.4 (pre-release) — testing epic #143 Move 3: extract & unit-test trapped logic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 All notable changes to the "dataverse-powertools" extension will be documented in this file.
 
+## 0.14.4 (pre-release)
+
+Testing epic (#143), Move 3 — extract trapped pure logic into `vscode`-free modules and unit-test it, so the network/registration payload shapes and the panel/test-scaffold logic are guarded in CI instead of only by the manual e2e. No behaviour change; 62 new unit tests (478 → 540).
+
+- **Plugin-step & workflow-activity registration payloads** — extracted into `src/general/dataverse/stepPayloads.ts`: the `@odata.bind` step body (`buildStepPayload`), the "does the live step differ" diff (`stepNeedsUpdate` / `normalizeFilteringAttributes`), and the sparse workflow-activity PATCH builder (`getWorkflowPatchPayload`). These build the exact bodies Dataverse receives during Deploy — now covered by 22 tests.
+- **Panel project-card view-model** — `src/panel/panelCards.ts`: the settings→card field mapping (name fallback chain, `.csproj` detail, trigger passthrough) and the time formatter, split from the fs/vscode reads in `panelState.ts`.
+- **Plugin unit-test scaffolding logic** — `src/plugins/unitTestingLogic.ts`: target-framework compatibility resolution (`net462`→`net472`, netstandard→`net8.0`), C# language-version parsing, class-name sanitising, and the per-framework boilerplate.
+
 ## 0.14.3 (pre-release)
 
 Completes the OAuth `pac` fix from 0.14.1 (#128, #129) — the reason it "worked but did nothing".

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "type": "git",
     "url": "https://github.com/pete-mc/dataverse-powertools"
   },
-  "version": "0.14.3",
+  "version": "0.14.4",
   "engines": {
     "vscode": "^1.93.0"
   },

--- a/src/general/dataverse/registerPluginSteps.ts
+++ b/src/general/dataverse/registerPluginSteps.ts
@@ -4,19 +4,9 @@ import { addDataverseSolutionComponent } from "./addDataverseSolutionComponent";
 import { DataverseContext, Options } from "./dataverseContext";
 import { dataverseApiUrl, logDataverseHttpError } from "./webApi";
 import { escapeODataString } from "./odata";
+import { PluginStepRegistration, ExistingStepSnapshot, buildStepPayload, stepNeedsUpdate } from "./stepPayloads";
 
-export interface PluginStepRegistration {
-  className: string;
-  fullTypeName: string;
-  messageName: string;
-  entityLogicalName?: string;
-  stage: number;
-  mode: number;
-  filteringAttributes?: string;
-  stepName: string;
-  executionOrder: number;
-  stepId?: string;
-}
+export type { PluginStepRegistration } from "./stepPayloads";
 
 async function ensureDataverseContext(context: DataversePowerToolsContext): Promise<boolean> {
   if (!context.dataverse) {
@@ -192,16 +182,6 @@ async function doesStepExistById(context: DataversePowerToolsContext, stepId: st
   return false;
 }
 
-interface ExistingStepSnapshot {
-  sdkmessageprocessingstepid?: string;
-  name?: string;
-  rank?: number;
-  stage?: number;
-  mode?: number;
-  filteringattributes?: string;
-  sdkMessageFilterId?: string;
-}
-
 async function getExistingStepSnapshot(context: DataversePowerToolsContext, stepId: string): Promise<ExistingStepSnapshot | undefined> {
   const data = await getJson(context, `sdkmessageprocessingsteps(${stepId})?$select=sdkmessageprocessingstepid,name,rank,stage,mode,filteringattributes,_sdkmessagefilterid_value`);
 
@@ -218,69 +198,6 @@ async function getExistingStepSnapshot(context: DataversePowerToolsContext, step
     filteringattributes: data.filteringattributes,
     sdkMessageFilterId: data._sdkmessagefilterid_value,
   };
-}
-
-function normalizeFilteringAttributes(value: string | undefined): string {
-  const normalized = (value || "")
-    .split(",")
-    .map((attribute) => attribute.trim().toLowerCase())
-    .filter((attribute) => attribute.length > 0)
-    .sort((a, b) => a.localeCompare(b));
-
-  return normalized.join(",");
-}
-
-function stepNeedsUpdate(existingStep: ExistingStepSnapshot, step: PluginStepRegistration, sdkMessageFilterId?: string): boolean {
-  const existingFilter = normalizeFilteringAttributes(existingStep.filteringattributes);
-  const requestedFilter = normalizeFilteringAttributes(step.filteringAttributes);
-  const existingMessageFilterId = existingStep.sdkMessageFilterId || undefined;
-  const requestedMessageFilterId = sdkMessageFilterId || undefined;
-
-  if ((existingStep.name || "") !== step.stepName) {
-    return true;
-  }
-
-  if ((existingStep.rank ?? 0) !== step.executionOrder) {
-    return true;
-  }
-
-  if ((existingStep.stage ?? 0) !== step.stage) {
-    return true;
-  }
-
-  if ((existingStep.mode ?? 0) !== step.mode) {
-    return true;
-  }
-
-  if (existingFilter !== requestedFilter) {
-    return true;
-  }
-
-  if ((existingMessageFilterId || "") !== (requestedMessageFilterId || "")) {
-    return true;
-  }
-
-  return false;
-}
-
-function buildStepPayload(step: PluginStepRegistration, pluginTypeId: string, sdkMessageId: string, sdkMessageFilterId?: string): any {
-  const payload: any = {
-    name: step.stepName,
-    rank: step.executionOrder,
-    stage: step.stage,
-    mode: step.mode,
-    supporteddeployment: 0,
-    filteringattributes: step.filteringAttributes || "",
-  };
-
-  payload["plugintypeid@odata.bind"] = `/plugintypes(${pluginTypeId})`;
-  payload["sdkmessageid@odata.bind"] = `/sdkmessages(${sdkMessageId})`;
-
-  if (sdkMessageFilterId) {
-    payload["sdkmessagefilterid@odata.bind"] = `/sdkmessagefilters(${sdkMessageFilterId})`;
-  }
-
-  return payload;
 }
 
 export interface RegisterPluginStepsResult {

--- a/src/general/dataverse/registerWorkflowActivities.ts
+++ b/src/general/dataverse/registerWorkflowActivities.ts
@@ -4,36 +4,22 @@ import { addDataverseSolutionComponent } from "./addDataverseSolutionComponent";
 import { DataverseContext, Options } from "./dataverseContext";
 import { dataverseApiUrl, logDataverseHttpError } from "./webApi";
 import { escapeODataString } from "./odata";
+import {
+  WorkflowActivityRegistration,
+  ExistingWorkflowSnapshot,
+  ResolvedWorkflowPluginType,
+  normalizeForCompare,
+  toResolvedWorkflowPluginType,
+  getWorkflowPatchPayload,
+} from "./stepPayloads";
 
-export interface WorkflowActivityRegistration {
-  className: string;
-  fullTypeName: string;
-  workflowName: string;
-  workflowDescription?: string;
-  workflowGroup?: string;
-}
+export type { WorkflowActivityRegistration } from "./stepPayloads";
 
 export interface RegisterWorkflowActivitiesResult {
   created: number;
   updated: number;
   unchanged: number;
   skipped: number;
-}
-
-interface ExistingWorkflowSnapshot {
-  name?: string;
-  friendlyname?: string;
-  description?: string;
-  workflowactivitygroupname?: string;
-}
-
-interface ResolvedWorkflowPluginType {
-  plugintypeid: string;
-  snapshot: ExistingWorkflowSnapshot;
-}
-
-function normalizeString(value: string | undefined): string {
-  return (value || "").trim();
 }
 
 async function ensureDataverseContext(context: DataversePowerToolsContext): Promise<boolean> {
@@ -140,27 +126,6 @@ async function resolveWorkflowPluginType(context: DataversePowerToolsContext, as
   };
 }
 
-function normalizeForCompare(value: string | undefined): string {
-  return (value || "").trim().toLowerCase();
-}
-
-function toResolvedWorkflowPluginType(record: any): ResolvedWorkflowPluginType | undefined {
-  const pluginTypeId = record?.plugintypeid as string | undefined;
-  if (!pluginTypeId) {
-    return undefined;
-  }
-
-  return {
-    plugintypeid: pluginTypeId,
-    snapshot: {
-      name: record?.name,
-      friendlyname: record?.friendlyname,
-      description: record?.description,
-      workflowactivitygroupname: record?.workflowactivitygroupname,
-    },
-  };
-}
-
 async function resolveWorkflowPluginTypeFromAssembly(
   context: DataversePowerToolsContext,
   assemblyId: string,
@@ -198,32 +163,6 @@ async function resolveWorkflowPluginTypeFromAssembly(
   }
 
   return undefined;
-}
-
-function getWorkflowPatchPayload(existing: ExistingWorkflowSnapshot, workflow: WorkflowActivityRegistration): any {
-  const payload: any = {};
-
-  const requestedName = normalizeString(workflow.workflowName) || workflow.className;
-  const requestedDescription = normalizeString(workflow.workflowDescription);
-  const requestedGroup = normalizeString(workflow.workflowGroup);
-
-  if (normalizeString(existing.name) !== requestedName) {
-    payload.name = requestedName;
-  }
-
-  if (normalizeString(existing.friendlyname) !== requestedName) {
-    payload.friendlyname = requestedName;
-  }
-
-  if (normalizeString(existing.description) !== requestedDescription) {
-    payload.description = requestedDescription;
-  }
-
-  if (normalizeString(existing.workflowactivitygroupname) !== requestedGroup) {
-    payload.workflowactivitygroupname = requestedGroup;
-  }
-
-  return payload;
 }
 
 export async function registerWorkflowActivities(

--- a/src/general/dataverse/stepPayloads.spec.ts
+++ b/src/general/dataverse/stepPayloads.spec.ts
@@ -1,0 +1,172 @@
+import { describe, it, expect } from "vitest";
+import {
+  normalizeFilteringAttributes,
+  stepNeedsUpdate,
+  buildStepPayload,
+  normalizeString,
+  normalizeForCompare,
+  toResolvedWorkflowPluginType,
+  getWorkflowPatchPayload,
+  PluginStepRegistration,
+  ExistingStepSnapshot,
+  WorkflowActivityRegistration,
+} from "./stepPayloads";
+
+function step(overrides: Partial<PluginStepRegistration> = {}): PluginStepRegistration {
+  return {
+    className: "MyPlugin",
+    fullTypeName: "My.NS.MyPlugin",
+    messageName: "Update",
+    entityLogicalName: "account",
+    stage: 40,
+    mode: 0,
+    filteringAttributes: "name,telephone1",
+    stepName: "My.NS.MyPlugin: Update of account",
+    executionOrder: 1,
+    ...overrides,
+  };
+}
+
+function existing(overrides: Partial<ExistingStepSnapshot> = {}): ExistingStepSnapshot {
+  return {
+    sdkmessageprocessingstepid: "step-1",
+    name: "My.NS.MyPlugin: Update of account",
+    rank: 1,
+    stage: 40,
+    mode: 0,
+    filteringattributes: "name,telephone1",
+    sdkMessageFilterId: undefined,
+    ...overrides,
+  };
+}
+
+describe("normalizeFilteringAttributes", () => {
+  it("trims, lower-cases, drops empties, and sorts", () => {
+    expect(normalizeFilteringAttributes(" Name , TELEPHONE1 ,,")).toBe("name,telephone1");
+  });
+
+  it("is order-insensitive (same set → same string)", () => {
+    expect(normalizeFilteringAttributes("b,a,c")).toBe(normalizeFilteringAttributes("c,a,b"));
+  });
+
+  it("returns empty string for undefined / empty", () => {
+    expect(normalizeFilteringAttributes(undefined)).toBe("");
+    expect(normalizeFilteringAttributes("")).toBe("");
+    expect(normalizeFilteringAttributes(" , , ")).toBe("");
+  });
+});
+
+describe("stepNeedsUpdate", () => {
+  it("is false when everything matches (including reordered filters)", () => {
+    expect(stepNeedsUpdate(existing({ filteringattributes: "telephone1,name" }), step())).toBe(false);
+  });
+
+  it.each([
+    ["name", { name: "different name" }],
+    ["rank", { rank: 99 }],
+    ["stage", { stage: 20 }],
+    ["mode", { mode: 1 }],
+    ["filteringattributes", { filteringattributes: "name" }],
+  ])("is true when %s differs", (_label, overrides) => {
+    expect(stepNeedsUpdate(existing(overrides as Partial<ExistingStepSnapshot>), step())).toBe(true);
+  });
+
+  it("treats missing rank/stage/mode as 0", () => {
+    expect(stepNeedsUpdate(existing({ rank: undefined, stage: undefined, mode: undefined }), step({ executionOrder: 0, stage: 0, mode: 0 }))).toBe(false);
+  });
+
+  it("detects a change in the sdk message filter id", () => {
+    expect(stepNeedsUpdate(existing({ sdkMessageFilterId: undefined }), step(), "filter-2")).toBe(true);
+    expect(stepNeedsUpdate(existing({ sdkMessageFilterId: "filter-2" }), step(), "filter-2")).toBe(false);
+  });
+});
+
+describe("buildStepPayload", () => {
+  it("builds the step body with the required @odata.bind navigations", () => {
+    const payload = buildStepPayload(step(), "type-1", "msg-1");
+    expect(payload).toMatchObject({
+      name: "My.NS.MyPlugin: Update of account",
+      rank: 1,
+      stage: 40,
+      mode: 0,
+      supporteddeployment: 0,
+      filteringattributes: "name,telephone1",
+    });
+    // Bracket access: the Dataverse nav-property keys aren't valid identifiers.
+    expect(payload["plugintypeid@odata.bind"]).toBe("/plugintypes(type-1)");
+    expect(payload["sdkmessageid@odata.bind"]).toBe("/sdkmessages(msg-1)");
+  });
+
+  it("omits the message-filter bind when no filter id is given", () => {
+    expect(buildStepPayload(step(), "type-1", "msg-1")).not.toHaveProperty("sdkmessagefilterid@odata.bind");
+  });
+
+  it("adds the message-filter bind when a filter id is given", () => {
+    expect(buildStepPayload(step(), "type-1", "msg-1", "filter-1")["sdkmessagefilterid@odata.bind"]).toBe("/sdkmessagefilters(filter-1)");
+  });
+
+  it("defaults filteringattributes to empty string", () => {
+    expect(buildStepPayload(step({ filteringAttributes: undefined }), "t", "m").filteringattributes).toBe("");
+  });
+});
+
+describe("normalizeString / normalizeForCompare", () => {
+  it("normalizeString trims only", () => {
+    expect(normalizeString("  Hi  ")).toBe("Hi");
+    expect(normalizeString(undefined)).toBe("");
+  });
+
+  it("normalizeForCompare trims and lower-cases", () => {
+    expect(normalizeForCompare("  Foo.Bar  ")).toBe("foo.bar");
+    expect(normalizeForCompare(undefined)).toBe("");
+  });
+});
+
+describe("toResolvedWorkflowPluginType", () => {
+  it("returns undefined when there is no plugintypeid", () => {
+    expect(toResolvedWorkflowPluginType(undefined)).toBeUndefined();
+    expect(toResolvedWorkflowPluginType({})).toBeUndefined();
+    expect(toResolvedWorkflowPluginType({ plugintypeid: "" })).toBeUndefined();
+  });
+
+  it("maps the record into id + snapshot", () => {
+    expect(
+      toResolvedWorkflowPluginType({
+        plugintypeid: "pt-1",
+        name: "My.Wf",
+        friendlyname: "My Wf",
+        description: "does things",
+        workflowactivitygroupname: "MyGroup",
+      }),
+    ).toEqual({
+      plugintypeid: "pt-1",
+      snapshot: { name: "My.Wf", friendlyname: "My Wf", description: "does things", workflowactivitygroupname: "MyGroup" },
+    });
+  });
+});
+
+describe("getWorkflowPatchPayload", () => {
+  const wf: WorkflowActivityRegistration = {
+    className: "MyActivity",
+    fullTypeName: "My.NS.MyActivity",
+    workflowName: "My Activity",
+    workflowDescription: "desc",
+    workflowGroup: "Group",
+  };
+
+  it("is empty when nothing differs", () => {
+    expect(getWorkflowPatchPayload({ name: "My Activity", friendlyname: "My Activity", description: "desc", workflowactivitygroupname: "Group" }, wf)).toEqual({});
+  });
+
+  it("includes only the fields that differ", () => {
+    expect(getWorkflowPatchPayload({ name: "My Activity", friendlyname: "My Activity", description: "old", workflowactivitygroupname: "Group" }, wf)).toEqual({
+      description: "desc",
+    });
+  });
+
+  it("falls back to className when workflowName is blank", () => {
+    const payload = getWorkflowPatchPayload({}, { ...wf, workflowName: "  ", workflowDescription: undefined, workflowGroup: undefined });
+    expect(payload.name).toBe("MyActivity");
+    expect(payload.friendlyname).toBe("MyActivity");
+  });
+});

--- a/src/general/dataverse/stepPayloads.ts
+++ b/src/general/dataverse/stepPayloads.ts
@@ -1,0 +1,178 @@
+// Pure, vscode/network-free builders for plugin-step and workflow-activity
+// registration payloads and change-detection. Extracted from
+// registerPluginSteps.ts / registerWorkflowActivities.ts so the OData
+// `@odata.bind` payload shapes and the "does this need an update" diffing can be
+// unit-tested in isolation (#143 Move 3). The network files import from here.
+
+// ─── Plugin steps ────────────────────────────────────────────────────────────
+
+export interface PluginStepRegistration {
+  className: string;
+  fullTypeName: string;
+  messageName: string;
+  entityLogicalName?: string;
+  stage: number;
+  mode: number;
+  filteringAttributes?: string;
+  stepName: string;
+  executionOrder: number;
+  stepId?: string;
+}
+
+export interface ExistingStepSnapshot {
+  sdkmessageprocessingstepid?: string;
+  name?: string;
+  rank?: number;
+  stage?: number;
+  mode?: number;
+  filteringattributes?: string;
+  sdkMessageFilterId?: string;
+}
+
+/** Canonicalise a comma-separated filtering-attributes list so two equivalent
+ * lists compare equal: trim, lower-case, drop empties, sort. */
+export function normalizeFilteringAttributes(value: string | undefined): string {
+  const normalized = (value || "")
+    .split(",")
+    .map((attribute) => attribute.trim().toLowerCase())
+    .filter((attribute) => attribute.length > 0)
+    .sort((a, b) => a.localeCompare(b));
+
+  return normalized.join(",");
+}
+
+/** True when the live step differs from what we want to register (so we PATCH). */
+export function stepNeedsUpdate(existingStep: ExistingStepSnapshot, step: PluginStepRegistration, sdkMessageFilterId?: string): boolean {
+  const existingFilter = normalizeFilteringAttributes(existingStep.filteringattributes);
+  const requestedFilter = normalizeFilteringAttributes(step.filteringAttributes);
+  const existingMessageFilterId = existingStep.sdkMessageFilterId || undefined;
+  const requestedMessageFilterId = sdkMessageFilterId || undefined;
+
+  if ((existingStep.name || "") !== step.stepName) {
+    return true;
+  }
+
+  if ((existingStep.rank ?? 0) !== step.executionOrder) {
+    return true;
+  }
+
+  if ((existingStep.stage ?? 0) !== step.stage) {
+    return true;
+  }
+
+  if ((existingStep.mode ?? 0) !== step.mode) {
+    return true;
+  }
+
+  if (existingFilter !== requestedFilter) {
+    return true;
+  }
+
+  if ((existingMessageFilterId || "") !== (requestedMessageFilterId || "")) {
+    return true;
+  }
+
+  return false;
+}
+
+/** Build the create/update body for an `sdkmessageprocessingstep`, including the
+ * `@odata.bind` navigation properties Dataverse requires. */
+export function buildStepPayload(step: PluginStepRegistration, pluginTypeId: string, sdkMessageId: string, sdkMessageFilterId?: string): Record<string, unknown> {
+  const payload: Record<string, unknown> = {
+    name: step.stepName,
+    rank: step.executionOrder,
+    stage: step.stage,
+    mode: step.mode,
+    supporteddeployment: 0,
+    filteringattributes: step.filteringAttributes || "",
+  };
+
+  payload["plugintypeid@odata.bind"] = `/plugintypes(${pluginTypeId})`;
+  payload["sdkmessageid@odata.bind"] = `/sdkmessages(${sdkMessageId})`;
+
+  if (sdkMessageFilterId) {
+    payload["sdkmessagefilterid@odata.bind"] = `/sdkmessagefilters(${sdkMessageFilterId})`;
+  }
+
+  return payload;
+}
+
+// ─── Workflow activities ─────────────────────────────────────────────────────
+
+export interface WorkflowActivityRegistration {
+  className: string;
+  fullTypeName: string;
+  workflowName: string;
+  workflowDescription?: string;
+  workflowGroup?: string;
+}
+
+export interface ExistingWorkflowSnapshot {
+  name?: string;
+  friendlyname?: string;
+  description?: string;
+  workflowactivitygroupname?: string;
+}
+
+export interface ResolvedWorkflowPluginType {
+  plugintypeid: string;
+  snapshot: ExistingWorkflowSnapshot;
+}
+
+export function normalizeString(value: string | undefined): string {
+  return (value || "").trim();
+}
+
+export function normalizeForCompare(value: string | undefined): string {
+  return (value || "").trim().toLowerCase();
+}
+
+/** Shape a `plugintypes` record into the id + snapshot we diff against; undefined
+ * when the record has no plugintypeid. */
+export function toResolvedWorkflowPluginType(
+  record: { plugintypeid?: string; name?: string; friendlyname?: string; description?: string; workflowactivitygroupname?: string } | undefined | null,
+): ResolvedWorkflowPluginType | undefined {
+  const pluginTypeId = record?.plugintypeid;
+  if (!pluginTypeId) {
+    return undefined;
+  }
+
+  return {
+    plugintypeid: pluginTypeId,
+    snapshot: {
+      name: record?.name,
+      friendlyname: record?.friendlyname,
+      description: record?.description,
+      workflowactivitygroupname: record?.workflowactivitygroupname,
+    },
+  };
+}
+
+/** Build a sparse PATCH body for a workflow-activity `plugintype`: only the
+ * fields that actually differ from the live record are included (empty object =
+ * no change). */
+export function getWorkflowPatchPayload(existing: ExistingWorkflowSnapshot, workflow: WorkflowActivityRegistration): Record<string, unknown> {
+  const payload: Record<string, unknown> = {};
+
+  const requestedName = normalizeString(workflow.workflowName) || workflow.className;
+  const requestedDescription = normalizeString(workflow.workflowDescription);
+  const requestedGroup = normalizeString(workflow.workflowGroup);
+
+  if (normalizeString(existing.name) !== requestedName) {
+    payload.name = requestedName;
+  }
+
+  if (normalizeString(existing.friendlyname) !== requestedName) {
+    payload.friendlyname = requestedName;
+  }
+
+  if (normalizeString(existing.description) !== requestedDescription) {
+    payload.description = requestedDescription;
+  }
+
+  if (normalizeString(existing.workflowactivitygroupname) !== requestedGroup) {
+    payload.workflowactivitygroupname = requestedGroup;
+  }
+
+  return payload;
+}

--- a/src/general/pacAuth.spec.ts
+++ b/src/general/pacAuth.spec.ts
@@ -1,5 +1,16 @@
 import { describe, it, expect } from "vitest";
-import { AUTH_PROFILE_NAME, pacAuthCreateInteractiveArgs, pacAuthSelectArgs, pacAuthDeleteArgs, pacOrgSelectArgs, isPacAuthError, parseDeviceCode, pacOutputHasError, pacSucceeded, listHasNamedProfile } from "./pacAuth";
+import {
+  AUTH_PROFILE_NAME,
+  pacAuthCreateInteractiveArgs,
+  pacAuthSelectArgs,
+  pacAuthDeleteArgs,
+  pacOrgSelectArgs,
+  isPacAuthError,
+  parseDeviceCode,
+  pacOutputHasError,
+  pacSucceeded,
+  listHasNamedProfile,
+} from "./pacAuth";
 
 describe("pacAuthCreateInteractiveArgs", () => {
   it("builds an interactive create for a named profile + environment", () => {
@@ -91,7 +102,7 @@ describe("parseDeviceCode", () => {
 describe("pacOutputHasError / pacSucceeded — pac exits 0 even on failure (#128/#129)", () => {
   // Real pac 2.8.1 output: these all returned exit code 0.
   const noProfiles = "Microsoft PowerPlatform CLI\nVersion: 2.8.1\n\nError: No profiles were found on this computer. Please run 'pac auth create' to create one.";
-  const badName = "Error: AuthProfileNameDoesNotExist\nThere is no authentication profile with name \"dataverse-powertools\"";
+  const badName = 'Error: AuthProfileNameDoesNotExist\nThere is no authentication profile with name "dataverse-powertools"';
   const good = "Connected to... org32218dcd\nThe early bound classes were generated successfully.";
 
   it("detects pac's Error: banner in output", () => {
@@ -115,7 +126,8 @@ describe("listHasNamedProfile — parse `pac auth list` (it exits 0 even with no
     expect(listHasNamedProfile("No profiles were found on this computer. Please run 'pac auth create'.", "dataverse-powertools")).toBe(false);
   });
   it("is true only when the named profile appears in the list", () => {
-    const list = "Index Active Kind      Name                 Friendly Name        Url\n[1]   *      UNIVERSAL      dataverse-powertools dataverse-powertools https://org.crm.dynamics.com";
+    const list =
+      "Index Active Kind      Name                 Friendly Name        Url\n[1]   *      UNIVERSAL      dataverse-powertools dataverse-powertools https://org.crm.dynamics.com";
     expect(listHasNamedProfile(list, "dataverse-powertools")).toBe(true);
     expect(listHasNamedProfile(list, "some-other-profile")).toBe(false);
   });

--- a/src/panel/panelCards.spec.ts
+++ b/src/panel/panelCards.spec.ts
@@ -1,0 +1,54 @@
+import { describe, it, expect } from "vitest";
+import { clock, buildProjectCard, ProjectCardFsInfo } from "./panelCards";
+import { ComponentSettings } from "../components/discovery";
+
+const noFs: ProjectCardFsInfo = { hasSpkl: false, downloadedProfiles: undefined, captureSupported: undefined };
+
+describe("clock", () => {
+  it("returns empty string for undefined", () => {
+    expect(clock(undefined)).toBe("");
+  });
+
+  it("formats a timestamp as HH:MM (24h or 12h locale-dependent, always non-empty)", () => {
+    // Use a fixed epoch; assert the shape rather than the exact locale rendering.
+    const out = clock(Date.UTC(2020, 0, 1, 9, 5));
+    expect(out).toMatch(/\d{1,2}:\d{2}/);
+  });
+});
+
+describe("buildProjectCard", () => {
+  it("prefers solutionName for the card name", () => {
+    const settings = { type: "webresource", solutionName: "MySolution", pluginProjectName: "MyPlugin" } as unknown as ComponentSettings;
+    expect(buildProjectCard(settings, "/root", "sub", false, noFs).name).toBe("MySolution");
+  });
+
+  it("falls back solutionName → pluginProjectName → relativeRoot → ''", () => {
+    expect(buildProjectCard({ type: "plugin", pluginProjectName: "MyPlugin" } as unknown as ComponentSettings, "/r", "sub", false, noFs).name).toBe("MyPlugin");
+    expect(buildProjectCard({ type: "plugin" } as unknown as ComponentSettings, "/r", "sub", false, noFs).name).toBe("sub");
+    expect(buildProjectCard({ type: "plugin" } as unknown as ComponentSettings, "/r", "", false, noFs).name).toBe("");
+  });
+
+  it("sets a .csproj detail only when there is a plugin project name", () => {
+    expect(buildProjectCard({ type: "plugin", pluginProjectName: "Acme" } as unknown as ComponentSettings, "/r", "", true, noFs).detail).toBe("Acme.csproj");
+    expect(buildProjectCard({ type: "webresource" } as unknown as ComponentSettings, "/r", "", true, noFs).detail).toBeUndefined();
+  });
+
+  it("defaults an empty type to '' and coerces the unit-testing flag to boolean", () => {
+    const card = buildProjectCard({ pluginUnitTestingEnabled: 1 } as unknown as ComponentSettings, "/r", "", true, noFs);
+    expect(card.type).toBe("");
+    expect(card.hasPluginUnitTesting).toBe(true);
+  });
+
+  it("passes through the fs/OS facts verbatim", () => {
+    const fsInfo: ProjectCardFsInfo = { hasSpkl: true, downloadedProfiles: 3, captureSupported: true };
+    const card = buildProjectCard({ type: "plugin" } as unknown as ComponentSettings, "/r", "", true, fsInfo);
+    expect(card.hasSpkl).toBe(true);
+    expect(card.downloadedProfiles).toBe(3);
+    expect(card.captureSupported).toBe(true);
+  });
+
+  it("carries the azure-function trigger through (#145)", () => {
+    const card = buildProjectCard({ type: "azurefunction", azureFunctionTrigger: "webhook" } as unknown as ComponentSettings, "/r", "", true, noFs);
+    expect(card.azureFunctionTrigger).toBe("webhook");
+  });
+});

--- a/src/panel/panelCards.ts
+++ b/src/panel/panelCards.ts
@@ -1,0 +1,48 @@
+// Pure, vscode-free view-model builders for the actions panel. Extracted from
+// panelState.ts so the settings→card field mapping and time formatting can be
+// unit-tested without the vscode API or the filesystem (#143 Move 3). The fs/OS
+// reads (spkl.json presence, downloaded-profile count, capture support) stay in
+// panelState.ts and are passed in as `fsInfo`.
+
+import { ProjectCardState } from "./menuModel";
+import { ComponentSettings } from "../components/discovery";
+
+/** Format an epoch timestamp as a short HH:MM local time; "" when undefined. */
+export function clock(timestamp: number | undefined): string {
+  if (timestamp === undefined) {
+    return "";
+  }
+  return new Date(timestamp).toLocaleTimeString([], { hour: "2-digit", minute: "2-digit" });
+}
+
+/** The filesystem/OS-derived facts a project card needs — computed by the caller
+ * (panelState.ts) so this builder stays pure. */
+export interface ProjectCardFsInfo {
+  /** whether a spkl.json sits at the component root */
+  hasSpkl: boolean;
+  /** profiles downloaded into <root>/profiles (plugins only; undefined otherwise) */
+  downloadedProfiles: number | undefined;
+  /** whether headless profiler capture is supported here (plugins on Windows) */
+  captureSupported: boolean | undefined;
+}
+
+/** Map a component's settings + its fs facts into the panel's project-card state.
+ * The name falls back solutionName → pluginProjectName → relativeRoot → "". */
+export function buildProjectCard(settings: ComponentSettings, root: string, relativeRoot: string, isRoot: boolean, fsInfo: ProjectCardFsInfo): ProjectCardState {
+  return {
+    type: settings.type ?? "",
+    name: (settings.solutionName as string) || (settings.pluginProjectName as string) || relativeRoot || "",
+    relativeRoot,
+    root,
+    isRoot,
+    detail: settings.pluginProjectName ? `${settings.pluginProjectName}.csproj` : undefined,
+    templateVersion: settings.templateversion,
+    hasPluginUnitTesting: !!settings.pluginUnitTestingEnabled,
+    hasSpkl: fsInfo.hasSpkl,
+    webresourceOutput: settings.webresourceOutput as "bundle" | "perFile" | undefined,
+    // #145: the card's primary action follows the trigger (webhook leads with Register, others with Build).
+    azureFunctionTrigger: settings.azureFunctionTrigger as string | undefined,
+    downloadedProfiles: fsInfo.downloadedProfiles,
+    captureSupported: fsInfo.captureSupported,
+  };
+}

--- a/src/panel/panelState.ts
+++ b/src/panel/panelState.ts
@@ -11,13 +11,7 @@ import { getScannedRegistrations } from "./registrationsScanner";
 import { getTraceLogCache, getActiveProfilesCache } from "./panelDataCache";
 import { isDebugSessionActive } from "../webresources/debug/debugWebresources";
 import { ComponentSettings } from "../components/discovery";
-
-function clock(timestamp: number | undefined): string {
-  if (timestamp === undefined) {
-    return "";
-  }
-  return new Date(timestamp).toLocaleTimeString([], { hour: "2-digit", minute: "2-digit" });
-}
+import { clock, buildProjectCard } from "./panelCards";
 
 function activityItems(): ActivityItem[] {
   return getRecentOperations().map((op) => ({
@@ -38,24 +32,15 @@ function countDownloadedProfiles(root: string): number {
   }
 }
 
+/** Gather the fs/OS facts for a card, then delegate the field mapping to the
+ * pure builder in panelCards.ts. */
 function projectCard(settings: ComponentSettings, root: string, relativeRoot: string, isRoot: boolean): ProjectCardState {
   const isPlugin = settings.type === "plugin";
-  return {
-    type: settings.type ?? "",
-    name: (settings.solutionName as string) || (settings.pluginProjectName as string) || relativeRoot || "",
-    relativeRoot,
-    root,
-    isRoot,
-    detail: settings.pluginProjectName ? `${settings.pluginProjectName}.csproj` : undefined,
-    templateVersion: settings.templateversion,
-    hasPluginUnitTesting: !!settings.pluginUnitTestingEnabled,
+  return buildProjectCard(settings, root, relativeRoot, isRoot, {
     hasSpkl: fs.existsSync(path.join(root, "spkl.json")),
-    webresourceOutput: settings.webresourceOutput as "bundle" | "perFile" | undefined,
-    // #145: the card's primary action follows the trigger (webhook leads with Register, others with Build).
-    azureFunctionTrigger: settings.azureFunctionTrigger as string | undefined,
     downloadedProfiles: isPlugin ? countDownloadedProfiles(root) : undefined,
     captureSupported: isPlugin ? process.platform === "win32" : undefined,
-  };
+  });
 }
 
 /** Snapshot the extension state the actions panel renders. Read-only and cheap:

--- a/src/plugins/unitTesting.ts
+++ b/src/plugins/unitTesting.ts
@@ -5,8 +5,15 @@ import * as vscode from "vscode";
 import DataversePowerToolsContext from "../context";
 import { findPrimaryPluginCsproj } from "./projectPaths";
 import { activeComponentRoot } from "../components/componentDiscovery";
-
-type UnitTestFramework = "mstest" | "xunit" | "nunit";
+import {
+  UnitTestFramework,
+  normalizePathForSettings,
+  getTemplateForFramework,
+  sanitizeClassName,
+  getTestBoilerplate,
+  resolveCompatibleTestTargetFramework,
+  tryParseCSharpLanguageVersion,
+} from "./unitTestingLogic";
 
 const dataverseUnitTestPackage = "DataverseUnitTest";
 
@@ -54,10 +61,6 @@ async function runDotnet(context: DataversePowerToolsContext, args: string[], cw
   }
 }
 
-function normalizePathForSettings(relativePath: string): string {
-  return relativePath.replace(/\\/g, "/");
-}
-
 export async function resolveTestProjectPath(context: DataversePowerToolsContext, workspacePath: string): Promise<string | undefined> {
   const configuredPath = context.projectSettings.pluginUnitTestingProject;
   if (configuredPath) {
@@ -98,104 +101,6 @@ async function promptFramework(context: DataversePowerToolsContext): Promise<Uni
   return picked?.target;
 }
 
-function getTemplateForFramework(framework: UnitTestFramework): string {
-  if (framework === "mstest") {
-    return "mstest";
-  }
-  if (framework === "nunit") {
-    return "nunit";
-  }
-  return "xunit";
-}
-
-function sanitizeClassName(input: string): string {
-  const trimmed = input.trim();
-  if (!trimmed) {
-    return "";
-  }
-
-  const cleaned = trimmed.replace(/[^a-zA-Z0-9_]/g, "");
-  if (!cleaned) {
-    return "";
-  }
-
-  if (/^[0-9]/.test(cleaned)) {
-    return `Test${cleaned}`;
-  }
-
-  return cleaned;
-}
-
-function getTestBoilerplate(framework: UnitTestFramework, namespaceName: string, className: string): string {
-  if (framework === "mstest") {
-    return `using Microsoft.VisualStudio.TestTools.UnitTesting;
-
-namespace ${namespaceName};
-
-[TestClass]
-public class ${className}
-{
-    [TestMethod]
-  public void TODO_Add_DataverseUnitTest_For_Plugin_Execution()
-    {
-    // TODO: Replace placeholders with your plugin class and DataverseUnitTest setup.
-    // TODO: Arrange a DataverseUnitTest context/service provider with target/pre-image data.
-    // TODO: Execute the plugin under test and assert expected output/state changes.
-    var messageName = "Update";
-    var tableLogicalName = "account";
-
-    Assert.IsFalse(string.IsNullOrWhiteSpace(messageName));
-    Assert.IsFalse(string.IsNullOrWhiteSpace(tableLogicalName));
-    }
-}
-`;
-  }
-
-  if (framework === "nunit") {
-    return `using NUnit.Framework;
-
-namespace ${namespaceName};
-
-public class ${className}
-{
-    [Test]
-  public void TODO_Add_DataverseUnitTest_For_Plugin_Execution()
-    {
-    // TODO: Replace placeholders with your plugin class and DataverseUnitTest setup.
-    // TODO: Arrange a DataverseUnitTest context/service provider with target/pre-image data.
-    // TODO: Execute the plugin under test and assert expected output/state changes.
-    var messageName = "Update";
-    var tableLogicalName = "account";
-
-    Assert.That(string.IsNullOrWhiteSpace(messageName), Is.False);
-    Assert.That(string.IsNullOrWhiteSpace(tableLogicalName), Is.False);
-    }
-}
-`;
-  }
-
-  return `using Xunit;
-
-namespace ${namespaceName};
-
-public class ${className}
-{
-    [Fact]
-  public void TODO_Add_DataverseUnitTest_For_Plugin_Execution()
-    {
-    // TODO: Replace placeholders with your plugin class and DataverseUnitTest setup.
-    // TODO: Arrange a DataverseUnitTest context/service provider with target/pre-image data.
-    // TODO: Execute the plugin under test and assert expected output/state changes.
-    var messageName = "Update";
-    var tableLogicalName = "account";
-
-    Assert.False(string.IsNullOrWhiteSpace(messageName));
-    Assert.False(string.IsNullOrWhiteSpace(tableLogicalName));
-    }
-}
-`;
-}
-
 async function addOrUpdateBoilerplate(
   context: DataversePowerToolsContext,
   framework: UnitTestFramework,
@@ -212,56 +117,6 @@ async function addOrUpdateBoilerplate(
   const content = getTestBoilerplate(framework, namespaceName, className);
   await vscode.workspace.fs.writeFile(vscode.Uri.file(testFilePath), Buffer.from(content, "utf8"));
   context.channel.appendLine(`Created unit test boilerplate: ${className}.cs`);
-}
-
-function tryParseDotNetFrameworkVersion(targetFramework: string): number | undefined {
-  const match = targetFramework
-    .trim()
-    .toLowerCase()
-    .match(/^net(\d{2,3})$/);
-  if (!match) {
-    return undefined;
-  }
-
-  const numeric = match[1];
-  if (numeric.length === 2) {
-    return Number.parseInt(numeric, 10) * 10;
-  }
-
-  return Number.parseInt(numeric, 10);
-}
-
-function isRunnableModernDotNetTargetFramework(targetFramework: string): boolean {
-  return /^net\d+\.\d+$/.test(targetFramework.trim().toLowerCase());
-}
-
-function resolveCompatibleTestTargetFramework(pluginTargetFramework: string): string {
-  const normalizedTargetFramework = pluginTargetFramework.trim().toLowerCase();
-  const parsedFrameworkVersion = tryParseDotNetFrameworkVersion(normalizedTargetFramework);
-  if (parsedFrameworkVersion !== undefined) {
-    return parsedFrameworkVersion < 472 ? "net472" : normalizedTargetFramework;
-  }
-
-  if (isRunnableModernDotNetTargetFramework(normalizedTargetFramework)) {
-    return normalizedTargetFramework;
-  }
-
-  if (normalizedTargetFramework.startsWith("netstandard")) {
-    return "net8.0";
-  }
-  return pluginTargetFramework;
-}
-
-function tryParseCSharpLanguageVersion(value: string): number | undefined {
-  const normalized = value.trim().toLowerCase();
-  const numericMatch = normalized.match(/^(\d+)(\.\d+)?$/);
-  if (!numericMatch) {
-    return undefined;
-  }
-
-  const major = Number.parseInt(numericMatch[1], 10);
-  const minor = numericMatch[2] ? Number.parseInt(numericMatch[2].replace(".", ""), 10) : 0;
-  return major * 10 + minor;
 }
 
 async function ensureTestProjectLanguageCompatibility(context: DataversePowerToolsContext, testCsprojPath: string): Promise<void> {

--- a/src/plugins/unitTestingLogic.spec.ts
+++ b/src/plugins/unitTestingLogic.spec.ts
@@ -1,0 +1,134 @@
+import { describe, it, expect } from "vitest";
+import {
+  normalizePathForSettings,
+  getTemplateForFramework,
+  sanitizeClassName,
+  getTestBoilerplate,
+  tryParseDotNetFrameworkVersion,
+  isRunnableModernDotNetTargetFramework,
+  resolveCompatibleTestTargetFramework,
+  tryParseCSharpLanguageVersion,
+} from "./unitTestingLogic";
+
+describe("normalizePathForSettings", () => {
+  it("converts backslashes to forward slashes", () => {
+    expect(normalizePathForSettings("a\\b\\c")).toBe("a/b/c");
+    expect(normalizePathForSettings("a/b")).toBe("a/b");
+  });
+});
+
+describe("getTemplateForFramework", () => {
+  it("maps each framework to its dotnet template id", () => {
+    expect(getTemplateForFramework("mstest")).toBe("mstest");
+    expect(getTemplateForFramework("nunit")).toBe("nunit");
+    expect(getTemplateForFramework("xunit")).toBe("xunit");
+  });
+});
+
+describe("sanitizeClassName", () => {
+  it("strips illegal characters", () => {
+    expect(sanitizeClassName("My-Test Class!")).toBe("MyTestClass");
+  });
+
+  it("prefixes Test when it would start with a digit", () => {
+    expect(sanitizeClassName("123abc")).toBe("Test123abc");
+  });
+
+  it("returns empty string when nothing legal remains", () => {
+    expect(sanitizeClassName("   ")).toBe("");
+    expect(sanitizeClassName("!!!")).toBe("");
+  });
+
+  it("keeps underscores and alphanumerics", () => {
+    expect(sanitizeClassName("Valid_Name1")).toBe("Valid_Name1");
+  });
+});
+
+describe("getTestBoilerplate", () => {
+  it("emits MSTest attributes + namespace/class", () => {
+    const out = getTestBoilerplate("mstest", "My.Ns", "MyTests");
+    expect(out).toContain("using Microsoft.VisualStudio.TestTools.UnitTesting;");
+    expect(out).toContain("[TestClass]");
+    expect(out).toContain("namespace My.Ns;");
+    expect(out).toContain("public class MyTests");
+  });
+
+  it("emits NUnit attributes", () => {
+    const out = getTestBoilerplate("nunit", "N", "C");
+    expect(out).toContain("using NUnit.Framework;");
+    expect(out).toContain("[Test]");
+  });
+
+  it("emits xUnit attributes (default branch)", () => {
+    const out = getTestBoilerplate("xunit", "N", "C");
+    expect(out).toContain("using Xunit;");
+    expect(out).toContain("[Fact]");
+  });
+});
+
+describe("tryParseDotNetFrameworkVersion", () => {
+  it.each([
+    ["net462", 462],
+    ["net48", 480],
+    ["NET472", 472],
+    [" net46 ", 460],
+  ])("parses classic framework %s → %i", (input, expected) => {
+    expect(tryParseDotNetFrameworkVersion(input)).toBe(expected);
+  });
+
+  it.each(["net8.0", "netstandard2.0", "latest", ""])("returns undefined for %s", (input) => {
+    expect(tryParseDotNetFrameworkVersion(input)).toBeUndefined();
+  });
+});
+
+describe("isRunnableModernDotNetTargetFramework", () => {
+  it("is true for SDK-style monikers", () => {
+    expect(isRunnableModernDotNetTargetFramework("net8.0")).toBe(true);
+    expect(isRunnableModernDotNetTargetFramework("NET6.0")).toBe(true);
+  });
+
+  it("is false for classic / netstandard", () => {
+    expect(isRunnableModernDotNetTargetFramework("net472")).toBe(false);
+    expect(isRunnableModernDotNetTargetFramework("netstandard2.0")).toBe(false);
+  });
+});
+
+describe("resolveCompatibleTestTargetFramework", () => {
+  it("bumps classic frameworks below 4.7.2 up to net472", () => {
+    expect(resolveCompatibleTestTargetFramework("net462")).toBe("net472");
+    expect(resolveCompatibleTestTargetFramework("net46")).toBe("net472");
+  });
+
+  it("keeps classic frameworks at or above 4.7.2", () => {
+    expect(resolveCompatibleTestTargetFramework("net472")).toBe("net472");
+    expect(resolveCompatibleTestTargetFramework("net48")).toBe("net48");
+  });
+
+  it("passes modern monikers through (normalized)", () => {
+    expect(resolveCompatibleTestTargetFramework("net8.0")).toBe("net8.0");
+    expect(resolveCompatibleTestTargetFramework("NET6.0")).toBe("net6.0");
+  });
+
+  it("maps netstandard to net8.0", () => {
+    expect(resolveCompatibleTestTargetFramework("netstandard2.0")).toBe("net8.0");
+  });
+
+  it("returns the original input for unrecognized monikers", () => {
+    expect(resolveCompatibleTestTargetFramework("weird")).toBe("weird");
+  });
+});
+
+describe("tryParseCSharpLanguageVersion", () => {
+  it.each([
+    ["10", 100],
+    ["7.3", 73],
+    ["9.0", 90],
+    ["11", 110],
+  ])("parses %s → %i", (input, expected) => {
+    expect(tryParseCSharpLanguageVersion(input)).toBe(expected);
+  });
+
+  it.each(["latest", "preview", "default", ""])("returns undefined for non-numeric %s", (input) => {
+    expect(tryParseCSharpLanguageVersion(input)).toBeUndefined();
+  });
+});

--- a/src/plugins/unitTestingLogic.ts
+++ b/src/plugins/unitTestingLogic.ts
@@ -1,0 +1,172 @@
+// Pure, vscode/fs/process-free helpers for the plugin unit-testing feature:
+// target-framework compatibility resolution, C# language-version parsing, test
+// class-name sanitising, and the per-framework test boilerplate. Extracted from
+// unitTesting.ts so this logic can be unit-tested in isolation (#143 Move 3).
+
+export type UnitTestFramework = "mstest" | "xunit" | "nunit";
+
+/** Settings files store forward-slash paths regardless of OS. */
+export function normalizePathForSettings(relativePath: string): string {
+  return relativePath.replace(/\\/g, "/");
+}
+
+/** The `dotnet new` template id for a chosen framework. */
+export function getTemplateForFramework(framework: UnitTestFramework): string {
+  if (framework === "mstest") {
+    return "mstest";
+  }
+  if (framework === "nunit") {
+    return "nunit";
+  }
+  return "xunit";
+}
+
+/** Turn arbitrary user input into a legal C# class identifier (strip illegal
+ * chars, prefix `Test` when it would start with a digit); "" when nothing legal
+ * remains. */
+export function sanitizeClassName(input: string): string {
+  const trimmed = input.trim();
+  if (!trimmed) {
+    return "";
+  }
+
+  const cleaned = trimmed.replace(/[^a-zA-Z0-9_]/g, "");
+  if (!cleaned) {
+    return "";
+  }
+
+  if (/^[0-9]/.test(cleaned)) {
+    return `Test${cleaned}`;
+  }
+
+  return cleaned;
+}
+
+/** Per-framework starter test file content. */
+export function getTestBoilerplate(framework: UnitTestFramework, namespaceName: string, className: string): string {
+  if (framework === "mstest") {
+    return `using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace ${namespaceName};
+
+[TestClass]
+public class ${className}
+{
+    [TestMethod]
+  public void TODO_Add_DataverseUnitTest_For_Plugin_Execution()
+    {
+    // TODO: Replace placeholders with your plugin class and DataverseUnitTest setup.
+    // TODO: Arrange a DataverseUnitTest context/service provider with target/pre-image data.
+    // TODO: Execute the plugin under test and assert expected output/state changes.
+    var messageName = "Update";
+    var tableLogicalName = "account";
+
+    Assert.IsFalse(string.IsNullOrWhiteSpace(messageName));
+    Assert.IsFalse(string.IsNullOrWhiteSpace(tableLogicalName));
+    }
+}
+`;
+  }
+
+  if (framework === "nunit") {
+    return `using NUnit.Framework;
+
+namespace ${namespaceName};
+
+public class ${className}
+{
+    [Test]
+  public void TODO_Add_DataverseUnitTest_For_Plugin_Execution()
+    {
+    // TODO: Replace placeholders with your plugin class and DataverseUnitTest setup.
+    // TODO: Arrange a DataverseUnitTest context/service provider with target/pre-image data.
+    // TODO: Execute the plugin under test and assert expected output/state changes.
+    var messageName = "Update";
+    var tableLogicalName = "account";
+
+    Assert.That(string.IsNullOrWhiteSpace(messageName), Is.False);
+    Assert.That(string.IsNullOrWhiteSpace(tableLogicalName), Is.False);
+    }
+}
+`;
+  }
+
+  return `using Xunit;
+
+namespace ${namespaceName};
+
+public class ${className}
+{
+    [Fact]
+  public void TODO_Add_DataverseUnitTest_For_Plugin_Execution()
+    {
+    // TODO: Replace placeholders with your plugin class and DataverseUnitTest setup.
+    // TODO: Arrange a DataverseUnitTest context/service provider with target/pre-image data.
+    // TODO: Execute the plugin under test and assert expected output/state changes.
+    var messageName = "Update";
+    var tableLogicalName = "account";
+
+    Assert.False(string.IsNullOrWhiteSpace(messageName));
+    Assert.False(string.IsNullOrWhiteSpace(tableLogicalName));
+    }
+}
+`;
+}
+
+/** Parse a classic .NET Framework moniker (`net462` → 462, `net48` → 480);
+ * undefined for modern (`net8.0`) or non-framework monikers. */
+export function tryParseDotNetFrameworkVersion(targetFramework: string): number | undefined {
+  const match = targetFramework
+    .trim()
+    .toLowerCase()
+    .match(/^net(\d{2,3})$/);
+  if (!match) {
+    return undefined;
+  }
+
+  const numeric = match[1];
+  if (numeric.length === 2) {
+    return Number.parseInt(numeric, 10) * 10;
+  }
+
+  return Number.parseInt(numeric, 10);
+}
+
+/** True for a modern SDK-style moniker like `net8.0` (runnable test host). */
+export function isRunnableModernDotNetTargetFramework(targetFramework: string): boolean {
+  return /^net\d+\.\d+$/.test(targetFramework.trim().toLowerCase());
+}
+
+/** Pick a test-project target framework compatible with the plugin's: classic
+ * frameworks below 4.7.2 bump to net472; modern monikers pass through;
+ * netstandard maps to net8.0. */
+export function resolveCompatibleTestTargetFramework(pluginTargetFramework: string): string {
+  const normalizedTargetFramework = pluginTargetFramework.trim().toLowerCase();
+  const parsedFrameworkVersion = tryParseDotNetFrameworkVersion(normalizedTargetFramework);
+  if (parsedFrameworkVersion !== undefined) {
+    return parsedFrameworkVersion < 472 ? "net472" : normalizedTargetFramework;
+  }
+
+  if (isRunnableModernDotNetTargetFramework(normalizedTargetFramework)) {
+    return normalizedTargetFramework;
+  }
+
+  if (normalizedTargetFramework.startsWith("netstandard")) {
+    return "net8.0";
+  }
+  return pluginTargetFramework;
+}
+
+/** Parse a C# `<LangVersion>` numeric value (`10` → 100, `7.3` → 73); undefined
+ * for non-numeric values like `latest` / `preview`. */
+export function tryParseCSharpLanguageVersion(value: string): number | undefined {
+  const normalized = value.trim().toLowerCase();
+  const numericMatch = normalized.match(/^(\d+)(\.\d+)?$/);
+  if (!numericMatch) {
+    return undefined;
+  }
+
+  const major = Number.parseInt(numericMatch[1], 10);
+  const minor = numericMatch[2] ? Number.parseInt(numericMatch[2].replace(".", ""), 10) : 0;
+  return major * 10 + minor;
+}


### PR DESCRIPTION
## What & why

Testing epic (#143), **Move 3** — move the centre of gravity down: extract pure logic that was trapped inside `vscode`/network-bound files into `vscode`-free modules and unit-test it, so the bug classes that keep escaping to production are guarded in CI rather than only by the manual e2e. **No behaviour change.**

478 → **540 unit tests** (+62).

## Extracted modules (+ specs)

- **`src/general/dataverse/stepPayloads.ts`** (22 tests) — the OData registration payloads that were inline in `registerPluginSteps.ts` / `registerWorkflowActivities.ts`: `buildStepPayload` (the `@odata.bind` step body), `stepNeedsUpdate` / `normalizeFilteringAttributes` (change detection), and `getWorkflowPatchPayload` (sparse workflow PATCH). These are the exact bodies Dataverse receives on Deploy.
- **`src/panel/panelCards.ts`** (8 tests) — `buildProjectCard` (settings→card field mapping: name fallback, `.csproj` detail, trigger passthrough) + `clock`, split from the fs/vscode reads in `panelState.ts`.
- **`src/plugins/unitTestingLogic.ts`** (32 tests) — `resolveCompatibleTestTargetFramework` (net462→net472, netstandard→net8.0), `tryParseDotNetFrameworkVersion` / `tryParseCSharpLanguageVersion`, `sanitizeClassName`, `getTestBoilerplate`, `getTemplateForFramework`.

The network/vscode files now import these and are pure orchestration.

## Deliberately skipped
`getProjectTypeActivation` (#143 target 6): it's a thin delegate to the already-pure, already-tested `projectTypes/registry.ts` plus an inherently `vscode` command-map lookup — no pure logic worth isolating.

## Remaining #143 moves (future patches)
Move 1 (real integration suite), Move 2 (mock the Dataverse Web API), Move 4 (trim e2e redundancy), Move 5 (CI subset).

## Verification
`lint` clean · `compile` clean · `test:coverage` 540/540 green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)