### PR TITLE
0.14.6 (pre-release) — Custom API definition-as-code core + typed handler generation (#142)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 All notable changes to the "dataverse-powertools" extension will be documented in this file.
 
+## 0.14.6 (pre-release)
+
+New: **Custom API / Custom Actions — definition-as-code** (#142), the core enabler + typed handler generation. Revives the parked Custom API milestone.
+
+- **One definition file is the source of truth.** A `*.customapi.json` describes the API — unique name, binding (Global / Entity / EntityCollection), function-vs-action, request parameters + response properties (typed), the implementing plugin type — with field names that mirror the Dataverse `CustomAPI` tables so a future metadata deploy maps 1:1. **New Custom API definition** (plugin card / palette) seeds a valid sample.
+- **Typed C# handler generation — the differentiator (#142 issue #2).** **Generate Custom API handlers** reads every definition in the plugin, validates it, and emits a strongly-typed handler: a request wrapper that reads `InputParameters` as typed values (`request.AccountId` is an `EntityReference`, not a magic-string cast), a response wrapper that writes `OutputParameters`, and the `IPlugin` class stub. Change the definition, regenerate, and the **compiler points at the drift**.
+- **Local validation before deploy (#142 issues #1/#6).** Catches the errors the platform would otherwise reject — missing required fields, invalid unique names, binding-requires-bound-entity (and Global-forbids-it), duplicate parameter names, invalid types — with readable messages.
+
+> **Architecture decision (v1):** a Custom API is a **plugin-scoped** definition file (it lives in a plugin component and is implemented by that plugin), not a separate component type — matching "almost always implemented by a plugin" and avoiding a duplicate component surface. The pure core (definition / validate / codegen) is unit-tested (27 tests). **Metadata deploy (#3, create/update/reconcile `CustomAPI` + params via the Web API) and the invoke-from-editor / typed-caller fast-follows (#4–#5) are not in this slice** — the generated handler and definition are ready; wiring them into the deploy is next.
+
 ## 0.14.5 (pre-release)
 
 PCF (#141) — ship the service-layer pattern as **VS Code snippets** (the 80/20 alternative to code-generator commands).

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "type": "git",
     "url": "https://github.com/pete-mc/dataverse-powertools"
   },
-  "version": "0.14.5",
+  "version": "0.14.6",
   "engines": {
     "vscode": "^1.93.0"
   },
@@ -574,6 +574,16 @@
       {
         "command": "dataverse-powertools.guidePluginProfiling",
         "title": "Dataverse PowerTools: Profile a Plugin (how to capture)",
+        "enablement": "dataverse-powertools.showLoaded && dataverse-powertools.isPlugin"
+      },
+      {
+        "command": "dataverse-powertools.newCustomApi",
+        "title": "Dataverse PowerTools: New Custom API definition",
+        "enablement": "dataverse-powertools.showLoaded && dataverse-powertools.isPlugin"
+      },
+      {
+        "command": "dataverse-powertools.generateCustomApiHandlers",
+        "title": "Dataverse PowerTools: Generate Custom API handlers",
         "enablement": "dataverse-powertools.showLoaded && dataverse-powertools.isPlugin"
       },
       {

--- a/src/customapi/customApiCommands.ts
+++ b/src/customapi/customApiCommands.ts
@@ -1,0 +1,116 @@
+// VS Code-facing commands for Custom API definition-as-code (#142). Thin
+// orchestration around the pure modules (definition / validate / generateHandler)
+// — file discovery, prompts, and writing output. Plugin-scoped: a Custom API is a
+// `*.customapi.json` file that lives inside a plugin component and is implemented
+// by that plugin (the architecture decision for #142 v1).
+
+import * as vscode from "vscode";
+import * as fs from "fs";
+import * as path from "path";
+import DataversePowerToolsContext from "../context";
+import { activeComponentRoot } from "../components/componentDiscovery";
+import { CUSTOM_API_FILE_SUFFIX, CustomApiDefinition, newCustomApiDefinition } from "./definition";
+import { validateCustomApiDefinition } from "./validate";
+import { generateCustomApiHandler, customApiHandlerFileName } from "./generateHandler";
+
+/** All `*.customapi.json` files directly under a component root. */
+export function findCustomApiDefinitionFiles(root: string): string[] {
+  try {
+    return fs
+      .readdirSync(root)
+      .filter((file) => file.toLowerCase().endsWith(CUSTOM_API_FILE_SUFFIX))
+      .map((file) => path.join(root, file));
+  } catch {
+    return [];
+  }
+}
+
+/** Scaffold a new sample `*.customapi.json` in the active plugin component. */
+export async function newCustomApi(context: DataversePowerToolsContext): Promise<void> {
+  const root = activeComponentRoot(context);
+  if (!root) {
+    vscode.window.showErrorMessage("Open or select a plugin component first.");
+    return;
+  }
+
+  const uniqueName = await vscode.window.showInputBox({
+    prompt: "Custom API unique name (e.g. sample_DoTheThing) — this becomes the message name.",
+    validateInput: (value) => (/^[A-Za-z][A-Za-z0-9_]*$/.test(value.trim()) ? undefined : "Start with a letter; letters, digits and underscores only."),
+  });
+  if (!uniqueName) {
+    return;
+  }
+
+  const pluginTypeName = await vscode.window.showInputBox({
+    prompt: "Full plugin type name that implements it (namespace.Class), e.g. Sample.Plugins.DoTheThing.",
+    value: `Dataverse.Plugins.${uniqueName.replace(/[^A-Za-z0-9_]/g, "")}`,
+  });
+  if (!pluginTypeName) {
+    return;
+  }
+
+  const definition = newCustomApiDefinition(uniqueName.trim(), pluginTypeName.trim());
+  const filePath = path.join(root, `${uniqueName.trim()}${CUSTOM_API_FILE_SUFFIX}`);
+  if (fs.existsSync(filePath)) {
+    vscode.window.showErrorMessage(`${path.basename(filePath)} already exists.`);
+    return;
+  }
+
+  fs.writeFileSync(filePath, JSON.stringify(definition, null, 2) + "\n", "utf8");
+  context.channel.appendLine(`Created Custom API definition: ${filePath}`);
+  const doc = await vscode.workspace.openTextDocument(vscode.Uri.file(filePath));
+  await vscode.window.showTextDocument(doc);
+}
+
+/** Validate every `*.customapi.json` in the active plugin component and generate
+ * its typed C# handler. Skips (and reports) files that fail validation. */
+export async function generateCustomApiHandlers(context: DataversePowerToolsContext): Promise<void> {
+  const root = activeComponentRoot(context);
+  if (!root) {
+    vscode.window.showErrorMessage("Open or select a plugin component first.");
+    return;
+  }
+
+  const files = findCustomApiDefinitionFiles(root);
+  if (files.length === 0) {
+    vscode.window.showInformationMessage(`No ${CUSTOM_API_FILE_SUFFIX} definitions found. Run "New Custom API definition" first.`);
+    return;
+  }
+
+  const outDir = path.join(root, "CustomApi");
+  let generated = 0;
+  let failed = 0;
+
+  for (const file of files) {
+    const name = path.basename(file);
+    let definition: CustomApiDefinition;
+    try {
+      definition = JSON.parse(fs.readFileSync(file, "utf8")) as CustomApiDefinition;
+    } catch (error) {
+      context.channel.appendLine(`✗ ${name}: not valid JSON — ${(error as Error).message}`);
+      failed++;
+      continue;
+    }
+
+    const errors = validateCustomApiDefinition(definition);
+    if (errors.length > 0) {
+      context.channel.appendLine(`✗ ${name}: ${errors.length} validation error(s):`);
+      errors.forEach((e) => context.channel.appendLine(`    - ${e}`));
+      failed++;
+      continue;
+    }
+
+    fs.mkdirSync(outDir, { recursive: true });
+    const outPath = path.join(outDir, customApiHandlerFileName(definition));
+    fs.writeFileSync(outPath, generateCustomApiHandler(definition), "utf8");
+    context.channel.appendLine(`✓ ${name} → CustomApi/${path.basename(outPath)}`);
+    generated++;
+  }
+
+  if (failed > 0) {
+    context.channel.show(true);
+    vscode.window.showWarningMessage(`Custom API: generated ${generated}, ${failed} failed validation. See the Dataverse PowerTools output.`);
+  } else {
+    vscode.window.showInformationMessage(`Custom API: generated ${generated} typed handler(s) into CustomApi/.`);
+  }
+}

--- a/src/customapi/definition.ts
+++ b/src/customapi/definition.ts
@@ -1,0 +1,151 @@
+// Custom API "definition-as-code" file format (#142, issue #1).
+//
+// PURE module — no `vscode` import — so the shape, defaults, validation
+// (validate.ts) and codegen (generateHandler.ts) are all unit-testable without
+// the editor. A `*.customapi.json` file on disk is the single source of truth a
+// Custom API's typed handler (and, later, its metadata deploy / typed caller)
+// derive from.
+//
+// Field names mirror the Dataverse CustomAPI / CustomAPIRequestParameter /
+// CustomAPIResponseProperty tables so a future metadata deploy (#3, DEFERRED)
+// maps 1:1. See:
+//   https://learn.microsoft.com/power-apps/developer/data-platform/custom-api-tables
+
+/** Dataverse Custom API binding type (CustomAPI.bindingtype). */
+export type CustomApiBinding = "Global" | "Entity" | "EntityCollection";
+
+/** Dataverse CustomAPI.allowedcustomprocessingsteptype — whether other plug-ins
+ * may register extra steps against the message this Custom API creates. */
+export type AllowedCustomProcessingStepType = "None" | "AsyncOnly" | "SyncAndAsync";
+
+/**
+ * The Custom API request-parameter / response-property type enum
+ * (CustomAPIRequestParameter.type / CustomAPIResponseProperty.type). These are
+ * the exact string values the platform accepts.
+ */
+export type CustomApiParameterType =
+  "Boolean" | "DateTime" | "Decimal" | "Entity" | "EntityCollection" | "EntityReference" | "Float" | "Integer" | "Money" | "Picklist" | "String" | "StringArray" | "Guid";
+
+/** All valid parameter-type values, for validation and quick-picks. */
+export const CUSTOM_API_PARAMETER_TYPES: readonly CustomApiParameterType[] = [
+  "Boolean",
+  "DateTime",
+  "Decimal",
+  "Entity",
+  "EntityCollection",
+  "EntityReference",
+  "Float",
+  "Integer",
+  "Money",
+  "Picklist",
+  "String",
+  "StringArray",
+  "Guid",
+];
+
+/** A single Custom API request parameter (an input to the message). */
+export interface CustomApiRequestParameter {
+  /** CustomAPIRequestParameter.uniquename — the key used in InputParameters. Immutable once deployed. */
+  uniqueName: string;
+  /** CustomAPIRequestParameter.name — primary name. Convention: `{apiUniqueName}.{uniqueName}`. */
+  name: string;
+  /** Localizable display name. */
+  displayName?: string;
+  /** Parameter data type. */
+  type: CustomApiParameterType;
+  /** Whether the caller may omit a value (CustomAPIRequestParameter.isoptional). */
+  isOptional?: boolean;
+  /** Localizable description. */
+  description?: string;
+}
+
+/** A single Custom API response property (an output of the message). */
+export interface CustomApiResponseProperty {
+  /** CustomAPIResponseProperty.uniquename — the key used in OutputParameters. Immutable once deployed. */
+  uniqueName: string;
+  /** CustomAPIResponseProperty.name — primary name. Convention: `{apiUniqueName}.{uniqueName}`. */
+  name: string;
+  /** Localizable display name. */
+  displayName?: string;
+  /** Property data type. */
+  type: CustomApiParameterType;
+  /** Localizable description. */
+  description?: string;
+}
+
+/**
+ * The full Custom API definition — one `*.customapi.json` file.
+ * Property names track the CustomAPI table columns.
+ */
+export interface CustomApiDefinition {
+  /** CustomAPI.uniquename — the message name (e.g. `sample_DoTheThing`). Immutable once deployed. */
+  uniqueName: string;
+  /** CustomAPI.name — primary name of the record. */
+  name: string;
+  /** Localizable display name (CustomAPI.displayname). */
+  displayName: string;
+  /** Localizable description (CustomAPI.description). */
+  description?: string;
+  /** CustomAPI.bindingtype. */
+  binding: CustomApiBinding;
+  /** CustomAPI.boundentitylogicalname — required when binding != "Global". */
+  boundEntityLogicalName?: string;
+  /** CustomAPI.isfunction — true = OData Function (GET), false = Action (POST). Immutable once deployed. */
+  isFunction: boolean;
+  /** CustomAPI.isprivate — hide from $metadata / codegen. */
+  isPrivate?: boolean;
+  /** CustomAPI.workflowsdkstepenabled — usable as a workflow action. */
+  enabledForWorkflow?: boolean;
+  /** CustomAPI.allowedcustomprocessingsteptype. */
+  allowedCustomProcessingStepType?: AllowedCustomProcessingStepType;
+  /** CustomAPI.executeprivilegename — a privilege Name that gates execution. */
+  executePrivilegeName?: string;
+  /** The C# plugin class that implements the main operation (CustomAPI.PluginTypeId → plugintype.typename). */
+  pluginTypeName: string;
+  /** Inputs. */
+  requestParameters: CustomApiRequestParameter[];
+  /** Outputs. */
+  responseProperties: CustomApiResponseProperty[];
+}
+
+/** File-name suffix that marks a Custom API definition file. */
+export const CUSTOM_API_FILE_SUFFIX = ".customapi.json";
+
+/**
+ * Build a minimal, valid sample definition to seed a new `*.customapi.json`.
+ * Global unbound Action with one example request param + one response property —
+ * enough to generate a compiling handler immediately.
+ */
+export function newCustomApiDefinition(uniqueName: string, pluginTypeName: string): CustomApiDefinition {
+  return {
+    uniqueName,
+    name: uniqueName,
+    displayName: uniqueName,
+    description: "",
+    binding: "Global",
+    isFunction: false,
+    isPrivate: false,
+    enabledForWorkflow: false,
+    allowedCustomProcessingStepType: "None",
+    pluginTypeName,
+    requestParameters: [
+      {
+        uniqueName: "InputValue",
+        name: `${uniqueName}.InputValue`,
+        displayName: "Input Value",
+        type: "String",
+        isOptional: false,
+        description: "Example request parameter.",
+      },
+    ],
+    responseProperties: [
+      {
+        uniqueName: "OutputValue",
+        name: `${uniqueName}.OutputValue`,
+        displayName: "Output Value",
+        type: "String",
+        description: "Example response property.",
+      },
+    ],
+  };
+}

--- a/src/customapi/generateHandler.spec.ts
+++ b/src/customapi/generateHandler.spec.ts
@@ -1,0 +1,81 @@
+import { describe, it, expect } from "vitest";
+import { generateCustomApiHandler, customApiParameterCSharpType, splitPluginTypeName, customApiHandlerFileName } from "./generateHandler";
+import { newCustomApiDefinition, CustomApiDefinition } from "./definition";
+
+describe("customApiParameterCSharpType", () => {
+  it.each([
+    ["String", "string"],
+    ["Integer", "int"],
+    ["Boolean", "bool"],
+    ["EntityReference", "EntityReference"],
+    ["Money", "Money"],
+    ["Picklist", "OptionSetValue"],
+    ["StringArray", "string[]"],
+    ["Guid", "System.Guid"],
+    ["DateTime", "System.DateTime"],
+  ] as const)("maps %s → %s", (type, csharp) => {
+    expect(customApiParameterCSharpType(type)).toBe(csharp);
+  });
+});
+
+describe("splitPluginTypeName", () => {
+  it("splits a qualified type name", () => {
+    expect(splitPluginTypeName("Sample.Plugins.DoTheThing")).toEqual({ namespaceName: "Sample.Plugins", className: "DoTheThing" });
+  });
+
+  it("defaults the namespace for an unqualified name", () => {
+    expect(splitPluginTypeName("DoTheThing")).toEqual({ namespaceName: "Dataverse.Plugins", className: "DoTheThing" });
+  });
+});
+
+describe("customApiHandlerFileName", () => {
+  it("derives the file name from the class", () => {
+    expect(customApiHandlerFileName(newCustomApiDefinition("x", "A.B.MyHandler"))).toBe("MyHandler.generated.cs");
+  });
+});
+
+describe("generateCustomApiHandler", () => {
+  const def = newCustomApiDefinition("sample_DoTheThing", "Sample.Plugins.DoTheThing");
+  const code = generateCustomApiHandler(def);
+
+  it("emits the namespace, request/response wrappers, and IPlugin class", () => {
+    expect(code).toContain("namespace Sample.Plugins");
+    expect(code).toContain("public sealed class DoTheThingRequest");
+    expect(code).toContain("public sealed class DoTheThingResponse");
+    expect(code).toContain("public sealed class DoTheThing : IPlugin");
+    expect(code).toContain("public void Execute(IServiceProvider serviceProvider)");
+  });
+
+  it("generates a typed, guarded getter for a request parameter", () => {
+    // sample has a String request param "InputValue"
+    expect(code).toContain("public string InputValue =>");
+    expect(code).toContain('_context.InputParameters.Contains("InputValue")');
+    expect(code).toContain('(string)_context.InputParameters["InputValue"]');
+  });
+
+  it("generates a typed setter for a response property", () => {
+    // sample has a String response prop "OutputValue"
+    expect(code).toContain("public string OutputValue");
+    expect(code).toContain('_context.OutputParameters["OutputValue"] = value;');
+  });
+
+  it("maps parameter types to their C# types in the generated code", () => {
+    const typed: CustomApiDefinition = {
+      ...def,
+      requestParameters: [
+        { uniqueName: "AccountId", name: "x.AccountId", type: "EntityReference" },
+        { uniqueName: "Count", name: "x.Count", type: "Integer" },
+      ],
+    };
+    const out = generateCustomApiHandler(typed);
+    expect(out).toContain("public EntityReference AccountId =>");
+    expect(out).toContain("public int Count =>");
+  });
+
+  it("handles a definition with no parameters gracefully", () => {
+    const empty: CustomApiDefinition = { ...def, requestParameters: [], responseProperties: [] };
+    const out = generateCustomApiHandler(empty);
+    expect(out).toContain("// (no request parameters defined)");
+    expect(out).toContain("// (no response properties defined)");
+  });
+});

--- a/src/customapi/generateHandler.ts
+++ b/src/customapi/generateHandler.ts
@@ -1,0 +1,139 @@
+// Pure C# codegen for a Custom API's typed plugin handler (#142, issue #2 — the
+// differentiator). From one definition it emits a strongly-typed request wrapper
+// (reads InputParameters as typed values), a response wrapper (writes
+// OutputParameters), and the IPlugin class stub — so the handler reads
+// `request.AccountId` instead of `(EntityReference)context.InputParameters["accountId"]`,
+// and a definition change surfaces as a compiler error. No `vscode` import →
+// unit-testable.
+
+import { CustomApiDefinition, CustomApiParameterType, CustomApiRequestParameter, CustomApiResponseProperty } from "./definition";
+
+/** Map a Custom API parameter type to the C# type the SDK surfaces it as.
+ * Keys are the platform's PascalCase type vocabulary, not identifiers. */
+/* eslint-disable @typescript-eslint/naming-convention */
+const CSHARP_TYPES: Record<CustomApiParameterType, string> = {
+  Boolean: "bool",
+  DateTime: "System.DateTime",
+  Decimal: "decimal",
+  Entity: "Entity",
+  EntityCollection: "EntityCollection",
+  EntityReference: "EntityReference",
+  Float: "double",
+  Integer: "int",
+  Money: "Money",
+  Picklist: "OptionSetValue",
+  String: "string",
+  StringArray: "string[]",
+  Guid: "System.Guid",
+};
+/* eslint-enable @typescript-eslint/naming-convention */
+
+export function customApiParameterCSharpType(type: CustomApiParameterType): string {
+  return CSHARP_TYPES[type];
+}
+
+/** Split a full type name into namespace + class (defaults the namespace when unqualified). */
+export function splitPluginTypeName(fullTypeName: string): { namespaceName: string; className: string } {
+  const trimmed = (fullTypeName || "").trim();
+  const idx = trimmed.lastIndexOf(".");
+  if (idx < 0) {
+    return { namespaceName: "Dataverse.Plugins", className: trimmed || "CustomApiHandler" };
+  }
+  return { namespaceName: trimmed.slice(0, idx), className: trimmed.slice(idx + 1) };
+}
+
+function requestProperty(param: CustomApiRequestParameter): string {
+  const csharpType = customApiParameterCSharpType(param.type);
+  // Optional params may be absent from InputParameters; guard the read.
+  return [
+    param.description ? `        /// <summary>${escapeXml(param.description)}</summary>` : undefined,
+    `        public ${csharpType} ${param.uniqueName} =>`,
+    `            _context.InputParameters.Contains("${param.uniqueName}") ? (${csharpType})_context.InputParameters["${param.uniqueName}"] : default(${csharpType});`,
+  ]
+    .filter(Boolean)
+    .join("\n");
+}
+
+function responseProperty(prop: CustomApiResponseProperty): string {
+  const csharpType = customApiParameterCSharpType(prop.type);
+  return [
+    prop.description ? `        /// <summary>${escapeXml(prop.description)}</summary>` : undefined,
+    `        public ${csharpType} ${prop.uniqueName}`,
+    `        {`,
+    `            set => _context.OutputParameters["${prop.uniqueName}"] = value;`,
+    `        }`,
+  ]
+    .filter(Boolean)
+    .join("\n");
+}
+
+function escapeXml(value: string): string {
+  return value.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;");
+}
+
+/**
+ * Generate the full C# handler file (request wrapper + response wrapper + IPlugin
+ * class) for a Custom API definition. The class name / namespace come from the
+ * definition's pluginTypeName.
+ */
+export function generateCustomApiHandler(def: CustomApiDefinition): string {
+  const { namespaceName, className } = splitPluginTypeName(def.pluginTypeName);
+  const requestClass = `${className}Request`;
+  const responseClass = `${className}Response`;
+
+  const requestMembers = def.requestParameters.map(requestProperty).join("\n\n");
+  const responseMembers = def.responseProperties.map(responseProperty).join("\n\n");
+
+  return `using System;
+using Microsoft.Xrm.Sdk;
+
+namespace ${namespaceName}
+{
+    /// <summary>
+    /// Typed request wrapper for the "${def.uniqueName}" Custom API — reads
+    /// InputParameters as typed values. Generated from ${def.uniqueName}${".customapi.json"}; regenerate on change.
+    /// </summary>
+    public sealed class ${requestClass}
+    {
+        private readonly IPluginExecutionContext _context;
+        public ${requestClass}(IPluginExecutionContext context) => _context = context;
+
+${requestMembers || "        // (no request parameters defined)"}
+    }
+
+    /// <summary>
+    /// Typed response wrapper for the "${def.uniqueName}" Custom API — writes OutputParameters.
+    /// </summary>
+    public sealed class ${responseClass}
+    {
+        private readonly IPluginExecutionContext _context;
+        public ${responseClass}(IPluginExecutionContext context) => _context = context;
+
+${responseMembers || "        // (no response properties defined)"}
+    }
+
+    /// <summary>
+    /// Implements the "${def.uniqueName}" Custom API message.
+    /// Registered as plugin type ${def.pluginTypeName}.
+    /// </summary>
+    public sealed class ${className} : IPlugin
+    {
+        public void Execute(IServiceProvider serviceProvider)
+        {
+            var context = (IPluginExecutionContext)serviceProvider.GetService(typeof(IPluginExecutionContext));
+            var request = new ${requestClass}(context);
+            var response = new ${responseClass}(context);
+
+            // TODO: implement the "${def.uniqueName}" operation.
+            // Read typed inputs from 'request', set typed outputs on 'response'.
+        }
+    }
+}
+`;
+}
+
+/** Output file name for a definition's generated handler. */
+export function customApiHandlerFileName(def: CustomApiDefinition): string {
+  const { className } = splitPluginTypeName(def.pluginTypeName);
+  return `${className}.generated.cs`;
+}

--- a/src/customapi/validate.spec.ts
+++ b/src/customapi/validate.spec.ts
@@ -1,0 +1,64 @@
+import { describe, it, expect } from "vitest";
+import { validateCustomApiDefinition } from "./validate";
+import { newCustomApiDefinition, CustomApiDefinition } from "./definition";
+
+function valid(): CustomApiDefinition {
+  return newCustomApiDefinition("sample_DoTheThing", "Sample.Plugins.DoTheThing");
+}
+
+describe("validateCustomApiDefinition", () => {
+  it("accepts the seeded sample definition", () => {
+    expect(validateCustomApiDefinition(valid())).toEqual([]);
+  });
+
+  it("flags missing required fields", () => {
+    const def = { ...valid(), uniqueName: "", name: "", displayName: "", pluginTypeName: "" };
+    const errors = validateCustomApiDefinition(def);
+    expect(errors).toEqual(expect.arrayContaining([expect.stringContaining("uniqueName is required"), expect.stringContaining("pluginTypeName is required")]));
+  });
+
+  it("rejects an invalid uniqueName", () => {
+    expect(validateCustomApiDefinition({ ...valid(), uniqueName: "9bad name" })).toEqual(expect.arrayContaining([expect.stringContaining("must start with a letter")]));
+  });
+
+  it("rejects an invalid binding value", () => {
+    expect(validateCustomApiDefinition({ ...valid(), binding: "Nonsense" as CustomApiDefinition["binding"] })).toEqual(
+      expect.arrayContaining([expect.stringContaining('binding "Nonsense" is invalid')]),
+    );
+  });
+
+  it("requires boundEntityLogicalName for a non-global binding", () => {
+    expect(validateCustomApiDefinition({ ...valid(), binding: "Entity" })).toEqual(expect.arrayContaining([expect.stringContaining("boundEntityLogicalName is required")]));
+  });
+
+  it("accepts a non-global binding with a bound entity", () => {
+    expect(validateCustomApiDefinition({ ...valid(), binding: "Entity", boundEntityLogicalName: "account" })).toEqual([]);
+  });
+
+  it("forbids boundEntityLogicalName on a Global binding", () => {
+    expect(validateCustomApiDefinition({ ...valid(), binding: "Global", boundEntityLogicalName: "account" })).toEqual(
+      expect.arrayContaining([expect.stringContaining("must not be set for a Global binding")]),
+    );
+  });
+
+  it("detects duplicate request-parameter unique names (case-insensitive)", () => {
+    const def = valid();
+    def.requestParameters = [
+      { uniqueName: "Foo", name: "x.Foo", type: "String" },
+      { uniqueName: "foo", name: "x.foo", type: "String" },
+    ];
+    expect(validateCustomApiDefinition(def)).toEqual(expect.arrayContaining([expect.stringContaining("duplicate uniqueName")]));
+  });
+
+  it("rejects an invalid parameter type", () => {
+    const def = valid();
+    def.responseProperties = [{ uniqueName: "Out", name: "x.Out", type: "Nope" as CustomApiDefinition["responseProperties"][number]["type"] }];
+    expect(validateCustomApiDefinition(def)).toEqual(expect.arrayContaining([expect.stringContaining("is not a valid Custom API parameter type")]));
+  });
+
+  it("rejects an invalid parameter name", () => {
+    const def = valid();
+    def.requestParameters = [{ uniqueName: "bad-name", name: "x", type: "String" }];
+    expect(validateCustomApiDefinition(def)).toEqual(expect.arrayContaining([expect.stringContaining('requestParameters "bad-name"')]));
+  });
+});

--- a/src/customapi/validate.ts
+++ b/src/customapi/validate.ts
@@ -1,0 +1,77 @@
+// Pure validation for a Custom API definition (#142, issues #1/#6). No `vscode`
+// import — unit-testable. Catches the errors the platform would otherwise reject
+// at deploy time, with a readable message instead of a cryptic HTTP fault. Rules
+// here are only ones that are unambiguously correct (no fragile guesses), so a
+// clean result is a strong signal the definition will deploy.
+
+import { CustomApiDefinition, CUSTOM_API_PARAMETER_TYPES, CustomApiRequestParameter, CustomApiResponseProperty } from "./definition";
+
+const VALID_BINDINGS = ["Global", "Entity", "EntityCollection"];
+// Dataverse unique/schema names: start with a letter, then letters/digits/underscore.
+const UNIQUE_NAME_PATTERN = /^[A-Za-z][A-Za-z0-9_]*$/;
+
+/**
+ * Validate a Custom API definition. Returns a list of human-readable error
+ * messages; an empty array means the definition is structurally valid.
+ */
+export function validateCustomApiDefinition(def: CustomApiDefinition): string[] {
+  const errors: string[] = [];
+
+  requireField(errors, "uniqueName", def.uniqueName);
+  requireField(errors, "name", def.name);
+  requireField(errors, "displayName", def.displayName);
+  requireField(errors, "pluginTypeName", def.pluginTypeName);
+
+  if (def.uniqueName && !UNIQUE_NAME_PATTERN.test(def.uniqueName)) {
+    errors.push(`uniqueName "${def.uniqueName}" must start with a letter and contain only letters, digits, or underscores.`);
+  }
+
+  if (!VALID_BINDINGS.includes(def.binding)) {
+    errors.push(`binding "${def.binding}" is invalid — must be one of ${VALID_BINDINGS.join(", ")}.`);
+  } else if (def.binding === "Global") {
+    if (def.boundEntityLogicalName) {
+      errors.push(`boundEntityLogicalName must not be set for a Global binding (it applies only to Entity / EntityCollection).`);
+    }
+  } else if (!def.boundEntityLogicalName) {
+    errors.push(`boundEntityLogicalName is required when binding is "${def.binding}".`);
+  }
+
+  validateMembers(errors, "requestParameters", def.requestParameters);
+  validateMembers(errors, "responseProperties", def.responseProperties);
+
+  return errors;
+}
+
+function requireField(errors: string[], field: string, value: string | undefined): void {
+  if (!value || !value.trim()) {
+    errors.push(`${field} is required.`);
+  }
+}
+
+function validateMembers(errors: string[], label: string, members: (CustomApiRequestParameter | CustomApiResponseProperty)[] | undefined): void {
+  if (!members) {
+    return;
+  }
+
+  const seen = new Set<string>();
+  for (const member of members) {
+    const where = `${label} "${member.uniqueName || "(unnamed)"}"`;
+
+    if (!member.uniqueName || !member.uniqueName.trim()) {
+      errors.push(`${label}: every entry needs a uniqueName.`);
+    } else {
+      if (!UNIQUE_NAME_PATTERN.test(member.uniqueName)) {
+        errors.push(`${where}: uniqueName must start with a letter and contain only letters, digits, or underscores.`);
+      }
+      const key = member.uniqueName.toLowerCase();
+      if (seen.has(key)) {
+        errors.push(`${label}: duplicate uniqueName "${member.uniqueName}" (names must be unique, case-insensitively).`);
+      }
+      seen.add(key);
+    }
+
+    if (!CUSTOM_API_PARAMETER_TYPES.includes(member.type)) {
+      errors.push(`${where}: type "${member.type}" is not a valid Custom API parameter type.`);
+    }
+  }
+}

--- a/src/projectTypes/activation.ts
+++ b/src/projectTypes/activation.ts
@@ -15,6 +15,7 @@ import { buildProject } from "../plugins/buildProject";
 import { buildAndDeploy } from "../plugins/buildAndDeploy";
 import { addClassDecoration, updateFilteringAttributes } from "../plugins/decorations";
 import { viewPluginTraceLogs } from "../plugins/traceLogs";
+import { newCustomApi, generateCustomApiHandlers } from "../customapi/customApiCommands";
 import { downloadPluginProfiles } from "../plugins/downloadProfiles";
 import { capturePluginRun } from "../plugins/profilerCapture";
 import { generatePluginReplayTest } from "../plugins/replayTest";
@@ -183,6 +184,9 @@ export const projectTypeActivations: Record<ProjectTypes, ProjectTypeActivation>
       "dataverse-powertools.capturePluginRun": (context) => capturePluginRun(context),
       "dataverse-powertools.generatePluginReplayTest": (context) => generatePluginReplayTest(context),
       "dataverse-powertools.guidePluginProfiling": (context) => guidePluginProfiling(context),
+      // Custom API definition-as-code (#142) — plugin-scoped.
+      "dataverse-powertools.newCustomApi": (context) => newCustomApi(context),
+      "dataverse-powertools.generateCustomApiHandlers": (context) => generateCustomApiHandlers(context),
     },
     async onProjectScaffolded(context) {
       if (isPluginV3(context)) {

--- a/src/projectTypes/registry.ts
+++ b/src/projectTypes/registry.ts
@@ -105,6 +105,8 @@ export const projectTypeRegistry: readonly ProjectTypeDescriptor[] = [
       `${prefix}capturePluginRun`,
       `${prefix}generatePluginReplayTest`,
       `${prefix}guidePluginProfiling`,
+      `${prefix}newCustomApi`,
+      `${prefix}generateCustomApiHandlers`,
     ],
     menu(state) {
       const legacy = (state.templateVersion ?? 0) < 3;
@@ -135,6 +137,8 @@ export const projectTypeRegistry: readonly ProjectTypeDescriptor[] = [
                 { command: `${prefix}configurePluginEarlyBound`, label: "Configure all earlybound settings" },
                 { command: `${prefix}updateFilteringAttributes`, label: "Update filtering attributes" },
                 { command: `${prefix}addClassDecoration`, label: "Add class decoration" },
+                { command: `${prefix}newCustomApi`, label: "New Custom API definition" },
+                { command: `${prefix}generateCustomApiHandlers`, label: "Generate Custom API handlers" },
               ]),
           { command: `${prefix}buildDeployWorkflow`, label: "Build & deploy workflow" },
           // The profiling how-to lives here now (#139) — per-step Profile toggles + the card's


### PR DESCRIPTION
## What & why

Revives the parked **Custom API / Custom Actions** milestone (#142) with the *core enabler* and the *differentiator*: one local definition file → validated → typed C# handler. Closes the magic-string/type-drift gap no environment-side tool can (this extension sits code-side).

## Architecture decision (v1)
A Custom API is a **plugin-scoped** `*.customapi.json` file (it lives in a plugin component, implemented by that plugin) — **not** a separate component type. Matches "almost always implemented by a plugin" and avoids a duplicate component/discovery/test surface. Made under the standing authority to decide while the maintainer is away; documented here + in the changelog so it can be revisited.

## Changes (pure core + minimal wiring)
- `src/customapi/definition.ts` — definition types mirroring the Dataverse `CustomAPI` / `CustomAPIRequestParameter` / `CustomAPIResponseProperty` tables + a valid sample factory.
- `src/customapi/validate.ts` (11 tests) — pre-deploy validation: required fields, unique-name pattern, binding⇄bound-entity consistency, duplicate params, invalid types. Only unambiguously-correct rules (no fragile guesses).
- `src/customapi/generateHandler.ts` (16 tests) — typed request wrapper (reads `InputParameters` typed + guarded), response wrapper (writes `OutputParameters`), and the `IPlugin` class stub; parameter-type→C#-type map.
- `src/customapi/customApiCommands.ts` — **New Custom API definition** (seed a sample) + **Generate Custom API handlers** (validate all `*.customapi.json`, emit `CustomApi/*.generated.cs`). Plugin-scoped, registered once.
- `registry.ts` / `activation.ts` / `package.json` — wire the two commands (registry↔package.json↔activation **parity test green**).

## Not in this slice (fast-follows)
Metadata **deploy** (#3 — create/update/reconcile `CustomAPI` + params via the Web API, both auth types), **invoke-from-editor** (#4), **reverse-engineer + typed caller** (#5). The generated handler + definition are ready to feed those.

## Verification
`lint` clean · `compile` clean · `test:coverage` **571/571** (+27). Command registration is covered by the existing plugin-component integration test (asserts the full `registry.commandIds` set registers).

🤖 Generated with [Claude Code](https://claude.com/claude-code)