### PR TITLE
0.14.11 (pre-release) — Power Pages Server Logic restricted-pattern lint (#150 slice)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 All notable changes to the "dataverse-powertools" extension will be documented in this file.
 
+## 0.14.11 (pre-release)
+
+Power Pages / Portals (#150) — **Server Logic restricted-pattern lint**, the first slice of the Portals TypeScript story.
+
+- **Lint Power Pages Server Logic** (palette, any JS/TS editor) checks your script against the platform's [blocked-pattern list](https://learn.microsoft.com/power-pages/configure/author-server-logic#limitations) — `import`/`require`, `eval`/`Function`, `setTimeout`/`setInterval`/`setImmediate`, `process`/`child_process`, `fs`, prototype manipulation (`__proto__`, `Object.setPrototypeOf`, `constructor.constructor`), `Proxy`/`Reflect`, `with`/`delete`, `debugger`, and more — plus unavailable browser APIs (`fetch`, `XMLHttpRequest`). Findings show as inline diagnostics (errors for blocked, warnings for unsupported) so you catch them **before** `pac powerpages upload` rejects the script with a cryptic message. Comments and string literals are ignored to avoid false positives. Pure lint engine, 27 unit tests.
+
+> This is one slice of the larger Portals component (#150). The TypeScript build pipeline (front-end bundle, Server-Logic-to-single-script bundling with inlined shared code, hot-reload, typed clients) is still to come and needs live-site verification.
+
 ## 0.14.10 (pre-release)
 
 Custom API (#142) — **Run Custom API from the editor** (issue #4). Completes the Custom API feature set: define → generate handler → deploy → **invoke**, plus the typed caller.

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "type": "git",
     "url": "https://github.com/pete-mc/dataverse-powertools"
   },
-  "version": "0.14.10",
+  "version": "0.14.11",
   "engines": {
     "vscode": "^1.95.0"
   },
@@ -683,6 +683,11 @@
         "command": "dataverse-powertools.invokeCustomApi",
         "title": "Dataverse PowerTools: Run Custom API",
         "enablement": "dataverse-powertools.showLoaded && dataverse-powertools.isPlugin"
+      },
+      {
+        "command": "dataverse-powertools.lintServerLogic",
+        "title": "Dataverse PowerTools: Lint Power Pages Server Logic",
+        "enablement": "editorLangId == javascript || editorLangId == typescript"
       },
       {
         "command": "dataverse-powertools.uploadPortal",

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -10,6 +10,7 @@ import { clearStoredCredentials } from "./general/connectionStringManager";
 import { checkConfigRevision } from "./general/configRefresh";
 import { registerDecorationCodeLens } from "./plugins/decorationsCodeLens";
 import { registerLmTools } from "./lmtools/registerLmTools";
+import { registerServerLogicLint } from "./portals/lintServerLogicCommand";
 import { registerMenuPanel } from "./panel/menuPanel";
 import { refreshPanelData } from "./panel/panelDataCache";
 import { registerSystemRequirementCommands } from "./general/systemRequirements";
@@ -31,6 +32,8 @@ export async function activate(vscodeContext: vscode.ExtensionContext) {
   registerAllComponentCommands(context);
   // Language Model Tools for Copilot agent mode (#140) — registered ONCE, globally.
   registerLmTools(context);
+  // Power Pages Server Logic lint (#150) — active-editor command + diagnostics, registered ONCE.
+  registerServerLogicLint(context);
   // Class-decoration / filtering-attribute / per-step-profiling CodeLens on plugin .cs files. Registered
   // ONCE here (its commands + provider are global) — never per plugin component, or a
   // second plugin component's initialise throws "command … already exists" (#47).

--- a/src/portals/lintServerLogicCommand.ts
+++ b/src/portals/lintServerLogicCommand.ts
@@ -1,0 +1,51 @@
+// Command: lint the active editor as Power Pages Server Logic (#150 #2). Surfaces
+// the pure lint (serverLogicLint.ts) as inline diagnostics + an output summary, so
+// blocked patterns are caught before `pac powerpages upload` rejects them. Registered
+// once, globally (not per-component). Pure logic lives in serverLogicLint.ts.
+
+import * as vscode from "vscode";
+import DataversePowerToolsContext from "../context";
+import { lintServerLogic, serverLogicPasses } from "./serverLogicLint";
+
+let diagnostics: vscode.DiagnosticCollection | undefined;
+
+export function registerServerLogicLint(context: DataversePowerToolsContext): void {
+  diagnostics = vscode.languages.createDiagnosticCollection("dvpt-server-logic");
+  context.vscode.subscriptions.push(diagnostics);
+  context.vscode.subscriptions.push(vscode.commands.registerCommand("dataverse-powertools.lintServerLogic", () => lintActiveEditor(context)));
+}
+
+function lintActiveEditor(context: DataversePowerToolsContext): void {
+  const editor = vscode.window.activeTextEditor;
+  if (!editor) {
+    vscode.window.showInformationMessage("Open the Server Logic script you want to lint.");
+    return;
+  }
+
+  const doc = editor.document;
+  const findings = lintServerLogic(doc.getText());
+
+  const diags = findings.map((f) => {
+    const lineText = doc.lineAt(Math.min(f.line - 1, doc.lineCount - 1));
+    const diag = new vscode.Diagnostic(
+      lineText.range,
+      `${f.message} (Server Logic ${f.severity === "blocked" ? "blocked pattern" : "unsupported API"}: ${f.pattern})`,
+      f.severity === "blocked" ? vscode.DiagnosticSeverity.Error : vscode.DiagnosticSeverity.Warning,
+    );
+    diag.source = "Dataverse PowerTools · Server Logic";
+    return diag;
+  });
+  diagnostics?.set(doc.uri, diags);
+
+  const blocked = findings.filter((f) => f.severity === "blocked").length;
+  const unsupported = findings.length - blocked;
+  if (findings.length === 0) {
+    vscode.window.showInformationMessage("Server Logic lint: no blocked or unsupported patterns found. ✅");
+  } else {
+    context.channel.appendLine(`\nServer Logic lint — ${blocked} blocked, ${unsupported} unsupported:`);
+    findings.forEach((f) => context.channel.appendLine(`  line ${f.line} [${f.severity}] ${f.pattern}: ${f.message}`));
+    context.channel.show(true);
+    const verdict = serverLogicPasses(findings) ? "would upload, but has unsupported browser APIs" : "would be REJECTED on upload";
+    vscode.window.showWarningMessage(`Server Logic lint: ${blocked} blocked, ${unsupported} unsupported — ${verdict}. See the editor + output.`);
+  }
+}

--- a/src/portals/serverLogicLint.spec.ts
+++ b/src/portals/serverLogicLint.spec.ts
@@ -1,0 +1,80 @@
+import { describe, it, expect } from "vitest";
+import { lintServerLogic, serverLogicPasses, stripCommentsAndStrings } from "./serverLogicLint";
+
+function patterns(code: string): string[] {
+  return lintServerLogic(code).map((f) => f.pattern);
+}
+
+describe("lintServerLogic — blocked patterns", () => {
+  it("passes a clean ES2023 handler", () => {
+    const code = `function get(context) {\n  const total = context.items.reduce((a, b) => a + b, 0);\n  return { total };\n}`;
+    const findings = lintServerLogic(code);
+    expect(findings).toEqual([]);
+    expect(serverLogicPasses(findings)).toBe(true);
+  });
+
+  it.each([
+    ["import x from 'y';", "import"],
+    ["const y = require('y');", "require("],
+    ["eval('1+1');", "eval("],
+    ["const f = new Function('return 1');", "Function("],
+    ["setTimeout(() => {}, 10);", "setTimeout("],
+    ["setInterval(() => {}, 10);", "setInterval("],
+    ["process.exit(1);", "process.exit"],
+    ["const cp = child_process;", "child_process"],
+    ["fs.readFileSync('x');", "fs."],
+    ["console.log(__dirname);", "__dirname"],
+    ["const c = this.constructor;", "this.constructor"],
+    ["with (obj) {}", "with("],
+    ["delete obj.x;", "delete"],
+    ["Object.setPrototypeOf(a, b);", "Object.setPrototypeOf"],
+    ["const p = new Proxy(t, h);", "Proxy("],
+    ["Reflect.get(o, 'k');", "Reflect."],
+    ["Symbol.for('x');", "Symbol.for"],
+    ["o.__proto__ = null;", "__proto__"],
+    ["debugger;", "debugger"],
+  ])("flags %s as blocked (%s)", (code, expected) => {
+    const findings = lintServerLogic(code);
+    expect(findings.map((f) => f.pattern)).toContain(expected);
+    expect(serverLogicPasses(findings)).toBe(false);
+  });
+
+  it("reports 1-based line numbers", () => {
+    const code = `function get() {\n  return 1;\n}\ndebugger;`;
+    const finding = lintServerLogic(code).find((f) => f.pattern === "debugger");
+    expect(finding?.line).toBe(4);
+  });
+});
+
+describe("lintServerLogic — unsupported (browser) APIs", () => {
+  it("flags fetch/XMLHttpRequest as unsupported but not blocking", () => {
+    const findings = lintServerLogic("const r = await fetch('/x');");
+    expect(findings.map((f) => f.pattern)).toContain("fetch(");
+    expect(findings.every((f) => f.severity === "unsupported")).toBe(true);
+    // unsupported alone still passes the blocked-gate
+    expect(serverLogicPasses(findings)).toBe(true);
+  });
+});
+
+describe("stripCommentsAndStrings — no false positives", () => {
+  it("ignores patterns inside line comments", () => {
+    expect(patterns("// use eval() here\nreturn 1;")).toEqual([]);
+  });
+
+  it("ignores patterns inside block comments", () => {
+    expect(patterns("/* debugger and require( */\nreturn 1;")).toEqual([]);
+  });
+
+  it("ignores patterns inside string literals", () => {
+    expect(patterns('const s = "please do not eval() this";')).toEqual([]);
+  });
+
+  it("still preserves line numbers across a multi-line block comment", () => {
+    const code = `/*\n line two\n*/\ndebugger;`;
+    expect(lintServerLogic(code).find((f) => f.pattern === "debugger")?.line).toBe(4);
+  });
+
+  it("stripCommentsAndStrings blanks string contents", () => {
+    expect(stripCommentsAndStrings('x = "eval("')).not.toContain("eval(");
+  });
+});

--- a/src/portals/serverLogicLint.ts
+++ b/src/portals/serverLogicLint.ts
@@ -1,0 +1,102 @@
+// Pure lint for Power Pages Server Logic (#150, issue #2). Server Logic runs in a
+// restricted ES2023 sandbox that rejects a fixed list of patterns (dynamic code,
+// process control, prototype manipulation, module syntax) and has no browser APIs.
+// Catching these locally gives a clear message instead of a cryptic server-side
+// rejection on upload. No `vscode` import → unit-testable.
+//
+// Pattern list is from the official docs:
+//   https://learn.microsoft.com/power-pages/configure/author-server-logic#limitations
+
+export type ServerLogicSeverity = "blocked" | "unsupported";
+
+export interface ServerLogicFinding {
+  /** 1-based line number. */
+  line: number;
+  /** The offending pattern label. */
+  pattern: string;
+  message: string;
+  severity: ServerLogicSeverity;
+}
+
+interface LintRule {
+  pattern: string;
+  regex: RegExp;
+  severity: ServerLogicSeverity;
+  message: string;
+}
+
+// "blocked" = the platform validator rejects the script; "unsupported" = present
+// but non-functional server-side (browser APIs). All should be fixed before upload.
+const RULES: LintRule[] = [
+  {
+    pattern: "import",
+    regex: /\bimport\s*\(|\bimport\b[^\n]*\bfrom\b|^\s*import\s+["']/m,
+    severity: "blocked",
+    message: "Module syntax (import) is not allowed — bundle shared code inline instead.",
+  },
+  { pattern: "require(", regex: /\brequire\s*\(/, severity: "blocked", message: "require() is not allowed — bundle dependencies inline." },
+  { pattern: "eval(", regex: /\beval\s*\(/, severity: "blocked", message: "eval() is not allowed (dynamic code execution)." },
+  { pattern: "Function(", regex: /\bnew\s+Function\s*\(|\bFunction\s*\(/, severity: "blocked", message: "The Function constructor is not allowed (dynamic code execution)." },
+  { pattern: "setTimeout(", regex: /\bsetTimeout\s*\(/, severity: "blocked", message: "setTimeout is not allowed." },
+  { pattern: "setInterval(", regex: /\bsetInterval\s*\(/, severity: "blocked", message: "setInterval is not allowed." },
+  { pattern: "setImmediate(", regex: /\bsetImmediate\s*\(/, severity: "blocked", message: "setImmediate is not allowed." },
+  { pattern: "process.exit", regex: /\bprocess\.exit\b/, severity: "blocked", message: "process.exit is not allowed." },
+  { pattern: "process.kill", regex: /\bprocess\.kill\b/, severity: "blocked", message: "process.kill is not allowed." },
+  { pattern: "child_process", regex: /\bchild_process\b/, severity: "blocked", message: "child_process is not allowed." },
+  { pattern: "fs.", regex: /\bfs\s*\./, severity: "blocked", message: "File-system access (fs.) is not allowed." },
+  { pattern: "__dirname", regex: /\b__dirname\b/, severity: "blocked", message: "__dirname is not allowed." },
+  { pattern: "__filename", regex: /\b__filename\b/, severity: "blocked", message: "__filename is not allowed." },
+  { pattern: "constructor.constructor", regex: /\bconstructor\s*\.\s*constructor\b/, severity: "blocked", message: "constructor.constructor is not allowed (sandbox escape)." },
+  { pattern: "this.constructor", regex: /\bthis\s*\.\s*constructor\b/, severity: "blocked", message: "this.constructor is not allowed (sandbox escape)." },
+  { pattern: "arguments.callee", regex: /\barguments\s*\.\s*callee\b/, severity: "blocked", message: "arguments.callee is not allowed." },
+  { pattern: "with(", regex: /\bwith\s*\(/, severity: "blocked", message: "with statements are not allowed." },
+  { pattern: "delete", regex: /\bdelete\s+[A-Za-z_$]/, severity: "blocked", message: "The delete operator is not allowed." },
+  { pattern: "Object.getPrototypeOf", regex: /\bObject\s*\.\s*getPrototypeOf\b/, severity: "blocked", message: "Object.getPrototypeOf is not allowed (prototype manipulation)." },
+  { pattern: "Object.setPrototypeOf", regex: /\bObject\s*\.\s*setPrototypeOf\b/, severity: "blocked", message: "Object.setPrototypeOf is not allowed (prototype manipulation)." },
+  { pattern: "Proxy(", regex: /\bnew\s+Proxy\s*\(|\bProxy\s*\(/, severity: "blocked", message: "Proxy is not allowed." },
+  { pattern: "Reflect.", regex: /\bReflect\s*\./, severity: "blocked", message: "Reflect is not allowed." },
+  { pattern: "Symbol.for", regex: /\bSymbol\s*\.\s*for\b/, severity: "blocked", message: "Symbol.for is not allowed." },
+  { pattern: "__proto__", regex: /\b__proto__\b/, severity: "blocked", message: "__proto__ is not allowed (prototype manipulation)." },
+  { pattern: "prototype", regex: /\bprototype\b/, severity: "blocked", message: "Accessing prototype is not allowed (prototype manipulation)." },
+  { pattern: "debugger", regex: /\bdebugger\b/, severity: "blocked", message: "debugger statements are not allowed." },
+  { pattern: "fetch(", regex: /\bfetch\s*\(/, severity: "unsupported", message: "fetch is a browser API and is unavailable server-side." },
+  { pattern: "XMLHttpRequest", regex: /\bXMLHttpRequest\b/, severity: "unsupported", message: "XMLHttpRequest is a browser API and is unavailable server-side." },
+];
+
+/**
+ * Best-effort strip of comments and string/template literals so patterns inside
+ * them don't cause false positives. Not a full parser — good enough for a lint.
+ */
+export function stripCommentsAndStrings(code: string): string {
+  let out = code.replace(/\/\*[\s\S]*?\*\//g, (m) => m.replace(/[^\n]/g, " ")); // block comments (keep newlines)
+  out = out.replace(/\/\/[^\n]*/g, ""); // line comments
+  // Replace string / template contents with spaces (keep quotes + length rough).
+  out = out.replace(/"(?:\\.|[^"\\])*"|'(?:\\.|[^'\\])*'|`(?:\\.|[^`\\])*`/g, (m) => m[0] + " ".repeat(Math.max(0, m.length - 2)) + m[0]);
+  return out;
+}
+
+/**
+ * Lint a Server Logic script for blocked / unsupported patterns. Returns findings
+ * with 1-based line numbers, in source order.
+ */
+export function lintServerLogic(code: string): ServerLogicFinding[] {
+  const stripped = stripCommentsAndStrings(code);
+  const lines = stripped.split(/\r?\n/);
+  const findings: ServerLogicFinding[] = [];
+
+  lines.forEach((line, index) => {
+    for (const rule of RULES) {
+      // Fresh test per line (regexes here are non-global, so no lastIndex state).
+      if (rule.regex.test(line)) {
+        findings.push({ line: index + 1, pattern: rule.pattern, message: rule.message, severity: rule.severity });
+      }
+    }
+  });
+
+  return findings;
+}
+
+/** Convenience: true when no blocked patterns are present (unsupported warnings allowed). */
+export function serverLogicPasses(findings: ServerLogicFinding[]): boolean {
+  return !findings.some((f) => f.severity === "blocked");
+}


### PR DESCRIPTION
## What & why
First slice of the Portals component (#150, issue #2): a **pre-deploy lint** for Power Pages **Server Logic**. Server Logic runs in a restricted ES2023 sandbox that rejects a fixed pattern list; catching those locally beats a cryptic server-side rejection on `pac powerpages upload`.

## Changes
- `src/portals/serverLogicLint.ts` (27 tests) — **pure** engine: the docs-verified blocked-pattern list (import/require, eval/Function, timers, process/child_process, fs, prototype manipulation, Proxy/Reflect, with/delete, debugger) + unsupported browser APIs (fetch/XMLHttpRequest). Strips comments + strings to avoid false positives; returns findings with 1-based line numbers + severity.
- `src/portals/lintServerLogicCommand.ts` — **Lint Power Pages Server Logic** command: inline diagnostics (error/warning) on the active JS/TS editor + an output summary. Registered once, globally.

## Scope
This is **one slice** of #150. The TS build pipeline (front-end bundle, Server-Logic single-script bundling with inlined shared code, hot-reload, typed clients) remains — it needs a real bundler + live-site verification.

## Verification
`lint` clean · `compile` clean · `test:coverage` **640/640** (+27). Pattern list from the official Server Logic limitations doc.

🤖 Generated with [Claude Code](https://claude.com/claude-code)