### PR TITLE
0.14.17 (pre-release) — Power Pages front-end TS build/bundle (#150 #1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 All notable changes to the "dataverse-powertools" extension will be documented in this file.
 
+## 0.14.17 (pre-release)
+
+Power Pages / Portals (#150) — **front-end TypeScript build** (issue #1), the browser-side counterpart to the 0.14.16 Server Logic build.
+
+- **Build Power Pages front-end web file (bundle)** (palette, any TS/TSX editor) runs esbuild to bundle the active front-end TypeScript — npm deps + shared code inlined, tree-shaken, minified, source-mapped — into a single browser **web file** (`<name>.js`) that OOTB `pac powerpages upload` serves. The build OOTB has no story for; upload stays OOTB. Pure esbuild arg building is unit-tested.
+
+> **Pre-release:** requires esbuild in your project; the site upload/serve round-trip isn't verified here. Together with the Server Logic build (0.14.16), the two halves of the Portals "real TypeScript build" (#150) now exist as commands; the full component model (frontend/backend/shared discovery, shared-library wiring across both, typed clients, hot-reload) is the remaining slice.
+
 ## 0.14.16 (pre-release)
 
 Power Pages / Portals (#150) — **Server Logic build**, the enabling feature (issue #2). Server Logic has no module system at runtime, so sharing code across logics is impossible OOTB; this bundles it for you.

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "type": "git",
     "url": "https://github.com/pete-mc/dataverse-powertools"
   },
-  "version": "0.14.16",
+  "version": "0.14.17",
   "engines": {
     "vscode": "^1.95.0"
   },
@@ -693,6 +693,11 @@
         "command": "dataverse-powertools.buildServerLogic",
         "title": "Dataverse PowerTools: Build Power Pages Server Logic (bundle)",
         "enablement": "editorLangId == typescript"
+      },
+      {
+        "command": "dataverse-powertools.buildPortalFrontend",
+        "title": "Dataverse PowerTools: Build Power Pages front-end web file (bundle)",
+        "enablement": "editorLangId == typescript || editorLangId == typescriptreact"
       },
       {
         "command": "dataverse-powertools.uploadPortal",

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -12,6 +12,7 @@ import { registerDecorationCodeLens } from "./plugins/decorationsCodeLens";
 import { registerLmTools } from "./lmtools/registerLmTools";
 import { registerServerLogicLint } from "./portals/lintServerLogicCommand";
 import { registerServerLogicBuild } from "./portals/buildServerLogicCommand";
+import { registerPortalFrontendBuild } from "./portals/buildPortalFrontendCommand";
 import { registerMenuPanel } from "./panel/menuPanel";
 import { refreshPanelData } from "./panel/panelDataCache";
 import { registerSystemRequirementCommands } from "./general/systemRequirements";
@@ -36,6 +37,7 @@ export async function activate(vscodeContext: vscode.ExtensionContext) {
   // Power Pages Server Logic lint + build (#150) — active-editor commands, registered ONCE.
   registerServerLogicLint(context);
   registerServerLogicBuild(context);
+  registerPortalFrontendBuild(context);
   // Class-decoration / filtering-attribute / per-step-profiling CodeLens on plugin .cs files. Registered
   // ONCE here (its commands + provider are global) — never per plugin component, or a
   // second plugin component's initialise throws "command … already exists" (#47).

--- a/src/portals/buildPortalFrontendCommand.ts
+++ b/src/portals/buildPortalFrontendCommand.ts
@@ -1,0 +1,44 @@
+// Command: build the active TypeScript file into a Power Pages front-end web file
+// (#150 #1). Runs esbuild to bundle it (npm deps + shared code inlined, tree-shaken,
+// minified, source-mapped) into a single browser JS web file OOTB `pac powerpages
+// upload` serves. Registered once, globally. Pure args in portalFrontendBuild.ts.
+//
+// Requires esbuild in the file's project (`npx esbuild`). Pre-release.
+
+import * as vscode from "vscode";
+import * as path from "path";
+import * as util from "util";
+import DataversePowerToolsContext from "../context";
+import { esbuildFrontendArgs, frontendOutputName } from "./portalFrontendBuild";
+
+const exec = util.promisify(require("child_process").exec);
+
+export function registerPortalFrontendBuild(context: DataversePowerToolsContext): void {
+  context.vscode.subscriptions.push(vscode.commands.registerCommand("dataverse-powertools.buildPortalFrontend", () => buildActiveFile(context)));
+}
+
+async function buildActiveFile(context: DataversePowerToolsContext): Promise<void> {
+  const editor = vscode.window.activeTextEditor;
+  if (!editor || !/\.[cm]?tsx?$/i.test(editor.document.fileName)) {
+    vscode.window.showInformationMessage("Open the portal front-end TypeScript file you want to build.");
+    return;
+  }
+
+  await editor.document.save();
+  const cwd = path.dirname(editor.document.fileName);
+  const entry = path.basename(editor.document.fileName);
+  const outFile = frontendOutputName(entry);
+
+  context.channel.appendLine(`\nBuilding portal front-end: ${entry} → ${outFile}`);
+  try {
+    await exec(`npx esbuild ${esbuildFrontendArgs(entry, outFile).join(" ")}`, { cwd });
+  } catch (error: unknown) {
+    context.channel.appendLine(`esbuild failed: ${(error as { stderr?: string; message?: string }).stderr || (error as Error).message}`);
+    context.channel.show(true);
+    vscode.window.showErrorMessage("Portal front-end build failed (is esbuild installed in this project?). See the Dataverse PowerTools output.");
+    return;
+  }
+
+  context.channel.appendLine(`Built ${outFile} (+ source map). Upload it as a web file with pac powerpages upload.`);
+  vscode.window.showInformationMessage(`Built portal front-end web file: ${outFile}.`);
+}

--- a/src/portals/portalFrontendBuild.spec.ts
+++ b/src/portals/portalFrontendBuild.spec.ts
@@ -1,0 +1,22 @@
+import { describe, it, expect } from "vitest";
+import { esbuildFrontendArgs, frontendOutputName } from "./portalFrontendBuild";
+
+describe("esbuildFrontendArgs", () => {
+  it("bundles to a minified, source-mapped browser IIFE web file", () => {
+    const args = esbuildFrontendArgs("src/frontend/main.ts", "webfiles/main.js");
+    expect(args).toContain("--bundle");
+    expect(args).toContain("src/frontend/main.ts");
+    expect(args).toContain("--format=iife");
+    expect(args).toContain("--target=es2017");
+    expect(args).toContain("--minify");
+    expect(args).toContain("--sourcemap");
+    expect(args).toContain("--outfile=webfiles/main.js");
+  });
+});
+
+describe("frontendOutputName", () => {
+  it("maps a TS/TSX entry to a .js web file", () => {
+    expect(frontendOutputName("main.ts")).toBe("main.js");
+    expect(frontendOutputName("widget.tsx")).toBe("widget.js");
+  });
+});

--- a/src/portals/portalFrontendBuild.ts
+++ b/src/portals/portalFrontendBuild.ts
@@ -1,0 +1,14 @@
+// Pure core for the Power Pages front-end build (#150, issue #1): compile a portal
+// front-end TypeScript entry into a single browser web file (JS) with npm deps
+// bundled, tree-shaking, and a source map — the OOTB stack has no real TS build.
+// No `vscode` import → unit-tested; buildPortalFrontendCommand.ts runs esbuild.
+
+/** esbuild CLI args to bundle a portal front-end entry into one browser web file. */
+export function esbuildFrontendArgs(entryFile: string, outFile: string): string[] {
+  return ["--bundle", entryFile, "--format=iife", "--target=es2017", "--minify", "--sourcemap", "--legal-comments=none", `--outfile=${outFile}`];
+}
+
+/** Output web-file name for a front-end entry (Power Pages JS web files are `.js`). */
+export function frontendOutputName(entryFileName: string): string {
+  return entryFileName.replace(/\.[cm]?tsx?$/i, "") + ".js";
+}


### PR DESCRIPTION
Portals (#150) issue #1 — the browser-side build. `Build Power Pages front-end web file` esbuild-bundles the active TS/TSX (deps + shared inlined, minified, sourcemapped) into a single web file for `pac powerpages upload`. Pure esbuild args unit-tested. With 0.14.16 (Server Logic build), both halves of the Portals TS build exist as commands; the full component model + hot-reload + typed clients remain. `lint`/`compile`/`coverage` **664/664** (+2). Pre-release: esbuild required; site round-trip unverified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)