### PR TITLE
0.14.16 (pre-release) — Power Pages Server Logic build/bundle (#150 #2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 All notable changes to the "dataverse-powertools" extension will be documented in this file.
 
+## 0.14.16 (pre-release)
+
+Power Pages / Portals (#150) — **Server Logic build**, the enabling feature (issue #2). Server Logic has no module system at runtime, so sharing code across logics is impossible OOTB; this bundles it for you.
+
+- **Build Power Pages Server Logic (bundle)** (palette, any TS editor) runs esbuild to bundle the active TypeScript file — **inlining its shared imports** — into one self-contained ES2023 script, strips the module syntax esbuild emits so the output is a classic script (top-level `get()`/`post()`, no `import`/`export`), lints the result against the [blocked-pattern list](https://learn.microsoft.com/power-pages/configure/author-server-logic#limitations), and writes `<name>.serverlogic.js` — ready for `pac powerpages upload`. Pairs with the 0.14.11 lint. Pure logic (esbuild args + the module-syntax stripper) is unit-tested (7 tests).
+
+> **Pre-release:** requires esbuild in your project and hasn't been round-tripped through a live Power Pages site yet. This is the build core of the larger Portals component (#150) — front-end bundle, shared-library wiring, typed clients, and hot-reload are still to come.
+
 ## 0.14.15 (pre-release)
 
 Testing epic (#143, Move 2) — **verify the workflow-activity registration orchestration** against a mocked Web API, matching 0.14.14 for plugin steps. `registerWorkflowActivities.spec.ts` asserts unchanged (no PATCH) / update (metadata differs) / skip (plugin type not in the assembly). +3 tests (655 total). The whole plugin Build & Deploy registration path — steps *and* workflow activities — is now covered in CI instead of only by the live e2e.

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "type": "git",
     "url": "https://github.com/pete-mc/dataverse-powertools"
   },
-  "version": "0.14.15",
+  "version": "0.14.16",
   "engines": {
     "vscode": "^1.95.0"
   },
@@ -688,6 +688,11 @@
         "command": "dataverse-powertools.lintServerLogic",
         "title": "Dataverse PowerTools: Lint Power Pages Server Logic",
         "enablement": "editorLangId == javascript || editorLangId == typescript"
+      },
+      {
+        "command": "dataverse-powertools.buildServerLogic",
+        "title": "Dataverse PowerTools: Build Power Pages Server Logic (bundle)",
+        "enablement": "editorLangId == typescript"
       },
       {
         "command": "dataverse-powertools.uploadPortal",

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -11,6 +11,7 @@ import { checkConfigRevision } from "./general/configRefresh";
 import { registerDecorationCodeLens } from "./plugins/decorationsCodeLens";
 import { registerLmTools } from "./lmtools/registerLmTools";
 import { registerServerLogicLint } from "./portals/lintServerLogicCommand";
+import { registerServerLogicBuild } from "./portals/buildServerLogicCommand";
 import { registerMenuPanel } from "./panel/menuPanel";
 import { refreshPanelData } from "./panel/panelDataCache";
 import { registerSystemRequirementCommands } from "./general/systemRequirements";
@@ -32,8 +33,9 @@ export async function activate(vscodeContext: vscode.ExtensionContext) {
   registerAllComponentCommands(context);
   // Language Model Tools for Copilot agent mode (#140) — registered ONCE, globally.
   registerLmTools(context);
-  // Power Pages Server Logic lint (#150) — active-editor command + diagnostics, registered ONCE.
+  // Power Pages Server Logic lint + build (#150) — active-editor commands, registered ONCE.
   registerServerLogicLint(context);
+  registerServerLogicBuild(context);
   // Class-decoration / filtering-attribute / per-step-profiling CodeLens on plugin .cs files. Registered
   // ONCE here (its commands + provider are global) — never per plugin component, or a
   // second plugin component's initialise throws "command … already exists" (#47).

--- a/src/portals/buildServerLogicCommand.ts
+++ b/src/portals/buildServerLogicCommand.ts
@@ -1,0 +1,67 @@
+// Command: build the active TypeScript file into a Power Pages Server Logic script
+// (#150 #2). Runs esbuild to bundle it (inlining shared imports) into one ES2023
+// file, strips the module syntax esbuild emits, lints the result against the
+// Server Logic blocked-pattern list, and writes `<name>.serverlogic.js` — the
+// self-contained classic script OOTB `pac powerpages upload` expects. Registered
+// once, globally. Pure logic (args / strip) is unit-tested in serverLogicBuild.ts.
+//
+// Requires esbuild available in the file's project (`npx esbuild`). Pre-release.
+
+import * as vscode from "vscode";
+import * as fs from "fs";
+import * as path from "path";
+import * as util from "util";
+import DataversePowerToolsContext from "../context";
+import { esbuildServerLogicArgs, stripModuleSyntax, serverLogicOutputName } from "./serverLogicBuild";
+import { lintServerLogic, serverLogicPasses } from "./serverLogicLint";
+
+const exec = util.promisify(require("child_process").exec);
+
+export function registerServerLogicBuild(context: DataversePowerToolsContext): void {
+  context.vscode.subscriptions.push(vscode.commands.registerCommand("dataverse-powertools.buildServerLogic", () => buildActiveFile(context)));
+}
+
+async function buildActiveFile(context: DataversePowerToolsContext): Promise<void> {
+  const editor = vscode.window.activeTextEditor;
+  if (!editor || !/\.[cm]?tsx?$/i.test(editor.document.fileName)) {
+    vscode.window.showInformationMessage("Open the Server Logic TypeScript file you want to build.");
+    return;
+  }
+
+  await editor.document.save();
+  const filePath = editor.document.fileName;
+  const cwd = path.dirname(filePath);
+  const entry = path.basename(filePath);
+  const tmpOut = `${serverLogicOutputName(entry)}.esbuild.tmp`;
+  const finalName = serverLogicOutputName(entry);
+
+  context.channel.appendLine(`\nBuilding Server Logic: ${entry} → ${finalName}`);
+  try {
+    await exec(`npx esbuild ${esbuildServerLogicArgs(entry, tmpOut).join(" ")}`, { cwd });
+  } catch (error: unknown) {
+    context.channel.appendLine(`esbuild failed: ${(error as { stderr?: string; message?: string }).stderr || (error as Error).message}`);
+    context.channel.show(true);
+    vscode.window.showErrorMessage("Server Logic build failed (is esbuild installed in this project?). See the Dataverse PowerTools output.");
+    return;
+  }
+
+  const tmpPath = path.join(cwd, tmpOut);
+  const bundled = fs.readFileSync(tmpPath, "utf8");
+  fs.rmSync(tmpPath, { force: true });
+
+  const script = stripModuleSyntax(bundled);
+  const finalPath = path.join(cwd, finalName);
+  fs.writeFileSync(finalPath, script, "utf8");
+
+  const findings = lintServerLogic(script);
+  if (findings.length === 0) {
+    vscode.window.showInformationMessage(`Built ${finalName} — no blocked patterns. ✅`);
+  } else {
+    const blocked = findings.filter((f) => f.severity === "blocked").length;
+    context.channel.appendLine(`Server Logic lint on the bundled output — ${blocked} blocked, ${findings.length - blocked} unsupported:`);
+    findings.forEach((f) => context.channel.appendLine(`  line ${f.line} [${f.severity}] ${f.pattern}: ${f.message}`));
+    context.channel.show(true);
+    const verdict = serverLogicPasses(findings) ? "has unsupported browser APIs" : "would be REJECTED on upload";
+    vscode.window.showWarningMessage(`Built ${finalName}, but it ${verdict}. See the output.`);
+  }
+}

--- a/src/portals/serverLogicBuild.spec.ts
+++ b/src/portals/serverLogicBuild.spec.ts
@@ -1,0 +1,53 @@
+import { describe, it, expect } from "vitest";
+import { esbuildServerLogicArgs, stripModuleSyntax, serverLogicOutputName } from "./serverLogicBuild";
+
+describe("esbuildServerLogicArgs", () => {
+  it("bundles to a single self-contained ES2023 file", () => {
+    const args = esbuildServerLogicArgs("src/backend/getWidgets.ts", "out/getWidgets.js");
+    expect(args).toContain("--bundle");
+    expect(args).toContain("src/backend/getWidgets.ts");
+    expect(args).toContain("--format=esm");
+    expect(args).toContain("--target=es2023");
+    expect(args).toContain("--platform=neutral");
+    expect(args).toContain("--outfile=out/getWidgets.js");
+  });
+});
+
+describe("stripModuleSyntax", () => {
+  it("removes a trailing export bookkeeping statement", () => {
+    const out = stripModuleSyntax(`function get() { return 1; }\nfunction post() {}\nexport { get, post };\n`);
+    expect(out).toContain("function get()");
+    expect(out).toContain("function post()");
+    expect(out).not.toMatch(/\bexport\b/);
+  });
+
+  it("strips the export keyword from top-level declarations", () => {
+    const out = stripModuleSyntax(`export function get() {}\nexport const CONST = 1;\nexport async function post() {}`);
+    expect(out).toContain("function get()");
+    expect(out).toContain("const CONST = 1;");
+    expect(out).toContain("async function post()");
+    expect(out).not.toMatch(/\bexport\b/);
+  });
+
+  it("handles renamed exports (export { x as y })", () => {
+    const out = stripModuleSyntax(`function h() {}\nexport { h as get };`);
+    expect(out).toContain("function h()");
+    expect(out).not.toMatch(/\bexport\b/);
+  });
+
+  it("drops export default", () => {
+    expect(stripModuleSyntax(`export default function get() {}`)).not.toMatch(/\bexport\b/);
+  });
+
+  it("leaves a body that already has no module syntax untouched (aside from trimming)", () => {
+    const code = `function get() {\n  return { ok: true };\n}`;
+    expect(stripModuleSyntax(code)).toBe(code);
+  });
+});
+
+describe("serverLogicOutputName", () => {
+  it("maps a TS entry to a .serverlogic.js output", () => {
+    expect(serverLogicOutputName("getWidgets.ts")).toBe("getWidgets.serverlogic.js");
+    expect(serverLogicOutputName("post.mts")).toBe("post.serverlogic.js");
+  });
+});

--- a/src/portals/serverLogicBuild.ts
+++ b/src/portals/serverLogicBuild.ts
@@ -1,0 +1,40 @@
+// Pure core for the Power Pages Server Logic build (#150, issue #2 — the enabling
+// feature). Server Logic has NO module system at runtime (import/require are
+// blocked), so sharing code across logics is impossible OOTB. The fix: bundle each
+// logic's TS (with its shared imports inlined) into ONE self-contained ES2023
+// script exposing top-level get()/post()/… — no ESM/CJS wrapper, no import in the
+// output. esbuild does the inlining; `stripModuleSyntax` removes the ESM export
+// bookkeeping esbuild emits so the result is a classic script. No `vscode` import.
+
+/** esbuild CLI args to bundle a Server Logic entry into a single ES2023 file. */
+export function esbuildServerLogicArgs(entryFile: string, outFile: string): string[] {
+  return ["--bundle", entryFile, "--format=esm", "--target=es2023", "--platform=neutral", "--legal-comments=none", `--outfile=${outFile}`];
+}
+
+/**
+ * Turn esbuild's bundled ESM output into a classic Server Logic script: drop the
+ * `export { … }` bookkeeping statements, `export default`, and leading `export `
+ * on top-level declarations, leaving top-level `function get()/post()/…`. The
+ * bundle already has no `import` (everything is inlined), so the result contains
+ * no module syntax at all.
+ */
+export function stripModuleSyntax(bundledCode: string): string {
+  return (
+    bundledCode
+      // `export { get, post as handler };` bookkeeping (with or without renames)
+      .replace(/^\s*export\s*\{[^}]*\}\s*;?\s*$/gm, "")
+      // `export default …` → keep the value as a statement is meaningless for
+      // Server Logic; drop the keyword so it's a no-op expression at worst.
+      .replace(/^\s*export\s+default\s+/gm, "")
+      // `export function get(){}` / `export const x =` → strip the leading keyword
+      .replace(/^(\s*)export\s+(?=(?:async\s+)?function\b|const\b|let\b|var\b|class\b)/gm, "$1")
+      // collapse the blank lines left behind
+      .replace(/\n{3,}/g, "\n\n")
+      .trimStart()
+  );
+}
+
+/** Output file name for a built Server Logic (from its entry file name). */
+export function serverLogicOutputName(entryFileName: string): string {
+  return entryFileName.replace(/\.[cm]?tsx?$/i, "") + ".serverlogic.js";
+}


### PR DESCRIPTION
## What & why
Portals (#150), issue #2 — **the enabling feature**: a real TypeScript build for Power Pages Server Logic. Server Logic bans `import`/`require` at runtime, so cross-logic code sharing is impossible OOTB. This bundles each logic (inlining shared code) into one self-contained ES2023 classic script.

## Changes
- `src/portals/serverLogicBuild.ts` (7 tests) — pure: `esbuildServerLogicArgs` (bundle → single ES2023 file) + `stripModuleSyntax` (turn esbuild's ESM output into a classic script: drop `export {…}` bookkeeping, `export default`, and leading `export ` on declarations) + `serverLogicOutputName`.
- `src/portals/buildServerLogicCommand.ts` — **Build Power Pages Server Logic (bundle)**: esbuild the active TS → strip → **lint (0.14.11)** → write `<name>.serverlogic.js`. Registered once.

## Scope / pre-release
Requires esbuild in the project; not yet round-tripped through a live site. This is the build **core** of #150 — the front-end bundle, shared-library wiring, typed clients and hot-reload are the remaining slices (need the full component model + a live site).

## Verification
`lint` clean · `compile` clean · `test:coverage` **662/662** (+7).

🤖 Generated with [Claude Code](https://claude.com/claude-code)