### PR TITLE
0.14.8 (pre-release) — Language Model Tools for Copilot agent mode (#140)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 All notable changes to the "dataverse-powertools" extension will be documented in this file.
 
+## 0.14.8 (pre-release)
+
+New: **Language Model Tools** — drive the extension from Copilot agent mode (#140). In-editor only; no MCP server, no port, no token, no files written.
+
+- **Five `#`-referenceable tools** appear in Copilot's tool picker the moment the extension activates:
+  - **Read (always on):** `dvpt_connectionStatus` (org + auth type + connected — never secrets), `dvpt_listComponents` (discovered plugins / web resources / PCF / functions), `dvpt_systemRequirements` (dotnet / node / pac).
+  - **Mutating (gated + confirmed):** `dvpt_deploy` (build & deploy) and `dvpt_generateEarlybound`. These are **off by default** — set `dataverse-powertools.copilot.accessMode` to `readwrite` to enable them — and each shows a native "run against `<org>`?" confirmation before it executes.
+- Tools are thin wrappers over the same command paths the UI uses (so a future MCP surface can reuse the handler logic), registered once globally (never per-component), and every mutating tool gates on the live connection under both auth types.
+
+> **Requires VS Code 1.95+** (the Language Model Tools API) — the extension's minimum engine moves from 1.93 to 1.95. Pure logic (tool list, access-mode gate, secret-free formatters) is unit-tested; registration is covered by an integration test.
+
 ## 0.14.7 (pre-release)
 
 Custom API (#142) — **metadata deploy** (issue #3), the second half of the v1 core. A definition now round-trips: edit → generate handler → **deploy the message to Dataverse**.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "dataverse-powertools",
-  "version": "0.14.2",
+  "version": "0.14.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "dataverse-powertools",
-      "version": "0.14.2",
+      "version": "0.14.7",
       "hasInstallScript": true,
       "dependencies": {
         "@azure/msal-node": "^5.4.0",
@@ -23,7 +23,7 @@
         "@types/jest": "^30.0.0",
         "@types/mocha": "^10.0.10",
         "@types/node": "^20.17.0",
-        "@types/vscode": "^1.93.0",
+        "@types/vscode": "^1.125.0",
         "@typescript-eslint/eslint-plugin": "^8.63.0",
         "@typescript-eslint/parser": "^8.63.0",
         "@vitest/coverage-v8": "^4.1.10",
@@ -2772,10 +2772,11 @@
       "license": "MIT"
     },
     "node_modules/@types/vscode": {
-      "version": "1.93.0",
-      "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.93.0.tgz",
-      "integrity": "sha512-kUK6jAHSR5zY8ps42xuW89NLcBpw1kOabah7yv38J8MyiYuOHxLQBi0e7zeXbQgVefDy/mZZetqEFC+Fl5eIEQ==",
-      "dev": true
+      "version": "1.125.0",
+      "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.125.0.tgz",
+      "integrity": "sha512-0icm/ZQAaism87P0ekHqi4/Ju9du+Tm0RUW+y7vqRsxY2cY0FNRX1nAnaW7nT6npPt2tfHiheZ55Zm9UhqonFA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/ws": {
       "version": "8.18.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "dataverse-powertools",
-  "version": "0.14.7",
+  "version": "0.14.8",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "dataverse-powertools",
-      "version": "0.14.7",
+      "version": "0.14.8",
       "hasInstallScript": true,
       "dependencies": {
         "@azure/msal-node": "^5.4.0",
@@ -23,7 +23,7 @@
         "@types/jest": "^30.0.0",
         "@types/mocha": "^10.0.10",
         "@types/node": "^20.17.0",
-        "@types/vscode": "^1.125.0",
+        "@types/vscode": "^1.95.0",
         "@typescript-eslint/eslint-plugin": "^8.63.0",
         "@typescript-eslint/parser": "^8.63.0",
         "@vitest/coverage-v8": "^4.1.10",
@@ -52,7 +52,7 @@
         "xrm-mock": "^3.6.2"
       },
       "engines": {
-        "vscode": "^1.93.0"
+        "vscode": "^1.95.0"
       }
     },
     "node_modules/@azu/format-text": {
@@ -2772,9 +2772,9 @@
       "license": "MIT"
     },
     "node_modules/@types/vscode": {
-      "version": "1.125.0",
-      "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.125.0.tgz",
-      "integrity": "sha512-0icm/ZQAaism87P0ekHqi4/Ju9du+Tm0RUW+y7vqRsxY2cY0FNRX1nAnaW7nT6npPt2tfHiheZ55Zm9UhqonFA==",
+      "version": "1.95.0",
+      "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.95.0.tgz",
+      "integrity": "sha512-0LBD8TEiNbet3NvWsmn59zLzOFu/txSlGxnv5yAFHCrhG9WvAnR3IvfHzMOs2aeWqgvNjq9pO99IUw8d3n+unw==",
       "dev": true,
       "license": "MIT"
     },

--- a/package.json
+++ b/package.json
@@ -9,9 +9,9 @@
     "type": "git",
     "url": "https://github.com/pete-mc/dataverse-powertools"
   },
-  "version": "0.14.7",
+  "version": "0.14.8",
   "engines": {
-    "vscode": "^1.93.0"
+    "vscode": "^1.95.0"
   },
   "categories": [
     "Other"
@@ -31,6 +31,89 @@
       {
         "language": "typescriptreact",
         "path": "./snippets/dvpt-pcf.code-snippets"
+      }
+    ],
+    "languageModelTools": [
+      {
+        "name": "dvpt_connectionStatus",
+        "displayName": "Dataverse connection status",
+        "modelDescription": "Get the current Dataverse PowerTools connection for this workspace: organization URL, auth type (service principal or interactive/OAuth), and whether a token has been acquired. Never returns secrets. Call this before other Dataverse tools to check readiness.",
+        "toolReferenceName": "dvptConnectionStatus",
+        "canBeReferencedInPrompt": true,
+        "icon": "$(plug)",
+        "tags": [
+          "dataverse",
+          "powertools"
+        ],
+        "inputSchema": {
+          "type": "object",
+          "properties": {}
+        }
+      },
+      {
+        "name": "dvpt_listComponents",
+        "displayName": "List Dataverse components",
+        "modelDescription": "List the Dataverse PowerTools components discovered in this workspace (plugins, web resources, PCF controls, Azure Functions, solutions), with their type, name, and folder.",
+        "toolReferenceName": "dvptListComponents",
+        "canBeReferencedInPrompt": true,
+        "icon": "$(list-tree)",
+        "tags": [
+          "dataverse",
+          "powertools"
+        ],
+        "inputSchema": {
+          "type": "object",
+          "properties": {}
+        }
+      },
+      {
+        "name": "dvpt_systemRequirements",
+        "displayName": "Dataverse PowerTools requirements",
+        "modelDescription": "Report whether the Dataverse PowerTools system requirements (dotnet, node, pac) are installed on this machine.",
+        "toolReferenceName": "dvptSystemRequirements",
+        "canBeReferencedInPrompt": true,
+        "icon": "$(checklist)",
+        "tags": [
+          "dataverse",
+          "powertools"
+        ],
+        "inputSchema": {
+          "type": "object",
+          "properties": {}
+        }
+      },
+      {
+        "name": "dvpt_deploy",
+        "displayName": "Build & deploy to Dataverse",
+        "modelDescription": "Build and deploy the active Dataverse PowerTools component (plugin package / web resources) to the connected environment. Mutating: requires the 'readwrite' Copilot access mode and asks for confirmation before running.",
+        "toolReferenceName": "dvptDeploy",
+        "canBeReferencedInPrompt": true,
+        "icon": "$(cloud-upload)",
+        "tags": [
+          "dataverse",
+          "powertools",
+          "deploy"
+        ],
+        "inputSchema": {
+          "type": "object",
+          "properties": {}
+        }
+      },
+      {
+        "name": "dvpt_generateEarlybound",
+        "displayName": "Generate early-bound classes",
+        "modelDescription": "Generate early-bound C# entity classes for the active plugin component from the connected Dataverse environment. Mutating (writes files): requires the 'readwrite' Copilot access mode and asks for confirmation before running.",
+        "toolReferenceName": "dvptGenerateEarlybound",
+        "canBeReferencedInPrompt": true,
+        "icon": "$(symbol-class)",
+        "tags": [
+          "dataverse",
+          "powertools"
+        ],
+        "inputSchema": {
+          "type": "object",
+          "properties": {}
+        }
       }
     ],
     "menus": {
@@ -672,6 +755,19 @@
     "configuration": {
       "title": "Dataverse PowerTools",
       "properties": {
+        "dataverse-powertools.copilot.accessMode": {
+          "type": "string",
+          "enum": [
+            "readonly",
+            "readwrite"
+          ],
+          "enumDescriptions": [
+            "Copilot may use read/inspect tools only (connection status, components, requirements).",
+            "Copilot may also use mutating tools (deploy, generate early-bound) — each with a per-call confirmation."
+          ],
+          "default": "readonly",
+          "markdownDescription": "Controls which Dataverse PowerTools [Language Model Tools](https://code.visualstudio.com/api/extension-guides/tools) Copilot agent mode may use. `readonly` (default) exposes only safe read tools; `readwrite` also enables mutating tools, each of which still asks for confirmation before running."
+        },
         "dataverse-powertools.debugBrowser": {
           "type": "string",
           "enum": [
@@ -730,7 +826,7 @@
     "@types/jest": "^30.0.0",
     "@types/mocha": "^10.0.10",
     "@types/node": "^20.17.0",
-    "@types/vscode": "^1.93.0",
+    "@types/vscode": "^1.125.0",
     "@typescript-eslint/eslint-plugin": "^8.63.0",
     "@typescript-eslint/parser": "^8.63.0",
     "@vitest/coverage-v8": "^4.1.10",

--- a/package.json
+++ b/package.json
@@ -826,7 +826,7 @@
     "@types/jest": "^30.0.0",
     "@types/mocha": "^10.0.10",
     "@types/node": "^20.17.0",
-    "@types/vscode": "^1.125.0",
+    "@types/vscode": "~1.95.0",
     "@typescript-eslint/eslint-plugin": "^8.63.0",
     "@typescript-eslint/parser": "^8.63.0",
     "@vitest/coverage-v8": "^4.1.10",

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -9,6 +9,7 @@ import { componentsToInitialise } from "./components/discovery";
 import { clearStoredCredentials } from "./general/connectionStringManager";
 import { checkConfigRevision } from "./general/configRefresh";
 import { registerDecorationCodeLens } from "./plugins/decorationsCodeLens";
+import { registerLmTools } from "./lmtools/registerLmTools";
 import { registerMenuPanel } from "./panel/menuPanel";
 import { refreshPanelData } from "./panel/panelDataCache";
 import { registerSystemRequirementCommands } from "./general/systemRequirements";
@@ -28,6 +29,8 @@ export async function activate(vscodeContext: vscode.ExtensionContext) {
   // Every project type's commands register ONCE here; handlers resolve which
   // component an invocation targets (#47) — no per-type registration anymore.
   registerAllComponentCommands(context);
+  // Language Model Tools for Copilot agent mode (#140) — registered ONCE, globally.
+  registerLmTools(context);
   // Class-decoration / filtering-attribute / per-step-profiling CodeLens on plugin .cs files. Registered
   // ONCE here (its commands + provider are global) — never per plugin component, or a
   // second plugin component's initialise throws "command … already exists" (#47).

--- a/src/lmtools/lmTools.spec.ts
+++ b/src/lmtools/lmTools.spec.ts
@@ -1,0 +1,102 @@
+import { describe, it, expect } from "vitest";
+import * as fs from "fs";
+import * as path from "path";
+import { LM_TOOLS, isToolAllowed, readOnlyRefusal, formatConnectionSummary, formatComponentList, formatRequirements } from "./lmTools";
+
+describe("LM_TOOLS ↔ package.json parity (#140)", () => {
+  const pkg = JSON.parse(fs.readFileSync(path.resolve(__dirname, "..", "..", "package.json"), "utf8"));
+  const contributed: { name: string }[] = pkg.contributes.languageModelTools ?? [];
+
+  it("registers exactly the contributed tools (names match both ways)", () => {
+    const specNames = LM_TOOLS.map((t) => t.name).sort();
+    const contributedNames = contributed.map((t) => t.name).sort();
+    expect(specNames).toEqual(contributedNames);
+  });
+
+  it("uses the readwrite access-mode setting declared in package.json", () => {
+    expect(pkg.contributes.configuration.properties["dataverse-powertools.copilot.accessMode"]).toBeTruthy();
+  });
+});
+
+describe("LM_TOOLS", () => {
+  it("has unique tool names", () => {
+    const names = LM_TOOLS.map((t) => t.name);
+    expect(new Set(names).size).toBe(names.length);
+  });
+
+  it("gives every mutating tool a command + confirm title", () => {
+    for (const t of LM_TOOLS.filter((x) => x.mutating)) {
+      expect(t.command, `${t.name} needs a command`).toBeTruthy();
+      expect(t.confirmTitle, `${t.name} needs a confirm title`).toBeTruthy();
+    }
+  });
+});
+
+describe("isToolAllowed", () => {
+  const read = { name: "r", mutating: false };
+  const write = { name: "w", mutating: true, command: "c", confirmTitle: "t" };
+
+  it("always allows read tools", () => {
+    expect(isToolAllowed(read, "readonly")).toBe(true);
+    expect(isToolAllowed(read, "readwrite")).toBe(true);
+  });
+
+  it("only allows mutating tools in readwrite mode", () => {
+    expect(isToolAllowed(write, "readonly")).toBe(false);
+    expect(isToolAllowed(write, "readwrite")).toBe(true);
+  });
+});
+
+describe("readOnlyRefusal", () => {
+  it("names the tool and the setting to change", () => {
+    const msg = readOnlyRefusal("dvpt_deploy");
+    expect(msg).toContain("dvpt_deploy");
+    expect(msg).toContain("dataverse-powertools.copilot.accessMode");
+    expect(msg).toContain("readwrite");
+  });
+});
+
+describe("formatConnectionSummary", () => {
+  it("reports no project when nothing is loaded", () => {
+    expect(formatConnectionSummary({ loaded: false, connected: false })).toContain("No Dataverse PowerTools project");
+  });
+
+  it("summarizes org, auth type and status without secrets", () => {
+    const out = formatConnectionSummary({ loaded: true, organizationUrl: "https://org.crm.dynamics.com", authType: "oauth", connected: true });
+    expect(out).toContain("https://org.crm.dynamics.com");
+    expect(out).toContain("interactive (OAuth)");
+    expect(out).toContain("connected");
+    expect(out.toLowerCase()).not.toContain("secret");
+    expect(out.toLowerCase()).not.toContain("token");
+  });
+
+  it("labels service-principal auth", () => {
+    expect(formatConnectionSummary({ loaded: true, authType: "clientsecret", connected: false })).toContain("service principal");
+  });
+});
+
+describe("formatComponentList", () => {
+  it("handles an empty workspace", () => {
+    expect(formatComponentList([])).toContain("No components");
+  });
+
+  it("marks the root and lists subfolders", () => {
+    const out = formatComponentList([
+      { type: "plugin", name: "MyPlugin", relativeRoot: "", isRoot: true },
+      { type: "webresource", name: "Web", relativeRoot: "web", isRoot: false },
+    ]);
+    expect(out).toContain("plugin: MyPlugin (root)");
+    expect(out).toContain("webresource: Web (web)");
+  });
+});
+
+describe("formatRequirements", () => {
+  it("flags missing requirements", () => {
+    const out = formatRequirements([
+      { name: "dotnet", installed: true },
+      { name: "pac", installed: false },
+    ]);
+    expect(out).toContain("dotnet: installed");
+    expect(out).toContain("pac: MISSING");
+  });
+});

--- a/src/lmtools/lmTools.ts
+++ b/src/lmtools/lmTools.ts
@@ -1,0 +1,84 @@
+// Pure core for the Language Model Tools surface (#140) — no `vscode` import, so
+// the tool list, the read/mutate access-mode gate, and the (secret-free) output
+// formatters are unit-tested here. registerLmTools.ts is the thin vscode binding
+// that reads context + calls executeCommand. Handlers are kept as thin wrappers
+// over the same command paths the UI uses, so a future MCP surface can reuse them.
+
+/** Read-only (default) vs read-write. Mutating tools require read-write. */
+export type AccessMode = "readonly" | "readwrite";
+
+export interface LmToolSpec {
+  /** Tool name, matching the package.json languageModelTools contribution. */
+  name: string;
+  /** Command executed by a mutating tool (via runForComponent's normal targeting). */
+  command?: string;
+  /** True for tools that change Dataverse / the workspace — gated + confirmed. */
+  mutating: boolean;
+  /** Title shown in the prepareInvocation confirmation for mutating tools. */
+  confirmTitle?: string;
+}
+
+/** The curated v1 tool list. Read tools are always available; mutating tools are
+ * gated on read-write access mode and confirmed per call. */
+export const LM_TOOLS: readonly LmToolSpec[] = [
+  { name: "dvpt_connectionStatus", mutating: false },
+  { name: "dvpt_listComponents", mutating: false },
+  { name: "dvpt_systemRequirements", mutating: false },
+  { name: "dvpt_deploy", command: "dataverse-powertools.buildAndDeploy", mutating: true, confirmTitle: "Build & deploy to Dataverse" },
+  { name: "dvpt_generateEarlybound", command: "dataverse-powertools.generateEarlyBound", mutating: true, confirmTitle: "Generate early-bound classes" },
+];
+
+/** Whether a tool may run under the given access mode. */
+export function isToolAllowed(spec: LmToolSpec, accessMode: AccessMode): boolean {
+  return spec.mutating ? accessMode === "readwrite" : true;
+}
+
+/** Message returned when a mutating tool is invoked in read-only mode. */
+export function readOnlyRefusal(toolName: string): string {
+  return (
+    `The "${toolName}" tool changes your Dataverse environment and is disabled in read-only mode. ` + `Set "dataverse-powertools.copilot.accessMode" to "readwrite" to allow it.`
+  );
+}
+
+export interface ConnectionSummaryInput {
+  loaded: boolean;
+  organizationUrl?: string;
+  authType?: "oauth" | "clientsecret";
+  connected: boolean;
+}
+
+/** Human-readable connection summary — never includes secrets or tokens. */
+export function formatConnectionSummary(input: ConnectionSummaryInput): string {
+  if (!input.loaded) {
+    return "No Dataverse PowerTools project is loaded in this workspace.";
+  }
+  const auth = input.authType === "oauth" ? "interactive (OAuth)" : "service principal";
+  const status = input.connected ? "connected" : "not connected yet (no token acquired)";
+  return [`Organization: ${input.organizationUrl ?? "(unknown)"}`, `Auth type: ${auth}`, `Status: ${status}`].join("\n");
+}
+
+export interface ComponentSummaryInput {
+  type: string;
+  name: string;
+  relativeRoot: string;
+  isRoot: boolean;
+}
+
+export function formatComponentList(components: ComponentSummaryInput[]): string {
+  if (components.length === 0) {
+    return "No components have been discovered in this workspace.";
+  }
+  return components.map((c) => `- ${c.type}: ${c.name}${c.isRoot ? " (root)" : c.relativeRoot ? ` (${c.relativeRoot})` : ""}`).join("\n");
+}
+
+export interface RequirementSummaryInput {
+  name: string;
+  installed: boolean;
+}
+
+export function formatRequirements(requirements: RequirementSummaryInput[]): string {
+  if (requirements.length === 0) {
+    return "No system requirements are being tracked.";
+  }
+  return requirements.map((r) => `- ${r.name}: ${r.installed ? "installed" : "MISSING"}`).join("\n");
+}

--- a/src/lmtools/registerLmTools.ts
+++ b/src/lmtools/registerLmTools.ts
@@ -1,0 +1,111 @@
+// vscode binding for the Language Model Tools surface (#140). Registers each tool
+// ONCE, globally (not in any per-component initialise* — the multi-component
+// registration trap). Read tools return secret-free summaries; mutating tools are
+// gated on the read-write access mode and show a native per-call confirmation via
+// prepareInvocation. Handlers are thin wrappers over the same command paths the UI
+// uses (executeCommand), so a future MCP surface can reuse the pure logic in
+// lmTools.ts.
+
+import * as vscode from "vscode";
+import DataversePowerToolsContext from "../context";
+import { getOrganizationUrl, parseConnectionString } from "../general/connectionString";
+import { parseAuthType, DataverseAuthType } from "../general/dataverse/authTypes";
+import { getSystemRequirementsStatus } from "../general/systemRequirements";
+import { ComponentSettings } from "../components/discovery";
+import { LM_TOOLS, LmToolSpec, AccessMode, isToolAllowed, readOnlyRefusal, formatConnectionSummary, formatComponentList, formatRequirements } from "./lmTools";
+
+function currentAccessMode(): AccessMode {
+  return vscode.workspace.getConfiguration("dataverse-powertools").get<string>("copilot.accessMode") === "readwrite" ? "readwrite" : "readonly";
+}
+
+function textResult(text: string): vscode.LanguageModelToolResult {
+  return new vscode.LanguageModelToolResult([new vscode.LanguageModelTextPart(text)]);
+}
+
+function connectionResult(context: DataversePowerToolsContext): vscode.LanguageModelToolResult {
+  const loaded = !!context.projectSettings?.connectionString;
+  const parts = parseConnectionString(context.connectionString);
+  return textResult(
+    formatConnectionSummary({
+      loaded,
+      organizationUrl: loaded ? getOrganizationUrl(context.connectionString) : undefined,
+      authType: loaded && parseAuthType(parts.authType) === DataverseAuthType.oauth ? "oauth" : "clientsecret",
+      connected: !!context.dataverse?.isValid,
+    }),
+  );
+}
+
+function componentsResult(context: DataversePowerToolsContext): vscode.LanguageModelToolResult {
+  const components = (context.components ?? [])
+    .filter((c) => c.settings?.type)
+    .map((c) => {
+      const settings = c.settings as ComponentSettings;
+      return {
+        type: settings.type ?? "",
+        name: (settings.solutionName as string) || (settings.pluginProjectName as string) || c.relativeRoot || "",
+        relativeRoot: c.relativeRoot,
+        isRoot: c.isRoot,
+      };
+    });
+  return textResult(formatComponentList(components));
+}
+
+function requirementsResult(): vscode.LanguageModelToolResult {
+  const snapshot = getSystemRequirementsStatus();
+  return textResult(
+    formatRequirements([
+      { name: "dotnet", installed: snapshot.dotnet },
+      { name: "node", installed: snapshot.node },
+      { name: "pac", installed: snapshot.pac },
+    ]),
+  );
+}
+
+function makeTool(context: DataversePowerToolsContext, spec: LmToolSpec): vscode.LanguageModelTool<unknown> {
+  return {
+    async invoke(): Promise<vscode.LanguageModelToolResult> {
+      if (spec.mutating && !isToolAllowed(spec, currentAccessMode())) {
+        return textResult(readOnlyRefusal(spec.name));
+      }
+      switch (spec.name) {
+        case "dvpt_connectionStatus":
+          return connectionResult(context);
+        case "dvpt_listComponents":
+          return componentsResult(context);
+        case "dvpt_systemRequirements":
+          return requirementsResult();
+        default:
+          if (spec.command) {
+            await vscode.commands.executeCommand(spec.command);
+            return textResult(`Ran "${spec.confirmTitle ?? spec.name}". See the Dataverse PowerTools output channel for details.`);
+          }
+          return textResult(`Unknown tool: ${spec.name}.`);
+      }
+    },
+    prepareInvocation: spec.mutating
+      ? async (): Promise<vscode.PreparedToolInvocation | undefined> => {
+          if (!isToolAllowed(spec, currentAccessMode())) {
+            // No confirmation dialog; invoke() returns the read-only guidance instead.
+            return undefined;
+          }
+          const org = getOrganizationUrl(context.connectionString) || "the connected environment";
+          return {
+            confirmationMessages: {
+              title: spec.confirmTitle ?? "Run Dataverse PowerTools tool",
+              message: new vscode.MarkdownString(`This will run **${spec.confirmTitle ?? spec.name}** against \`${org}\`.`),
+            },
+          };
+        }
+      : undefined,
+  };
+}
+
+/** Register every LM tool once. No-op on hosts without the API (extension still activates). */
+export function registerLmTools(context: DataversePowerToolsContext): void {
+  if (!vscode.lm || typeof vscode.lm.registerTool !== "function") {
+    return;
+  }
+  for (const spec of LM_TOOLS) {
+    context.vscode.subscriptions.push(vscode.lm.registerTool(spec.name, makeTool(context, spec)));
+  }
+}

--- a/src/test/suite/lmTools.test.ts
+++ b/src/test/suite/lmTools.test.ts
@@ -1,0 +1,22 @@
+import * as assert from "assert";
+import * as vscode from "vscode";
+
+// Integration test (#140): the Language Model Tools register once, globally, in a
+// real extension host — so Copilot agent mode can see them. Mirrors the
+// command-registration integration test.
+
+suite("Language Model Tools registration (integration, #140)", () => {
+  const expected = ["dvpt_connectionStatus", "dvpt_listComponents", "dvpt_systemRequirements", "dvpt_deploy", "dvpt_generateEarlybound"];
+
+  test("every contributed LM tool is registered on the host", async () => {
+    const ext = vscode.extensions.getExtension("dataversepowertools.dataverse-powertools");
+    assert.ok(ext, "extension should be present");
+    await ext!.activate();
+
+    // vscode.lm.tools is the readonly list of registered tools.
+    const registered = new Set((vscode.lm.tools ?? []).map((t) => t.name));
+    for (const name of expected) {
+      assert.ok(registered.has(name), `LM tool '${name}' should be registered`);
+    }
+  });
+});


### PR DESCRIPTION
## What & why

Exposes a curated set of the extension's capabilities as **VS Code Language Model Tools** (`vscode.lm.registerTool` + `contributes.languageModelTools`) so Copilot agent mode can drive Dataverse PowerTools by natural language. In-editor only — no MCP server, no port, no token, no files written.

## Tools
- **Read (always available):** `dvpt_connectionStatus` (org + auth type + connected — **never** secrets/tokens), `dvpt_listComponents`, `dvpt_systemRequirements`.
- **Mutating (gated + confirmed):** `dvpt_deploy`, `dvpt_generateEarlybound` — **off by default**; enable via `dataverse-powertools.copilot.accessMode: readwrite`. Each uses `prepareInvocation` for a native "run against `<org>`?" confirmation.

## Design (per #140)
- Handlers are **thin wrappers over existing command paths** (`executeCommand`) — pure logic (tool list, access-mode gate, secret-free formatters) lives in `src/lmtools/lmTools.ts` so a future MCP surface can reuse it.
- Registered **once, globally** in `extension.ts` (never per-component — the multi-component registration trap).
- Mutating tools gate on the live connection (the command path itself uses `canCallDataverseApi`, both auth types).

## Engine bump
Minimum VS Code **1.93 → 1.95** (the Language Model Tools API is stable from 1.95). `@types/vscode` bumped to match.

## Verification
`lint` clean · `compile` clean · `test:coverage` **596/596** (+13, incl. package.json↔LM_TOOLS parity). Registration covered by a new integration test (`vscode.lm.tools` includes all five in a real host).

## Out of scope (per #140)
Extension-hosted MCP server for external agents (Claude Code CLI / Cursor) — separate design.

🤖 Generated with [Claude Code](https://claude.com/claude-code)