### PR TITLE
0.14.12 (pre-release) — Azure Functions publish + local run (#145 #6/#7)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 All notable changes to the "dataverse-powertools" extension will be documented in this file.
 
+## 0.14.12 (pre-release)
+
+Azure Functions (#145) — real **Azure publish** and **local run** (issues #6/#7), upgrading the previous guide-only deploy.
+
+- **Publish to Azure (func)** — prompts for the Function App name and runs `func azure functionapp publish <app>` in a terminal (Azure sign-in handled interactively by `func`). The guide-only "Deploy to Azure…" stays as a fallback.
+- **Run locally (func start)** — starts the Functions host in a terminal for the inner loop.
+
+Both sit on the Azure Functions component card's overflow. Pure `func` arg building is unit-tested.
+
+> **Pre-release:** these shell out to Azure Functions Core Tools (`func`) and, for publish, expect you to be signed in to Azure with the Function App already created — verify against your subscription. Not yet delivered for #145: a **Send Test Context** command — the `RemoteExecutionContext` webhook payload uses `DataContractJsonSerializer`'s exact wire format, which I won't hand-generate blindly; it needs a captured real payload or a live func host to validate against.
+
 ## 0.14.11 (pre-release)
 
 Power Pages / Portals (#150) — **Server Logic restricted-pattern lint**, the first slice of the Portals TypeScript story.

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "type": "git",
     "url": "https://github.com/pete-mc/dataverse-powertools"
   },
-  "version": "0.14.11",
+  "version": "0.14.12",
   "engines": {
     "vscode": "^1.95.0"
   },
@@ -752,6 +752,16 @@
       {
         "command": "dataverse-powertools.deployAzureFunctionGuide",
         "title": "Dataverse PowerTools: Deploy Azure Function to Azure",
+        "enablement": "dataverse-powertools.showLoaded && dataverse-powertools.isAzureFunction"
+      },
+      {
+        "command": "dataverse-powertools.publishAzureFunction",
+        "title": "Dataverse PowerTools: Publish Azure Function (func)",
+        "enablement": "dataverse-powertools.showLoaded && dataverse-powertools.isAzureFunction"
+      },
+      {
+        "command": "dataverse-powertools.startAzureFunctionHost",
+        "title": "Dataverse PowerTools: Run Azure Function locally (func start)",
         "enablement": "dataverse-powertools.showLoaded && dataverse-powertools.isAzureFunction"
       },
       {

--- a/src/azurefunction/funcArgs.spec.ts
+++ b/src/azurefunction/funcArgs.spec.ts
@@ -1,0 +1,23 @@
+import { describe, it, expect } from "vitest";
+import { funcAzurePublishArgs, funcStartArgs, toCommandLine } from "./funcArgs";
+
+describe("funcAzurePublishArgs", () => {
+  it("builds the publish command for an app", () => {
+    expect(funcAzurePublishArgs("my-func-app")).toEqual(["azure", "functionapp", "publish", "my-func-app"]);
+  });
+});
+
+describe("funcStartArgs", () => {
+  it("is just start", () => {
+    expect(funcStartArgs()).toEqual(["start"]);
+  });
+});
+
+describe("toCommandLine", () => {
+  it("joins program + args", () => {
+    expect(toCommandLine("func", ["azure", "functionapp", "publish", "app"])).toBe("func azure functionapp publish app");
+  });
+  it("quotes args with spaces", () => {
+    expect(toCommandLine("func", ["azure", "functionapp", "publish", "my app"])).toBe('func azure functionapp publish "my app"');
+  });
+});

--- a/src/azurefunction/funcArgs.ts
+++ b/src/azurefunction/funcArgs.ts
@@ -1,0 +1,19 @@
+// Pure arg builders for the Azure Functions Core Tools (`func`) — #145 issues
+// #6/#7 (Azure publish + local run). No `vscode` → unit-tested. funcCommands.ts
+// runs these in a VS Code terminal (long-lived host / interactive Azure prompts).
+
+/** `func azure functionapp publish <app>` — deploy the built function to Azure. */
+export function funcAzurePublishArgs(functionAppName: string): string[] {
+  return ["azure", "functionapp", "publish", functionAppName];
+}
+
+/** `func start` — run the Functions host locally for the inner loop. */
+export function funcStartArgs(): string[] {
+  return ["start"];
+}
+
+/** A shell-safe command line from a program + args (quotes args containing spaces). */
+export function toCommandLine(program: string, args: string[]): string {
+  const quote = (a: string) => (/\s/.test(a) ? `"${a}"` : a);
+  return [program, ...args.map(quote)].join(" ");
+}

--- a/src/azurefunction/funcCommands.ts
+++ b/src/azurefunction/funcCommands.ts
@@ -1,0 +1,50 @@
+// Azure Functions Core Tools (`func`) commands — #145 #6/#7. Run in a VS Code
+// integrated terminal because both are long-lived / interactive: `func start`
+// hosts the function until stopped, and `func azure functionapp publish` prompts
+// for Azure sign-in. The pure arg building is unit-tested in funcArgs.ts.
+//
+// These shell out to `func` (Azure Functions Core Tools) and, for publish, expect
+// the user to be signed in to Azure — verify against your subscription.
+
+import * as vscode from "vscode";
+import DataversePowerToolsContext from "../context";
+import { activeComponentRoot } from "../components/componentDiscovery";
+import { funcAzurePublishArgs, funcStartArgs, toCommandLine } from "./funcArgs";
+
+function runInTerminal(name: string, cwd: string, commandLine: string): void {
+  const terminal = vscode.window.createTerminal({ name, cwd });
+  terminal.show(true);
+  terminal.sendText(commandLine);
+}
+
+/** Publish the built function to Azure with `func azure functionapp publish <app>`. */
+export async function publishAzureFunctionToAzure(context: DataversePowerToolsContext): Promise<void> {
+  const root = activeComponentRoot(context);
+  if (!root) {
+    vscode.window.showErrorMessage("Open or select an Azure Functions component first.");
+    return;
+  }
+
+  const appName = await vscode.window.showInputBox({
+    prompt: "Azure Function App name to publish to (must already exist, and you must be signed in to Azure).",
+    placeHolder: "my-function-app",
+    validateInput: (v) => (v.trim() ? undefined : "Enter the Function App name."),
+  });
+  if (!appName) {
+    return;
+  }
+
+  context.channel.appendLine(`Publishing to Azure Function App '${appName.trim()}' via func — see the terminal.`);
+  runInTerminal(`func publish · ${appName.trim()}`, root, toCommandLine("func", funcAzurePublishArgs(appName.trim())));
+}
+
+/** Run the Functions host locally with `func start` (the inner loop). */
+export function startAzureFunctionHost(context: DataversePowerToolsContext): void {
+  const root = activeComponentRoot(context);
+  if (!root) {
+    vscode.window.showErrorMessage("Open or select an Azure Functions component first.");
+    return;
+  }
+  context.channel.appendLine("Starting the local Functions host (func start) — see the terminal. Stop it with Ctrl+C.");
+  runInTerminal("func start", root, toCommandLine("func", funcStartArgs()));
+}

--- a/src/projectTypes/activation.ts
+++ b/src/projectTypes/activation.ts
@@ -58,6 +58,7 @@ import { buildAzureFunction } from "../azurefunction/buildAzureFunction";
 import { registerWebhookStep } from "../azurefunction/registerWebhookStep";
 import { generateAzureFunctionEarlyBound } from "../azurefunction/generateAzureFunctionEarlyBound";
 import { deployAzureFunctionGuide } from "../azurefunction/deployAzureFunctionGuide";
+import { publishAzureFunctionToAzure, startAzureFunctionHost } from "../azurefunction/funcCommands";
 import { promptAndScaffoldTrigger } from "../azurefunction/scaffoldTrigger";
 
 type CommandImpl = (context: DataversePowerToolsContext, resourceUri?: vscode.Uri) => unknown;
@@ -318,6 +319,8 @@ export const projectTypeActivations: Record<ProjectTypes, ProjectTypeActivation>
       "dataverse-powertools.registerWebhookStep": tracked("Register webhook & step", registerWebhookStep),
       "dataverse-powertools.generateAzureFunctionEarlyBound": tracked("Generate early bound", generateAzureFunctionEarlyBound),
       "dataverse-powertools.deployAzureFunctionGuide": (context) => deployAzureFunctionGuide(context),
+      "dataverse-powertools.publishAzureFunction": (context) => publishAzureFunctionToAzure(context),
+      "dataverse-powertools.startAzureFunctionHost": (context) => startAzureFunctionHost(context),
     },
     // A function component isn't necessarily a Dataverse webhook (#145) — ask how it's
     // triggered and scaffold only that sample handler. The template ships the shared

--- a/src/projectTypes/registry.ts
+++ b/src/projectTypes/registry.ts
@@ -293,7 +293,14 @@ export const projectTypeRegistry: readonly ProjectTypeDescriptor[] = [
     // v1 core (#145): scaffold + typed RemoteExecutionContext + register webhook/step +
     // ServiceClient callback + early-bound. Azure publish and local `func start` /
     // send-test-context are explicit fast-follows (#145 items 6 and 7).
-    commandIds: [`${prefix}registerWebhookStep`, `${prefix}buildAzureFunction`, `${prefix}generateAzureFunctionEarlyBound`, `${prefix}deployAzureFunctionGuide`],
+    commandIds: [
+      `${prefix}registerWebhookStep`,
+      `${prefix}buildAzureFunction`,
+      `${prefix}generateAzureFunctionEarlyBound`,
+      `${prefix}deployAzureFunctionGuide`,
+      `${prefix}publishAzureFunction`,
+      `${prefix}startAzureFunctionHost`,
+    ],
     menu(state) {
       // A function component need not be a Dataverse webhook (#145) — it may be a plain HTTP
       // API, a timer, or a Service Bus consumer. Only the HTTP-webhook trigger leads with
@@ -306,7 +313,11 @@ export const projectTypeRegistry: readonly ProjectTypeDescriptor[] = [
         // The Azure publish itself is done with the Azure Functions extension / func CLI (guide only).
         primary: webhook ? register : build,
         secondary: [...(webhook ? [build] : [register]), { command: `${prefix}generateAzureFunctionEarlyBound`, label: "Generate Earlybound" }],
-        overflow: [{ command: `${prefix}deployAzureFunctionGuide`, label: "Deploy to Azure…" }],
+        overflow: [
+          { command: `${prefix}startAzureFunctionHost`, label: "Run locally (func start)" },
+          { command: `${prefix}publishAzureFunction`, label: "Publish to Azure (func)" },
+          { command: `${prefix}deployAzureFunctionGuide`, label: "Deploy to Azure…" },
+        ],
       };
     },
   },


### PR DESCRIPTION
## What & why
Azure Functions (#145), issues #6/#7 — upgrade the guide-only Azure deploy to **real commands**: publish to Azure and run the host locally.

## Changes
- `src/azurefunction/funcArgs.ts` (4 tests) — pure `func` arg builders (`funcAzurePublishArgs`, `funcStartArgs`, `toCommandLine`).
- `src/azurefunction/funcCommands.ts` — **Publish to Azure (func)** (prompts app name → `func azure functionapp publish` in a terminal) + **Run locally (func start)**. Terminal-based because both are long-lived / interactive.
- Wired onto the Azure Functions card overflow (registry/activation/package.json parity green).

## ⚠️ Pre-release
Shell out to Azure Functions Core Tools (`func`); publish expects Azure sign-in + an existing Function App — verify against your subscription. **Not** included: Send Test Context — the `RemoteExecutionContext` webhook payload uses `DataContractJsonSerializer`'s exact wire format; I won't hand-generate a payload I can't validate. It needs a captured real payload or a live func host.

## Verification
`lint` clean · `compile` clean · `test:coverage` **644/644** (+4).

🤖 Generated with [Claude Code](https://claude.com/claude-code)