### PR TITLE
0.14.7 (pre-release) — Custom API metadata deploy + reconcile (#142 #3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 All notable changes to the "dataverse-powertools" extension will be documented in this file.
 
+## 0.14.7 (pre-release)
+
+Custom API (#142) — **metadata deploy** (issue #3), the second half of the v1 core. A definition now round-trips: edit → generate handler → **deploy the message to Dataverse**.
+
+- **Deploy Custom APIs** (plugin card / palette) pushes every `*.customapi.json` in the plugin to the environment: creates or updates the `CustomAPI` record, then **reconciles** its request parameters and response properties — creating new ones, updating changed labels, and **deleting any removed from the file** (the definition is the source of truth). Resolves the implementing plugin type first (and tells you to deploy the plugin if it's missing), then adds the Custom API to the project's solution.
+- **Correct by construction.** Option-set values (binding 0–2, processing-step 0–2, `customapifieldtype` 0–12) and the **immutable-after-save** column rules (updates omit `bindingtype` / `isfunction` / `uniquename` / `type` so the platform doesn't reject them) are taken straight from the Microsoft docs and unit-tested (12 tests). Works under **both auth types** (gates on the live connection, not the tenant).
+
+> **Pre-release — verify against an org before relying.** The payload shapes, option-set values and reconcile logic are docs-verified and unit-tested, but the create/update/**delete** calls have not yet been exercised against a live environment (there's no headless Web API test harness). Treat the first real deploy as a supervised check — especially the delete-reconcile of parameters. Remaining #142 fast-follows: invoke-from-editor (#4) and reverse-engineer + typed caller (#5).
+
 ## 0.14.6 (pre-release)
 
 New: **Custom API / Custom Actions — definition-as-code** (#142), the core enabler + typed handler generation. Revives the parked Custom API milestone.

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "type": "git",
     "url": "https://github.com/pete-mc/dataverse-powertools"
   },
-  "version": "0.14.6",
+  "version": "0.14.7",
   "engines": {
     "vscode": "^1.93.0"
   },
@@ -584,6 +584,11 @@
       {
         "command": "dataverse-powertools.generateCustomApiHandlers",
         "title": "Dataverse PowerTools: Generate Custom API handlers",
+        "enablement": "dataverse-powertools.showLoaded && dataverse-powertools.isPlugin"
+      },
+      {
+        "command": "dataverse-powertools.deployCustomApis",
+        "title": "Dataverse PowerTools: Deploy Custom APIs",
         "enablement": "dataverse-powertools.showLoaded && dataverse-powertools.isPlugin"
       },
       {

--- a/src/customapi/deployCustomApi.ts
+++ b/src/customapi/deployCustomApi.ts
@@ -1,0 +1,247 @@
+// VS Code / Web API orchestration for the Custom API metadata deploy (#142, #3).
+// Pushes each *.customapi.json to Dataverse — create/update the CustomAPI record,
+// then reconcile its request parameters + response properties (create/update, and
+// DELETE any removed from the file), then add it to the project's solution.
+//
+// Gates on the LIVE connection (works under both auth types — never on tenantId,
+// per #90/#91). The payload/reconcile logic is pure + unit-tested in
+// deployPayloads.ts; this file is the HTTP glue, mirroring registerPluginSteps.ts.
+//
+// NB: pre-release — the create/update/delete calls have not yet been run against a
+// live org (no headless Web API harness). The payload shapes and option-set values
+// are docs-verified and unit-tested; verify against an environment before relying.
+
+import fetch from "node-fetch";
+import * as fs from "fs";
+import * as path from "path";
+import * as vscode from "vscode";
+import DataversePowerToolsContext from "../context";
+import { activeComponentRoot } from "../components/componentDiscovery";
+import { DataverseContext, Options } from "../general/dataverse/dataverseContext";
+import { dataverseApiUrl, logDataverseHttpError } from "../general/dataverse/webApi";
+import { escapeODataString } from "../general/dataverse/odata";
+import { addDataverseSolutionComponentByObjectId } from "../general/dataverse/addDataverseSolutionComponent";
+import { CustomApiDefinition } from "./definition";
+import { validateCustomApiDefinition } from "./validate";
+import { findCustomApiDefinitionFiles } from "./customApiCommands";
+import {
+  buildCustomApiCreatePayload,
+  buildCustomApiUpdatePayload,
+  buildRequestParameterCreatePayload,
+  buildResponsePropertyCreatePayload,
+  buildMemberUpdatePayload,
+  reconcileByUniqueName,
+  ExistingNamedRecord,
+} from "./deployPayloads";
+
+async function ensureContext(context: DataversePowerToolsContext): Promise<boolean> {
+  if (!context.dataverse) {
+    context.dataverse = new DataverseContext(context);
+  }
+  return context.dataverse.isValid ? true : context.dataverse.initialize();
+}
+
+function jsonHeaders(token: string): { headers: Record<string, string> } {
+  /* eslint-disable @typescript-eslint/naming-convention */
+  return {
+    headers: {
+      Authorization: `Bearer ${token}`,
+      Accept: "application/json",
+      "Content-Type": "application/json",
+      "OData-MaxVersion": "4.0",
+      "OData-Version": "4.0",
+    },
+  };
+  /* eslint-enable @typescript-eslint/naming-convention */
+}
+
+async function getJson(context: DataversePowerToolsContext, relativeUrl: string): Promise<any | undefined> {
+  const token = await context.dataverse.getAuthorizationToken();
+  const baseUrl = context.dataverse.organizationUrl;
+  if (!token || !baseUrl) {
+    return undefined;
+  }
+  const response = await fetch(dataverseApiUrl(baseUrl, relativeUrl), { method: "GET", ...jsonHeaders(token) } as Options);
+  if (!response.ok) {
+    await logDataverseHttpError(context.channel, `GET ${relativeUrl}`, response);
+    return undefined;
+  }
+  return response.json();
+}
+
+/** POST a record; returns the new record id (parsed from the OData-EntityId header) or undefined. */
+async function createRecord(context: DataversePowerToolsContext, entitySet: string, payload: Record<string, unknown>): Promise<string | undefined> {
+  const token = await context.dataverse.getAuthorizationToken();
+  const baseUrl = context.dataverse.organizationUrl;
+  if (!token || !baseUrl) {
+    return undefined;
+  }
+  const response = await fetch(dataverseApiUrl(baseUrl, entitySet), { method: "POST", body: JSON.stringify(payload), ...jsonHeaders(token) } as Options);
+  if (!response.ok) {
+    await logDataverseHttpError(context.channel, `POST ${entitySet}`, response);
+    return undefined;
+  }
+  const entityId = response.headers.get("OData-EntityId") || response.headers.get("odata-entityid") || "";
+  const match = entityId.match(/\(([0-9a-fA-F-]{36})\)/);
+  return match?.[1];
+}
+
+async function patchRecord(context: DataversePowerToolsContext, entitySet: string, id: string, payload: Record<string, unknown>): Promise<boolean> {
+  const token = await context.dataverse.getAuthorizationToken();
+  const baseUrl = context.dataverse.organizationUrl;
+  if (!token || !baseUrl) {
+    return false;
+  }
+  const response = await fetch(dataverseApiUrl(baseUrl, `${entitySet}(${id})`), { method: "PATCH", body: JSON.stringify(payload), ...jsonHeaders(token) } as Options);
+  if (!response.ok) {
+    await logDataverseHttpError(context.channel, `PATCH ${entitySet}(${id})`, response);
+    return false;
+  }
+  return true;
+}
+
+async function deleteRecord(context: DataversePowerToolsContext, entitySet: string, id: string): Promise<boolean> {
+  const token = await context.dataverse.getAuthorizationToken();
+  const baseUrl = context.dataverse.organizationUrl;
+  if (!token || !baseUrl) {
+    return false;
+  }
+  const response = await fetch(dataverseApiUrl(baseUrl, `${entitySet}(${id})`), { method: "DELETE", ...jsonHeaders(token) } as Options);
+  if (!response.ok && response.status !== 404) {
+    await logDataverseHttpError(context.channel, `DELETE ${entitySet}(${id})`, response);
+    return false;
+  }
+  return true;
+}
+
+async function resolvePluginTypeId(context: DataversePowerToolsContext, typeName: string): Promise<string | undefined> {
+  const data = await getJson(context, `plugintypes?$select=plugintypeid,typename&$filter=typename eq '${escapeODataString(typeName)}'`);
+  return Array.isArray(data?.value) && data.value.length > 0 ? data.value[0].plugintypeid : undefined;
+}
+
+async function findCustomApiId(context: DataversePowerToolsContext, uniqueName: string): Promise<string | undefined> {
+  const data = await getJson(context, `customapis?$select=customapiid&$filter=uniquename eq '${escapeODataString(uniqueName)}'`);
+  return Array.isArray(data?.value) && data.value.length > 0 ? data.value[0].customapiid : undefined;
+}
+
+async function existingMembers(context: DataversePowerToolsContext, entitySet: string, idField: string, customApiId: string): Promise<ExistingNamedRecord[]> {
+  const data = await getJson(context, `${entitySet}?$select=${idField},uniquename&$filter=_customapiid_value eq ${customApiId}`);
+  const rows: any[] = Array.isArray(data?.value) ? data.value : [];
+  return rows.map((r) => ({ id: r[idField], uniquename: r.uniquename }));
+}
+
+/** Deploy one definition. Returns true on success. */
+async function deployOne(context: DataversePowerToolsContext, def: CustomApiDefinition, solutionUniqueName?: string): Promise<boolean> {
+  const pluginTypeId = await resolvePluginTypeId(context, def.pluginTypeName);
+  if (!pluginTypeId) {
+    context.channel.appendLine(`✗ ${def.uniqueName}: plugin type '${def.pluginTypeName}' not found in the environment — deploy & register the plugin first.`);
+    return false;
+  }
+
+  let customApiId = await findCustomApiId(context, def.uniqueName);
+  if (customApiId) {
+    if (!(await patchRecord(context, "customapis", customApiId, buildCustomApiUpdatePayload(def, pluginTypeId)))) {
+      return false;
+    }
+    context.channel.appendLine(`  Updated CustomAPI '${def.uniqueName}'.`);
+  } else {
+    customApiId = await createRecord(context, "customapis", buildCustomApiCreatePayload(def, pluginTypeId));
+    if (!customApiId) {
+      return false;
+    }
+    context.channel.appendLine(`  Created CustomAPI '${def.uniqueName}'.`);
+  }
+
+  // Reconcile request parameters.
+  const reqPlan = reconcileByUniqueName(def.requestParameters, await existingMembers(context, "customapirequestparameters", "customapirequestparameterid", customApiId));
+  for (const p of reqPlan.toCreate) {
+    await createRecord(context, "customapirequestparameters", buildRequestParameterCreatePayload(p, customApiId));
+  }
+  for (const u of reqPlan.toUpdate) {
+    await patchRecord(context, "customapirequestparameters", u.id, buildMemberUpdatePayload(u.desired));
+  }
+  for (const id of reqPlan.toDelete) {
+    await deleteRecord(context, "customapirequestparameters", id);
+  }
+
+  // Reconcile response properties.
+  const respPlan = reconcileByUniqueName(def.responseProperties, await existingMembers(context, "customapiresponseproperties", "customapiresponsepropertyid", customApiId));
+  for (const p of respPlan.toCreate) {
+    await createRecord(context, "customapiresponseproperties", buildResponsePropertyCreatePayload(p, customApiId));
+  }
+  for (const u of respPlan.toUpdate) {
+    await patchRecord(context, "customapiresponseproperties", u.id, buildMemberUpdatePayload(u.desired));
+  }
+  for (const id of respPlan.toDelete) {
+    await deleteRecord(context, "customapiresponseproperties", id);
+  }
+
+  context.channel.appendLine(
+    `  Parameters: +${reqPlan.toCreate.length} ~${reqPlan.toUpdate.length} -${reqPlan.toDelete.length}; ` +
+      `Response: +${respPlan.toCreate.length} ~${respPlan.toUpdate.length} -${respPlan.toDelete.length}.`,
+  );
+
+  if (solutionUniqueName) {
+    const added = await addDataverseSolutionComponentByObjectId(context, solutionUniqueName, customApiId);
+    context.channel.appendLine(added ? `  Added to solution '${solutionUniqueName}'.` : `  Could not add to solution '${solutionUniqueName}'.`);
+  }
+
+  return true;
+}
+
+/** Deploy every *.customapi.json in the active plugin component to Dataverse. */
+export async function deployCustomApis(context: DataversePowerToolsContext): Promise<void> {
+  const root = activeComponentRoot(context);
+  if (!root) {
+    vscode.window.showErrorMessage("Open or select a plugin component first.");
+    return;
+  }
+  if (!(await ensureContext(context))) {
+    vscode.window.showErrorMessage("Connect to a Dataverse environment first.");
+    return;
+  }
+
+  const files = findCustomApiDefinitionFiles(root);
+  if (files.length === 0) {
+    vscode.window.showInformationMessage('No .customapi.json definitions found. Run "New Custom API definition" first.');
+    return;
+  }
+
+  context.channel.show(true);
+  const solutionUniqueName = context.projectSettings?.solutionName as string | undefined;
+  let ok = 0;
+  let failed = 0;
+
+  await vscode.window.withProgress({ location: vscode.ProgressLocation.Notification, title: "Deploying Custom APIs…" }, async () => {
+    for (const file of files) {
+      const name = path.basename(file);
+      let def: CustomApiDefinition;
+      try {
+        def = JSON.parse(fs.readFileSync(file, "utf8")) as CustomApiDefinition;
+      } catch (error) {
+        context.channel.appendLine(`✗ ${name}: not valid JSON — ${(error as Error).message}`);
+        failed++;
+        continue;
+      }
+      const errors = validateCustomApiDefinition(def);
+      if (errors.length > 0) {
+        context.channel.appendLine(`✗ ${name}: ${errors.length} validation error(s) — fix before deploy.`);
+        errors.forEach((e) => context.channel.appendLine(`    - ${e}`));
+        failed++;
+        continue;
+      }
+      context.channel.appendLine(`Deploying ${name}…`);
+      if (await deployOne(context, def, solutionUniqueName)) {
+        ok++;
+      } else {
+        failed++;
+      }
+    }
+  });
+
+  if (failed > 0) {
+    vscode.window.showWarningMessage(`Custom API deploy: ${ok} succeeded, ${failed} failed. See the Dataverse PowerTools output.`);
+  } else {
+    vscode.window.showInformationMessage(`Custom API deploy: ${ok} deployed.`);
+  }
+}

--- a/src/customapi/deployPayloads.spec.ts
+++ b/src/customapi/deployPayloads.spec.ts
@@ -1,0 +1,117 @@
+import { describe, it, expect } from "vitest";
+import {
+  BINDING_TYPE,
+  PROCESSING_STEP_TYPE,
+  FIELD_TYPE,
+  buildCustomApiCreatePayload,
+  buildCustomApiUpdatePayload,
+  buildRequestParameterCreatePayload,
+  buildResponsePropertyCreatePayload,
+  buildMemberUpdatePayload,
+  reconcileByUniqueName,
+} from "./deployPayloads";
+import { newCustomApiDefinition, CustomApiDefinition } from "./definition";
+
+describe("option-set maps (per customapi-tables docs)", () => {
+  it("binding type", () => {
+    expect(BINDING_TYPE.Global).toBe(0);
+    expect(BINDING_TYPE.Entity).toBe(1);
+    expect(BINDING_TYPE.EntityCollection).toBe(2);
+  });
+  it("processing step type", () => {
+    expect(PROCESSING_STEP_TYPE.None).toBe(0);
+    expect(PROCESSING_STEP_TYPE.AsyncOnly).toBe(1);
+    expect(PROCESSING_STEP_TYPE.SyncAndAsync).toBe(2);
+  });
+  it("field type (customapifieldtype 0..12)", () => {
+    expect(FIELD_TYPE.Boolean).toBe(0);
+    expect(FIELD_TYPE.EntityReference).toBe(5);
+    expect(FIELD_TYPE.String).toBe(10);
+    expect(FIELD_TYPE.Guid).toBe(12);
+  });
+});
+
+describe("buildCustomApiCreatePayload", () => {
+  it("includes immutable columns + the plugin bind, with description falling back to displayName", () => {
+    const def = newCustomApiDefinition("sample_Do", "Sample.Plugins.Do");
+    const payload = buildCustomApiCreatePayload(def, "pt-1");
+    expect(payload).toMatchObject({
+      uniquename: "sample_Do",
+      bindingtype: 0,
+      isfunction: false,
+      isprivate: false,
+      allowedcustomprocessingsteptype: 0,
+      description: "sample_Do", // empty description → displayName
+    });
+    expect(payload["PluginTypeId@odata.bind"]).toBe("/plugintypes(pt-1)");
+    expect(payload).not.toHaveProperty("boundentitylogicalname"); // Global
+  });
+
+  it("adds boundentitylogicalname for a non-global binding", () => {
+    const def: CustomApiDefinition = { ...newCustomApiDefinition("x", "A.B"), binding: "Entity", boundEntityLogicalName: "account" };
+    expect(buildCustomApiCreatePayload(def, "pt").boundentitylogicalname).toBe("account");
+  });
+});
+
+describe("buildCustomApiUpdatePayload", () => {
+  it("omits immutable columns (bindingtype/isfunction/uniquename) and keeps mutable ones", () => {
+    const def = newCustomApiDefinition("sample_Do", "Sample.Plugins.Do");
+    const payload = buildCustomApiUpdatePayload(def, "pt-1");
+    expect(payload).toMatchObject({ name: "sample_Do", displayname: "sample_Do", isprivate: false });
+    expect(payload).not.toHaveProperty("bindingtype");
+    expect(payload).not.toHaveProperty("isfunction");
+    expect(payload).not.toHaveProperty("uniquename");
+    expect(payload["PluginTypeId@odata.bind"]).toBe("/plugintypes(pt-1)");
+  });
+});
+
+describe("member payloads", () => {
+  it("request parameter create carries type int, isoptional, and the CustomAPI bind", () => {
+    const payload = buildRequestParameterCreatePayload({ uniqueName: "AccountId", name: "x.AccountId", type: "EntityReference", isOptional: true }, "api-1");
+    expect(payload).toMatchObject({ uniquename: "AccountId", type: 5, isoptional: true });
+    expect(payload["CustomAPIId@odata.bind"]).toBe("/customapis(api-1)");
+  });
+
+  it("response property create has no isoptional", () => {
+    const payload = buildResponsePropertyCreatePayload({ uniqueName: "Out", name: "x.Out", type: "String" }, "api-1");
+    expect(payload).toMatchObject({ uniquename: "Out", type: 10 });
+    expect(payload).not.toHaveProperty("isoptional");
+  });
+
+  it("member update carries only mutable fields", () => {
+    expect(buildMemberUpdatePayload({ uniqueName: "AccountId", name: "x", type: "EntityReference", displayName: "Account" })).toEqual({
+      displayname: "Account",
+      description: "AccountId",
+    });
+  });
+});
+
+describe("reconcileByUniqueName", () => {
+  const desired = [
+    { uniqueName: "Keep", name: "x.Keep", type: "String" as const },
+    { uniqueName: "Add", name: "x.Add", type: "String" as const },
+  ];
+  const existing = [
+    { id: "id-keep", uniquename: "keep" }, // case-insensitive match
+    { id: "id-drop", uniquename: "Drop" },
+  ];
+
+  it("splits desired vs existing into create / update / delete", () => {
+    const plan = reconcileByUniqueName(desired, existing);
+    expect(plan.toCreate.map((c) => c.uniqueName)).toEqual(["Add"]);
+    expect(plan.toUpdate.map((u) => ({ name: u.desired.uniqueName, id: u.id }))).toEqual([{ name: "Keep", id: "id-keep" }]);
+    expect(plan.toDelete).toEqual(["id-drop"]);
+  });
+
+  it("all-new when nothing exists", () => {
+    const plan = reconcileByUniqueName(desired, []);
+    expect(plan.toCreate).toHaveLength(2);
+    expect(plan.toUpdate).toHaveLength(0);
+    expect(plan.toDelete).toHaveLength(0);
+  });
+
+  it("deletes everything when the definition has no members", () => {
+    const plan = reconcileByUniqueName([], existing);
+    expect(plan.toDelete).toEqual(["id-keep", "id-drop"]);
+  });
+});

--- a/src/customapi/deployPayloads.ts
+++ b/src/customapi/deployPayloads.ts
@@ -1,0 +1,160 @@
+// Pure builders for the Custom API metadata deploy (#142, issue #3). No `vscode`
+// / no network — the Web API payloads and the create/update/delete reconcile are
+// unit-tested here; deployCustomApi.ts does the actual HTTP. Option-set integer
+// values and the immutable-after-save column list are per the official docs:
+//   https://learn.microsoft.com/power-apps/developer/data-platform/custom-api-tables
+//   https://learn.microsoft.com/power-apps/developer/data-platform/create-custom-api-solution
+
+import { CustomApiDefinition, CustomApiBinding, AllowedCustomProcessingStepType, CustomApiParameterType, CustomApiRequestParameter, CustomApiResponseProperty } from "./definition";
+
+// Keys below are the platform's PascalCase option-set labels, not identifiers.
+/* eslint-disable @typescript-eslint/naming-convention */
+/** CustomAPI.bindingtype option-set values. */
+export const BINDING_TYPE: Record<CustomApiBinding, number> = { Global: 0, Entity: 1, EntityCollection: 2 };
+/** CustomAPI.allowedcustomprocessingsteptype option-set values. */
+export const PROCESSING_STEP_TYPE: Record<AllowedCustomProcessingStepType, number> = { None: 0, AsyncOnly: 1, SyncAndAsync: 2 };
+/** customapifieldtype option-set values (request-parameter / response-property `type`). */
+export const FIELD_TYPE: Record<CustomApiParameterType, number> = {
+  Boolean: 0,
+  DateTime: 1,
+  Decimal: 2,
+  Entity: 3,
+  EntityCollection: 4,
+  EntityReference: 5,
+  Float: 6,
+  Integer: 7,
+  Money: 8,
+  Picklist: 9,
+  String: 10,
+  StringArray: 11,
+  Guid: 12,
+};
+/* eslint-enable @typescript-eslint/naming-convention */
+
+/**
+ * Body to CREATE the CustomAPI record. Includes the immutable-after-save columns
+ * (bindingtype, isfunction, uniquename, …) which are only valid on create.
+ * `description` is SystemRequired, so it falls back to the display name.
+ */
+export function buildCustomApiCreatePayload(def: CustomApiDefinition, pluginTypeId: string): Record<string, unknown> {
+  const payload: Record<string, unknown> = {
+    uniquename: def.uniqueName,
+    name: def.name,
+    displayname: def.displayName,
+    description: def.description || def.displayName,
+    bindingtype: BINDING_TYPE[def.binding],
+    isfunction: !!def.isFunction,
+    isprivate: !!def.isPrivate,
+    workflowsdkstepenabled: !!def.enabledForWorkflow,
+    allowedcustomprocessingsteptype: PROCESSING_STEP_TYPE[def.allowedCustomProcessingStepType ?? "None"],
+  };
+  payload["PluginTypeId@odata.bind"] = `/plugintypes(${pluginTypeId})`;
+  if (def.binding !== "Global" && def.boundEntityLogicalName) {
+    payload.boundentitylogicalname = def.boundEntityLogicalName;
+  }
+  if (def.executePrivilegeName) {
+    payload.executeprivilegename = def.executePrivilegeName;
+  }
+  return payload;
+}
+
+/**
+ * Body to UPDATE (PATCH) an existing CustomAPI — MUTABLE columns only. The
+ * immutable columns (bindingtype, isfunction, uniquename, boundentitylogicalname,
+ * allowedcustomprocessingsteptype, workflowsdkstepenabled) are omitted so the
+ * platform doesn't reject the update.
+ */
+export function buildCustomApiUpdatePayload(def: CustomApiDefinition, pluginTypeId: string): Record<string, unknown> {
+  const payload: Record<string, unknown> = {
+    name: def.name,
+    displayname: def.displayName,
+    description: def.description || def.displayName,
+    isprivate: !!def.isPrivate,
+  };
+  payload["PluginTypeId@odata.bind"] = `/plugintypes(${pluginTypeId})`;
+  if (def.executePrivilegeName) {
+    payload.executeprivilegename = def.executePrivilegeName;
+  }
+  return payload;
+}
+
+/** Body to CREATE a request parameter (bound to its CustomAPI). */
+export function buildRequestParameterCreatePayload(param: CustomApiRequestParameter, customApiId: string): Record<string, unknown> {
+  const payload: Record<string, unknown> = {
+    uniquename: param.uniqueName,
+    name: param.name,
+    displayname: param.displayName || param.uniqueName,
+    description: param.description || param.displayName || param.uniqueName,
+    type: FIELD_TYPE[param.type],
+    isoptional: !!param.isOptional,
+  };
+  payload["CustomAPIId@odata.bind"] = `/customapis(${customApiId})`;
+  return payload;
+}
+
+/** Body to CREATE a response property (bound to its CustomAPI). */
+export function buildResponsePropertyCreatePayload(prop: CustomApiResponseProperty, customApiId: string): Record<string, unknown> {
+  const payload: Record<string, unknown> = {
+    uniquename: prop.uniqueName,
+    name: prop.name,
+    displayname: prop.displayName || prop.uniqueName,
+    description: prop.description || prop.displayName || prop.uniqueName,
+    type: FIELD_TYPE[prop.type],
+  };
+  payload["CustomAPIId@odata.bind"] = `/customapis(${customApiId})`;
+  return payload;
+}
+
+/** Body to UPDATE a request parameter or response property — mutable columns only
+ * (type / uniquename / isoptional are immutable). */
+export function buildMemberUpdatePayload(member: CustomApiRequestParameter | CustomApiResponseProperty): Record<string, unknown> {
+  return {
+    displayname: member.displayName || member.uniqueName,
+    description: member.description || member.uniqueName,
+  };
+}
+
+/** An existing child record as read back from Dataverse. */
+export interface ExistingNamedRecord {
+  id: string;
+  uniquename: string;
+}
+
+/** The result of diffing desired members against what's live. */
+export interface ReconcilePlan<T> {
+  toCreate: T[];
+  toUpdate: { desired: T; id: string }[];
+  /** ids of records present in the env but absent from the definition — to delete. */
+  toDelete: string[];
+}
+
+/**
+ * Diff desired members (request params / response props) against the live records
+ * by uniqueName (case-insensitive): new → create, matched → update, orphaned → delete.
+ * This is the "reconcile deletes" behaviour — a param removed from the file is
+ * removed in the environment.
+ */
+export function reconcileByUniqueName<T extends { uniqueName: string }>(desired: T[], existing: ExistingNamedRecord[]): ReconcilePlan<T> {
+  const existingByName = new Map(existing.map((e) => [e.uniquename.toLowerCase(), e]));
+  const desiredNames = new Set(desired.map((d) => d.uniqueName.toLowerCase()));
+
+  const toCreate: T[] = [];
+  const toUpdate: { desired: T; id: string }[] = [];
+  const toDelete: string[] = [];
+
+  for (const d of desired) {
+    const match = existingByName.get(d.uniqueName.toLowerCase());
+    if (match) {
+      toUpdate.push({ desired: d, id: match.id });
+    } else {
+      toCreate.push(d);
+    }
+  }
+  for (const e of existing) {
+    if (!desiredNames.has(e.uniquename.toLowerCase())) {
+      toDelete.push(e.id);
+    }
+  }
+
+  return { toCreate, toUpdate, toDelete };
+}

--- a/src/projectTypes/activation.ts
+++ b/src/projectTypes/activation.ts
@@ -16,6 +16,7 @@ import { buildAndDeploy } from "../plugins/buildAndDeploy";
 import { addClassDecoration, updateFilteringAttributes } from "../plugins/decorations";
 import { viewPluginTraceLogs } from "../plugins/traceLogs";
 import { newCustomApi, generateCustomApiHandlers } from "../customapi/customApiCommands";
+import { deployCustomApis } from "../customapi/deployCustomApi";
 import { downloadPluginProfiles } from "../plugins/downloadProfiles";
 import { capturePluginRun } from "../plugins/profilerCapture";
 import { generatePluginReplayTest } from "../plugins/replayTest";
@@ -187,6 +188,7 @@ export const projectTypeActivations: Record<ProjectTypes, ProjectTypeActivation>
       // Custom API definition-as-code (#142) — plugin-scoped.
       "dataverse-powertools.newCustomApi": (context) => newCustomApi(context),
       "dataverse-powertools.generateCustomApiHandlers": (context) => generateCustomApiHandlers(context),
+      "dataverse-powertools.deployCustomApis": (context) => deployCustomApis(context),
     },
     async onProjectScaffolded(context) {
       if (isPluginV3(context)) {

--- a/src/projectTypes/registry.ts
+++ b/src/projectTypes/registry.ts
@@ -107,6 +107,7 @@ export const projectTypeRegistry: readonly ProjectTypeDescriptor[] = [
       `${prefix}guidePluginProfiling`,
       `${prefix}newCustomApi`,
       `${prefix}generateCustomApiHandlers`,
+      `${prefix}deployCustomApis`,
     ],
     menu(state) {
       const legacy = (state.templateVersion ?? 0) < 3;
@@ -139,6 +140,7 @@ export const projectTypeRegistry: readonly ProjectTypeDescriptor[] = [
                 { command: `${prefix}addClassDecoration`, label: "Add class decoration" },
                 { command: `${prefix}newCustomApi`, label: "New Custom API definition" },
                 { command: `${prefix}generateCustomApiHandlers`, label: "Generate Custom API handlers" },
+                { command: `${prefix}deployCustomApis`, label: "Deploy Custom APIs" },
               ]),
           { command: `${prefix}buildDeployWorkflow`, label: "Build & deploy workflow" },
           // The profiling how-to lives here now (#139) — per-step Profile toggles + the card's


### PR DESCRIPTION
## What & why

Second half of the Custom API v1 core (#142, issue #3): **deploy the definition to Dataverse**. Now a `*.customapi.json` round-trips — edit → generate typed handler (0.14.6) → **deploy the message metadata**.

## Changes
- `src/customapi/deployPayloads.ts` (12 tests) — **pure** Web API payload builders + reconcile: `buildCustomApiCreate/UpdatePayload` (create includes immutable columns; update omits them), request/response create payloads, `buildMemberUpdatePayload`, and `reconcileByUniqueName` (create / update / **delete-removed**). Option-set values (binding 0–2, processing 0–2, `customapifieldtype` 0–12) and the immutable-column list are docs-verified.
- `src/customapi/deployCustomApi.ts` — the HTTP orchestration: resolve plugin type → create/update `CustomAPI` → reconcile request params + response props → add to the project solution. Gates on the live connection (both auth types). Mirrors `registerPluginSteps.ts`.
- `registry.ts` / `activation.ts` / `package.json` — **Deploy Custom APIs** command (plugin-scoped, parity green).

## ⚠️ Pre-release — not yet live-verified
The payloads, option-sets and reconcile are docs-verified + unit-tested, but the create/update/**delete** calls haven't run against a live org (no headless Web API harness). The first real deploy — especially the parameter delete-reconcile — should be a **supervised check**.

## Verification
`lint` clean · `compile` clean · `test:coverage` **583/583** (+12). Command registration covered by the existing plugin-component integration test.

## #142 status
Core done: definition (#1) + validation (#6) + typed handler (#2) + deploy (#3). Fast-follows remaining: invoke-from-editor (#4), reverse-engineer + typed caller (#5).

🤖 Generated with [Claude Code](https://claude.com/claude-code)