### PR TITLE
0.14.18 (pre-release) — typed Power Pages Server Logic client (#150 #4)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 All notable changes to the "dataverse-powertools" extension will be documented in this file.
 
+## 0.14.18 (pre-release)
+
+Power Pages / Portals (#150) — **typed Server Logic client** (issue #4), end-to-end typing for portal JS that calls Server Logic.
+
+- **New Power Pages Server Logic definition** seeds a `*.serverlogic.json` (name, HTTP method, request/response field types). **Generate Power Pages Server Logic client** emits `<name>.client.ts` — a typed `Request`/`Response` interface plus an `async` wrapper that calls `/_api/serverlogics/<name>` via `shell.safeAjax` (CSRF handled), with the request body omitted for GET/DELETE. Portal JS hitting Server Logic gets IntelliSense and compile-time safety instead of untyped string-bashing. Pure codegen, 6 unit tests.
+
+> Design note: v1 derives the client from a small `*.serverlogic.json` definition (my call while the maintainer is away) rather than inferring types from the backend handler TS — the definition can be shared with the handler for both-ends typing, and inferring-from-handler can layer on later. **Pre-release:** not yet exercised against a live site.
+
 ## 0.14.17 (pre-release)
 
 Power Pages / Portals (#150) — **front-end TypeScript build** (issue #1), the browser-side counterpart to the 0.14.16 Server Logic build.

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "type": "git",
     "url": "https://github.com/pete-mc/dataverse-powertools"
   },
-  "version": "0.14.17",
+  "version": "0.14.18",
   "engines": {
     "vscode": "^1.95.0"
   },
@@ -698,6 +698,15 @@
         "command": "dataverse-powertools.buildPortalFrontend",
         "title": "Dataverse PowerTools: Build Power Pages front-end web file (bundle)",
         "enablement": "editorLangId == typescript || editorLangId == typescriptreact"
+      },
+      {
+        "command": "dataverse-powertools.newServerLogicDefinition",
+        "title": "Dataverse PowerTools: New Power Pages Server Logic definition"
+      },
+      {
+        "command": "dataverse-powertools.generateServerLogicClient",
+        "title": "Dataverse PowerTools: Generate Power Pages Server Logic client",
+        "enablement": "resourceExtname == .json"
       },
       {
         "command": "dataverse-powertools.uploadPortal",

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -13,6 +13,7 @@ import { registerLmTools } from "./lmtools/registerLmTools";
 import { registerServerLogicLint } from "./portals/lintServerLogicCommand";
 import { registerServerLogicBuild } from "./portals/buildServerLogicCommand";
 import { registerPortalFrontendBuild } from "./portals/buildPortalFrontendCommand";
+import { registerServerLogicClient } from "./portals/serverLogicClientCommand";
 import { registerMenuPanel } from "./panel/menuPanel";
 import { refreshPanelData } from "./panel/panelDataCache";
 import { registerSystemRequirementCommands } from "./general/systemRequirements";
@@ -38,6 +39,7 @@ export async function activate(vscodeContext: vscode.ExtensionContext) {
   registerServerLogicLint(context);
   registerServerLogicBuild(context);
   registerPortalFrontendBuild(context);
+  registerServerLogicClient(context);
   // Class-decoration / filtering-attribute / per-step-profiling CodeLens on plugin .cs files. Registered
   // ONCE here (its commands + provider are global) — never per plugin component, or a
   // second plugin component's initialise throws "command … already exists" (#47).

--- a/src/portals/serverLogicClient.spec.ts
+++ b/src/portals/serverLogicClient.spec.ts
@@ -1,0 +1,54 @@
+// Server Logic request/response field names are PascalCase by convention.
+/* eslint-disable @typescript-eslint/naming-convention */
+import { describe, it, expect } from "vitest";
+import { generateServerLogicClient, newServerLogicDefinition, serverLogicClientFileName, ServerLogicDefinition } from "./serverLogicClient";
+
+describe("newServerLogicDefinition", () => {
+  it("seeds a POST logic with one request + response field", () => {
+    const def = newServerLogicDefinition("getWidgets");
+    expect(def).toMatchObject({ name: "getWidgets", method: "POST" });
+    expect(def.request).toBeTruthy();
+    expect(def.response).toBeTruthy();
+  });
+});
+
+describe("serverLogicClientFileName", () => {
+  it("appends .client.ts", () => {
+    expect(serverLogicClientFileName(newServerLogicDefinition("getWidgets"))).toBe("getWidgets.client.ts");
+  });
+});
+
+describe("generateServerLogicClient", () => {
+  const def = newServerLogicDefinition("getWidgets");
+  const code = generateServerLogicClient(def);
+
+  it("emits typed request/response interfaces + a camelCased function", () => {
+    expect(code).toContain("export interface GetWidgetsRequest");
+    expect(code).toContain("export interface GetWidgetsResponse");
+    expect(code).toContain("export function getWidgets(request: GetWidgetsRequest): Promise<GetWidgetsResponse>");
+    expect(code).toContain("InputValue: string;");
+    expect(code).toContain("OutputValue: string;");
+  });
+
+  it("calls shell.safeAjax against the serverlogics endpoint with the right verb", () => {
+    expect(code).toContain('url: "/_api/serverlogics/getWidgets"');
+    expect(code).toContain('type: "POST"');
+    expect(code).toContain("data: JSON.stringify(request)"); // POST sends a body
+    expect(code).toContain("shell.safeAjax");
+  });
+
+  it("omits the request body for a GET", () => {
+    const get: ServerLogicDefinition = { ...def, method: "GET" };
+    const code = generateServerLogicClient(get);
+    expect(code).toContain('type: "GET"');
+    expect(code).not.toContain("data: JSON.stringify(request)");
+  });
+
+  it("emits custom field types verbatim", () => {
+    const typed: ServerLogicDefinition = { name: "search", method: "POST", request: { Term: "string", Take: "number" }, response: { Items: "string[]" } };
+    const code = generateServerLogicClient(typed);
+    expect(code).toContain("Term: string;");
+    expect(code).toContain("Take: number;");
+    expect(code).toContain("Items: string[];");
+  });
+});

--- a/src/portals/serverLogicClient.ts
+++ b/src/portals/serverLogicClient.ts
@@ -1,0 +1,97 @@
+// Pure codegen for a typed front-end client that calls a Power Pages Server Logic
+// via `shell.safeAjax` (#150, issue #4). A `*.serverlogic.json` definition (name +
+// HTTP method + request/response field types) is the source of truth; this emits a
+// typed request/response + an async wrapper that calls `/_api/serverlogics/<name>`
+// with CSRF handled by `shell.safeAjax`. Shared with the backend via the same
+// definition, this closes the untyped string-bashing gap on portal JS. No `vscode`.
+
+export type ServerLogicMethod = "GET" | "POST" | "PUT" | "PATCH" | "DELETE";
+
+/** A `*.serverlogic.json` definition. Field values are raw TS types (e.g. "string",
+ * "number", "boolean", "string[]", "unknown") so the client is flexible. */
+export interface ServerLogicDefinition {
+  /** The Server Logic name — the `/_api/serverlogics/<name>` resource. */
+  name: string;
+  description?: string;
+  /** HTTP verb the logic handles (its top-level get()/post()/…). Defaults to POST. */
+  method?: ServerLogicMethod;
+  /** Request fields → TS type. */
+  request?: Record<string, string>;
+  /** Response fields → TS type. */
+  response?: Record<string, string>;
+}
+
+export const SERVER_LOGIC_FILE_SUFFIX = ".serverlogic.json";
+
+function pascal(name: string): string {
+  const cleaned = name.replace(/[^A-Za-z0-9]+(.)?/g, (_m, c: string | undefined) => (c ? c.toUpperCase() : ""));
+  return cleaned.charAt(0).toUpperCase() + cleaned.slice(1);
+}
+
+function camel(name: string): string {
+  const p = pascal(name);
+  return p.charAt(0).toLowerCase() + p.slice(1);
+}
+
+function fields(record: Record<string, string> | undefined, fallbackComment: string): string {
+  const entries = Object.entries(record ?? {});
+  if (entries.length === 0) {
+    return `  ${fallbackComment}`;
+  }
+  return entries.map(([key, type]) => `  ${key}: ${type};`).join("\n");
+}
+
+/** Seed a minimal valid definition. Field names are PascalCase by convention. */
+export function newServerLogicDefinition(name: string): ServerLogicDefinition {
+  /* eslint-disable @typescript-eslint/naming-convention */
+  return {
+    name,
+    description: "",
+    method: "POST",
+    request: { InputValue: "string" },
+    response: { OutputValue: "string" },
+  };
+  /* eslint-enable @typescript-eslint/naming-convention */
+}
+
+/** Generate the typed TS client module for a Server Logic definition. */
+export function generateServerLogicClient(def: ServerLogicDefinition): string {
+  const type = pascal(def.name);
+  const fn = camel(def.name);
+  const method = def.method ?? "POST";
+  const sendsBody = method !== "GET" && method !== "DELETE";
+
+  return `// Auto-generated typed client for the "${def.name}" Power Pages Server Logic.
+// Regenerate from ${def.name}${SERVER_LOGIC_FILE_SUFFIX} when the definition changes.
+// Requires the Power Pages shell (shell.safeAjax handles the CSRF token).
+
+/* eslint-disable */
+declare const shell: any;
+
+export interface ${type}Request {
+${fields(def.request, "// (no request fields)")}
+}
+
+export interface ${type}Response {
+${fields(def.response, "// (no response fields)")}
+}
+
+/** Call the "${def.name}" Server Logic (${method} /_api/serverlogics/${def.name}). */
+export function ${fn}(request: ${type}Request): Promise<${type}Response> {
+  return new Promise<${type}Response>((resolve, reject) => {
+    shell.safeAjax({
+      type: "${method}",
+      url: "/_api/serverlogics/${def.name}",
+      contentType: "application/json",${sendsBody ? "\n      data: JSON.stringify(request)," : ""}
+      success: (response: ${type}Response) => resolve(response),
+      error: (xhr: unknown) => reject(xhr),
+    });
+  });
+}
+`;
+}
+
+/** Output file name for a definition's generated client. */
+export function serverLogicClientFileName(def: ServerLogicDefinition): string {
+  return `${def.name}.client.ts`;
+}

--- a/src/portals/serverLogicClientCommand.ts
+++ b/src/portals/serverLogicClientCommand.ts
@@ -1,0 +1,64 @@
+// Command: generate a typed front-end client from a `*.serverlogic.json` definition
+// (#150 #4). Open the definition and run it — writes `<name>.client.ts` next to it,
+// ready to import from a portal web file / PCF control for typed `shell.safeAjax`
+// calls. Registered once, globally. Pure codegen lives in serverLogicClient.ts.
+
+import * as vscode from "vscode";
+import * as fs from "fs";
+import * as path from "path";
+import DataversePowerToolsContext from "../context";
+import { SERVER_LOGIC_FILE_SUFFIX, ServerLogicDefinition, generateServerLogicClient, serverLogicClientFileName, newServerLogicDefinition } from "./serverLogicClient";
+
+export function registerServerLogicClient(context: DataversePowerToolsContext): void {
+  context.vscode.subscriptions.push(vscode.commands.registerCommand("dataverse-powertools.generateServerLogicClient", () => generateFromActive(context)));
+  context.vscode.subscriptions.push(vscode.commands.registerCommand("dataverse-powertools.newServerLogicDefinition", () => scaffold(context)));
+}
+
+async function scaffold(context: DataversePowerToolsContext): Promise<void> {
+  const folders = vscode.workspace.workspaceFolders;
+  if (!folders || folders.length === 0) {
+    vscode.window.showErrorMessage("Open a folder first.");
+    return;
+  }
+  const name = await vscode.window.showInputBox({
+    prompt: "Server Logic name (the /_api/serverlogics/<name> resource).",
+    validateInput: (v) => (/^[A-Za-z][A-Za-z0-9_]*$/.test(v.trim()) ? undefined : "Start with a letter; letters, digits and underscores only."),
+  });
+  if (!name) {
+    return;
+  }
+  const filePath = path.join(folders[0].uri.fsPath, `${name.trim()}${SERVER_LOGIC_FILE_SUFFIX}`);
+  if (fs.existsSync(filePath)) {
+    vscode.window.showErrorMessage(`${path.basename(filePath)} already exists.`);
+    return;
+  }
+  fs.writeFileSync(filePath, JSON.stringify(newServerLogicDefinition(name.trim()), null, 2) + "\n", "utf8");
+  context.channel.appendLine(`Created Server Logic definition: ${filePath}`);
+  await vscode.window.showTextDocument(await vscode.workspace.openTextDocument(vscode.Uri.file(filePath)));
+}
+
+async function generateFromActive(context: DataversePowerToolsContext): Promise<void> {
+  const editor = vscode.window.activeTextEditor;
+  if (!editor || !editor.document.fileName.toLowerCase().endsWith(SERVER_LOGIC_FILE_SUFFIX)) {
+    vscode.window.showInformationMessage(`Open a ${SERVER_LOGIC_FILE_SUFFIX} definition, or run "New Server Logic definition" first.`);
+    return;
+  }
+
+  let def: ServerLogicDefinition;
+  try {
+    def = JSON.parse(editor.document.getText()) as ServerLogicDefinition;
+  } catch (error) {
+    vscode.window.showErrorMessage(`${path.basename(editor.document.fileName)} is not valid JSON: ${(error as Error).message}`);
+    return;
+  }
+  if (!def.name || !/^[A-Za-z][A-Za-z0-9_]*$/.test(def.name)) {
+    vscode.window.showErrorMessage("The definition needs a valid 'name' (letter, then letters/digits/underscores).");
+    return;
+  }
+
+  const outPath = path.join(path.dirname(editor.document.fileName), serverLogicClientFileName(def));
+  fs.writeFileSync(outPath, generateServerLogicClient(def), "utf8");
+  context.channel.appendLine(`Generated Server Logic client: ${outPath}`);
+  await vscode.window.showTextDocument(await vscode.workspace.openTextDocument(vscode.Uri.file(outPath)));
+  vscode.window.showInformationMessage(`Generated ${path.basename(outPath)} — copy it into your portal front-end / PCF project.`);
+}


### PR DESCRIPTION
Portals (#150) issue #4 — end-to-end typing. `New Server Logic definition` seeds a `*.serverlogic.json`; `Generate Server Logic client` emits a typed Request/Response + `shell.safeAjax` wrapper for `/_api/serverlogics/<name>` (CSRF handled, GET/DELETE omit body). Pure codegen, 6 tests. **670/670**. Design: v1 uses a small definition file (shareable with the handler) rather than TS-handler inference. Pre-release: live-site round-trip unverified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)