### PR TITLE
0.14.15 (pre-release) — verify workflow-activity registration orchestration (#143 Move 2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to the "dataverse-powertools" extension will be documented in this file.
 
+## 0.14.15 (pre-release)
+
+Testing epic (#143, Move 2) — **verify the workflow-activity registration orchestration** against a mocked Web API, matching 0.14.14 for plugin steps. `registerWorkflowActivities.spec.ts` asserts unchanged (no PATCH) / update (metadata differs) / skip (plugin type not in the assembly). +3 tests (655 total). The whole plugin Build & Deploy registration path — steps *and* workflow activities — is now covered in CI instead of only by the live e2e.
+
 ## 0.14.14 (pre-release)
 
 Testing epic (#143, Move 2) — **verify the plugin-step registration orchestration against a mocked Web API**. Plugin *Build & Deploy* registers SDK message-processing steps over the Web API; that path was only exercised by the live e2e. New `registerPluginSteps.spec.ts` drives it through the `node-fetch` mock + `fakeDataverseContext` harness and asserts the four outcomes — **create** a new step, leave an identical step **unchanged** (no PATCH), **update** a step whose config differs, and **skip** a step whose plugin type isn't in the assembly. +4 tests (652 total). Continues moving the deploy-path coverage down from the fragile e2e into CI.

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "type": "git",
     "url": "https://github.com/pete-mc/dataverse-powertools"
   },
-  "version": "0.14.14",
+  "version": "0.14.15",
   "engines": {
     "vscode": "^1.95.0"
   },

--- a/src/general/dataverse/registerWorkflowActivities.spec.ts
+++ b/src/general/dataverse/registerWorkflowActivities.spec.ts
@@ -1,0 +1,75 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+vi.mock("node-fetch", () => ({ default: vi.fn() }));
+import fetch from "node-fetch";
+import { registerWorkflowActivities } from "./registerWorkflowActivities";
+import { WorkflowActivityRegistration } from "./stepPayloads";
+import { fakeDataverseContext, okJson } from "../../../test/dataverseTestUtils";
+
+// #143 Move 2 — verify the workflow-activity registration orchestration (plugin
+// Build & Deploy) against a mocked Web API: unchanged / update / skip.
+
+const fetchMock = fetch as unknown as ReturnType<typeof vi.fn>;
+beforeEach(() => fetchMock.mockReset());
+
+function noContent() {
+  return { ok: true, status: 204, statusText: "", headers: { get: () => null }, json: async () => ({}), text: async () => "" };
+}
+
+const workflow: WorkflowActivityRegistration = {
+  className: "MyActivity",
+  fullTypeName: "NS.MyActivity",
+  workflowName: "My Activity",
+  workflowDescription: "desc",
+  workflowGroup: "Grp",
+};
+
+/** A plugintype record that matches `workflow` exactly (→ unchanged). */
+const matchingRecord = {
+  plugintypeid: "pt-1",
+  typename: "NS.MyActivity",
+  name: "My Activity",
+  friendlyname: "My Activity",
+  description: "desc",
+  workflowactivitygroupname: "Grp",
+};
+
+function route(records: unknown[]) {
+  fetchMock.mockImplementation((url: string, opts: { method?: string } = {}) => {
+    const method = opts.method ?? "GET";
+    if (method === "GET" && String(url).includes("plugintypes")) {
+      return Promise.resolve(okJson({ value: records }));
+    }
+    return Promise.resolve(noContent()); // PATCH
+  });
+}
+
+function methodCalls(method: string, urlPart: string): number {
+  return fetchMock.mock.calls.filter((c) => (c[1]?.method ?? "GET") === method && String(c[0]).includes(urlPart)).length;
+}
+
+describe("registerWorkflowActivities — orchestration vs mocked Web API (#143 Move 2)", () => {
+  it("leaves a matching workflow activity unchanged (no PATCH)", async () => {
+    route([matchingRecord]);
+    const { context } = fakeDataverseContext();
+    const result = await registerWorkflowActivities(context, "asm-1", [workflow]);
+    expect(result).toMatchObject({ unchanged: 1, updated: 0, skipped: 0 });
+    expect(methodCalls("PATCH", "plugintypes(pt-1)")).toBe(0);
+  });
+
+  it("PATCHes a workflow activity whose metadata differs", async () => {
+    route([{ ...matchingRecord, description: "old description" }]);
+    const { context } = fakeDataverseContext();
+    const result = await registerWorkflowActivities(context, "asm-1", [workflow]);
+    expect(result).toMatchObject({ updated: 1, unchanged: 0 });
+    expect(methodCalls("PATCH", "plugintypes(pt-1)")).toBe(1);
+  });
+
+  it("skips a workflow activity whose plugin type isn't in the assembly", async () => {
+    route([]);
+    const { context } = fakeDataverseContext();
+    const result = await registerWorkflowActivities(context, "asm-1", [workflow]);
+    expect(result).toMatchObject({ skipped: 1, updated: 0 });
+    expect(methodCalls("PATCH", "plugintypes")).toBe(0);
+  });
+});


### PR DESCRIPTION
Testing epic #143 Move 2: `registerWorkflowActivities.spec.ts` — unchanged / update / skip via the mocked Web API, matching 0.14.14 for steps. The full plugin Build & Deploy registration path is now CI-covered. **655/655** (+3).

🤖 Generated with [Claude Code](https://claude.com/claude-code)