### PR TITLE
0.14.20 (pre-release) — Azure Functions send-test-context (#145 #7)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 All notable changes to the "dataverse-powertools" extension will be documented in this file.
 
+## 0.14.20 (pre-release)
+
+Azure Functions (#145) — **Send test context** (issue #7), the local inner loop for webhook functions.
+
+- **Send test RemoteExecutionContext to local function** builds a sample Dataverse webhook payload — a `RemoteExecutionContext` in the platform's **exact documented DataContractJson wire format** (typed `InputParameters["Target"]` entity with the `__type` discriminator, `/Date(ms)/` timestamps, all top-level fields) — and POSTs it to your locally-running function (`func start`), so you can exercise the typed handler without a live Dataverse trigger. Prompts for the function name, message, and primary entity. The payload builder is pure + unit-tested against the documented shape (5 tests), so `ReadRemoteExecutionContextAsync` deserializes it correctly.
+
+> This closes the last v1-core-adjacent gap in #145 — earlier deferred because I wouldn't hand-generate the payload blind; the shape is now taken verbatim from the [official webhook docs](https://learn.microsoft.com/power-apps/developer/data-platform/use-webhooks). Requires the local host running (`Run locally (func start)`).
+
 ## 0.14.19 (pre-release)
 
 Power Pages / Portals (#150) — **portal-wide build** (issues #1 + #2 together), on the portal card.

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "type": "git",
     "url": "https://github.com/pete-mc/dataverse-powertools"
   },
-  "version": "0.14.19",
+  "version": "0.14.20",
   "engines": {
     "vscode": "^1.95.0"
   },
@@ -786,6 +786,11 @@
       {
         "command": "dataverse-powertools.startAzureFunctionHost",
         "title": "Dataverse PowerTools: Run Azure Function locally (func start)",
+        "enablement": "dataverse-powertools.showLoaded && dataverse-powertools.isAzureFunction"
+      },
+      {
+        "command": "dataverse-powertools.sendTestContext",
+        "title": "Dataverse PowerTools: Send test RemoteExecutionContext to local function",
         "enablement": "dataverse-powertools.showLoaded && dataverse-powertools.isAzureFunction"
       },
       {

--- a/src/azurefunction/sampleContext.spec.ts
+++ b/src/azurefunction/sampleContext.spec.ts
@@ -1,0 +1,48 @@
+import { describe, it, expect } from "vitest";
+import { buildSampleRemoteExecutionContext } from "./sampleContext";
+
+describe("buildSampleRemoteExecutionContext", () => {
+  const ctx = buildSampleRemoteExecutionContext({ messageName: "Create", primaryEntityName: "account", targetAttributes: { name: "Contoso" }, timestampMs: 1000 });
+
+  it("sets the top-level context fields per the documented wire format", () => {
+    expect(ctx.MessageName).toBe("Create");
+    expect(ctx.PrimaryEntityName).toBe("account");
+    expect(ctx.Stage).toBe(40);
+    expect(ctx.Mode).toBe(1);
+    expect(ctx.OperationCreatedOn).toBe("/Date(1000)/");
+    expect(ctx.ParentContext).toBeNull();
+  });
+
+  it("shapes InputParameters as a KeyValuePair array with a typed Target entity", () => {
+    const input = ctx.InputParameters as { key: string; value: Record<string, unknown> }[];
+    expect(input).toHaveLength(1);
+    expect(input[0].key).toBe("Target");
+    const target = input[0].value;
+    expect(target.__type).toBe("Entity:http://schemas.microsoft.com/xrm/2011/Contracts");
+    expect(target.LogicalName).toBe("account");
+    expect(target.Attributes).toEqual([{ key: "name", value: "Contoso" }]);
+  });
+
+  it("defaults stage/mode and empty images/params", () => {
+    const c = buildSampleRemoteExecutionContext({ messageName: "Update", primaryEntityName: "contact" });
+    expect(c.Stage).toBe(40);
+    expect(c.Mode).toBe(1);
+    expect(c.PreEntityImages).toEqual([]);
+    expect(c.PostEntityImages).toEqual([]);
+    expect(c.OutputParameters).toEqual([]);
+    expect((c.InputParameters as { value: Record<string, unknown> }[])[0].value.Attributes).toEqual([]);
+  });
+
+  it("honours an overridden stage/mode (e.g. synchronous pre-op)", () => {
+    const c = buildSampleRemoteExecutionContext({ messageName: "Create", primaryEntityName: "account", stage: 20, mode: 0 });
+    expect(c.Stage).toBe(20);
+    expect(c.Mode).toBe(0);
+  });
+
+  it("uses valid GUID placeholders", () => {
+    const guid = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/;
+    expect(ctx.OrganizationId).toMatch(guid);
+    expect(ctx.UserId).toMatch(guid);
+    expect(ctx.PrimaryEntityId).toMatch(guid);
+  });
+});

--- a/src/azurefunction/sampleContext.ts
+++ b/src/azurefunction/sampleContext.ts
@@ -1,0 +1,86 @@
+// Pure builder for a sample Dataverse webhook payload — a `RemoteExecutionContext`
+// in the exact DataContractJson wire format the platform POSTs (#145 #7). This is
+// what the scaffolded function's `ReadRemoteExecutionContextAsync` deserializes,
+// so a locally-POSTed sample exercises the real handler without a live trigger.
+// Format is taken verbatim from the official docs:
+//   https://learn.microsoft.com/power-apps/developer/data-platform/use-webhooks
+// No `vscode` import → unit-tested.
+
+/* eslint-disable @typescript-eslint/naming-convention */
+
+export interface SampleContextOptions {
+  messageName: string;
+  primaryEntityName: string;
+  /** Target entity attributes (logical name → value). */
+  targetAttributes?: Record<string, unknown>;
+  /** Pipeline stage — 40 = PostOperation (default). */
+  stage?: number;
+  /** Execution mode — 1 = Asynchronous (default), 0 = Synchronous. */
+  mode?: number;
+  /** Epoch ms for the date fields (deterministic; default 0). */
+  timestampMs?: number;
+}
+
+// DataContractJson type discriminators the SDK emits.
+const ENTITY_TYPE = "Entity:http://schemas.microsoft.com/xrm/2011/Contracts";
+
+// Fixed, valid-hex placeholder GUIDs (a test trigger doesn't need real ids).
+const PRIMARY_ID = "11111111-1111-1111-1111-111111111111";
+const USER_ID = "22222222-2222-2222-2222-222222222222";
+const BUSINESS_UNIT_ID = "33333333-3333-3333-3333-333333333333";
+const ORG_ID = "44444444-4444-4444-4444-444444444444";
+const STEP_ID = "55555555-5555-5555-5555-555555555555";
+
+function attributeArray(attributes: Record<string, unknown>): { key: string; value: unknown }[] {
+  return Object.entries(attributes).map(([key, value]) => ({ key, value }));
+}
+
+function entity(logicalName: string, id: string, attributes: Record<string, unknown>): Record<string, unknown> {
+  return {
+    __type: ENTITY_TYPE,
+    Attributes: attributeArray(attributes),
+    EntityState: null,
+    FormattedValues: [],
+    Id: id,
+    KeyAttributes: [],
+    LogicalName: logicalName,
+    RelatedEntities: [],
+    RowVersion: null,
+  };
+}
+
+/** Build a sample `RemoteExecutionContext` JSON object in the platform's wire format. */
+export function buildSampleRemoteExecutionContext(opts: SampleContextOptions): Record<string, unknown> {
+  const date = `/Date(${opts.timestampMs ?? 0})/`;
+  const target = entity(opts.primaryEntityName, PRIMARY_ID, opts.targetAttributes ?? {});
+
+  return {
+    BusinessUnitId: BUSINESS_UNIT_ID,
+    CorrelationId: "66666666-6666-6666-6666-666666666666",
+    Depth: 1,
+    InitiatingUserId: USER_ID,
+    InputParameters: [{ key: "Target", value: target }],
+    IsExecutingOffline: false,
+    IsInTransaction: false,
+    IsOfflinePlayback: false,
+    IsolationMode: 1,
+    MessageName: opts.messageName,
+    Mode: opts.mode ?? 1,
+    OperationCreatedOn: date,
+    OperationId: "77777777-7777-7777-7777-777777777777",
+    OrganizationId: ORG_ID,
+    OrganizationName: "SampleOrg",
+    OutputParameters: [],
+    OwningExtension: { Id: STEP_ID, KeyAttributes: [], LogicalName: "sdkmessageprocessingstep", Name: null, RowVersion: null },
+    ParentContext: null,
+    PostEntityImages: [],
+    PreEntityImages: [],
+    PrimaryEntityId: PRIMARY_ID,
+    PrimaryEntityName: opts.primaryEntityName,
+    RequestId: null,
+    SecondaryEntityName: "none",
+    SharedVariables: [],
+    Stage: opts.stage ?? 40,
+    UserId: USER_ID,
+  };
+}

--- a/src/azurefunction/sendTestContext.ts
+++ b/src/azurefunction/sendTestContext.ts
@@ -1,0 +1,60 @@
+// Command: send a sample Dataverse webhook (RemoteExecutionContext) to the local
+// Functions host (#145 #7) — the inner loop without a live trigger. Run the host
+// first with "Run locally (func start)". Builds a docs-accurate payload
+// (sampleContext.ts) and POSTs it to http://localhost:<port>/api/<function>.
+
+import fetch from "node-fetch";
+import * as vscode from "vscode";
+import DataversePowerToolsContext from "../context";
+import { buildSampleRemoteExecutionContext } from "./sampleContext";
+
+export async function sendTestContext(context: DataversePowerToolsContext): Promise<void> {
+  const functionName = await vscode.window.showInputBox({
+    prompt: "Function name (the route after /api/ on the local host).",
+    placeHolder: "OnAccountCreate",
+    validateInput: (v) => (v.trim() ? undefined : "Enter the function name."),
+  });
+  if (!functionName) {
+    return;
+  }
+
+  const url = await vscode.window.showInputBox({
+    prompt: "Local function URL",
+    value: `http://localhost:7071/api/${functionName.trim()}`,
+  });
+  if (!url) {
+    return;
+  }
+
+  const messageName = (await vscode.window.showInputBox({ prompt: "Message name", value: "Create" }))?.trim();
+  if (messageName === undefined) {
+    return;
+  }
+  const primaryEntityName = (await vscode.window.showInputBox({ prompt: "Primary entity logical name", value: "account" }))?.trim();
+  if (primaryEntityName === undefined) {
+    return;
+  }
+
+  const payload = buildSampleRemoteExecutionContext({ messageName: messageName || "Create", primaryEntityName: primaryEntityName || "account", timestampMs: 0 });
+
+  context.channel.show(true);
+  context.channel.appendLine(`\nPOST ${url}  (sample ${messageName} of ${primaryEntityName})`);
+  try {
+    const response = await vscode.window.withProgress({ location: vscode.ProgressLocation.Notification, title: "Sending test context…" }, async () => {
+      /* eslint-disable @typescript-eslint/naming-convention */
+      return fetch(url, { method: "POST", headers: { "Content-Type": "application/json" }, body: JSON.stringify(payload) } as never);
+      /* eslint-enable @typescript-eslint/naming-convention */
+    });
+
+    const body = await response.text();
+    context.channel.appendLine(`→ ${response.status} ${response.statusText}${body ? `\n${body}` : ""}`);
+    if (response.ok) {
+      vscode.window.showInformationMessage(`Test context sent — ${response.status}.`);
+    } else {
+      vscode.window.showWarningMessage(`Function returned ${response.status}. See the Dataverse PowerTools output.`);
+    }
+  } catch (error) {
+    context.channel.appendLine(`Could not reach ${url}: ${(error as Error).message}`);
+    vscode.window.showErrorMessage("Could not reach the local function. Start it first with 'Run locally (func start)'.");
+  }
+}

--- a/src/projectTypes/activation.ts
+++ b/src/projectTypes/activation.ts
@@ -60,6 +60,7 @@ import { registerWebhookStep } from "../azurefunction/registerWebhookStep";
 import { generateAzureFunctionEarlyBound } from "../azurefunction/generateAzureFunctionEarlyBound";
 import { deployAzureFunctionGuide } from "../azurefunction/deployAzureFunctionGuide";
 import { publishAzureFunctionToAzure, startAzureFunctionHost } from "../azurefunction/funcCommands";
+import { sendTestContext } from "../azurefunction/sendTestContext";
 import { promptAndScaffoldTrigger } from "../azurefunction/scaffoldTrigger";
 
 type CommandImpl = (context: DataversePowerToolsContext, resourceUri?: vscode.Uri) => unknown;
@@ -323,6 +324,7 @@ export const projectTypeActivations: Record<ProjectTypes, ProjectTypeActivation>
       "dataverse-powertools.deployAzureFunctionGuide": (context) => deployAzureFunctionGuide(context),
       "dataverse-powertools.publishAzureFunction": (context) => publishAzureFunctionToAzure(context),
       "dataverse-powertools.startAzureFunctionHost": (context) => startAzureFunctionHost(context),
+      "dataverse-powertools.sendTestContext": (context) => sendTestContext(context),
     },
     // A function component isn't necessarily a Dataverse webhook (#145) — ask how it's
     // triggered and scaffold only that sample handler. The template ships the shared

--- a/src/projectTypes/registry.ts
+++ b/src/projectTypes/registry.ts
@@ -300,6 +300,7 @@ export const projectTypeRegistry: readonly ProjectTypeDescriptor[] = [
       `${prefix}deployAzureFunctionGuide`,
       `${prefix}publishAzureFunction`,
       `${prefix}startAzureFunctionHost`,
+      `${prefix}sendTestContext`,
     ],
     menu(state) {
       // A function component need not be a Dataverse webhook (#145) — it may be a plain HTTP
@@ -315,6 +316,7 @@ export const projectTypeRegistry: readonly ProjectTypeDescriptor[] = [
         secondary: [...(webhook ? [build] : [register]), { command: `${prefix}generateAzureFunctionEarlyBound`, label: "Generate Earlybound" }],
         overflow: [
           { command: `${prefix}startAzureFunctionHost`, label: "Run locally (func start)" },
+          { command: `${prefix}sendTestContext`, label: "Send test context (local)" },
           { command: `${prefix}publishAzureFunction`, label: "Publish to Azure (func)" },
           { command: `${prefix}deployAzureFunctionGuide`, label: "Deploy to Azure…" },
         ],


### PR DESCRIPTION
## What & why
Azure Functions (#145) issue #7 — the local inner loop. **Send test RemoteExecutionContext** builds a sample Dataverse webhook payload and POSTs it to the locally-running function, exercising the typed handler without a live trigger.

## The key point
I earlier deferred this as "the DataContractJsonSerializer payload shape can't be verified without a live host." I researched the [official webhook docs](https://learn.microsoft.com/power-apps/developer/data-platform/use-webhooks), which give the **exact serialized JSON** — so the payload is now **grounded, not guessed**: `InputParameters` as a `{key,value}` array with a `Target` entity carrying the `__type` discriminator, `/Date(ms)/` timestamps, and every top-level field. This is precisely what the scaffold's `ReadRemoteExecutionContextAsync` deserializes.

## Changes
- `src/azurefunction/sampleContext.ts` (5 tests) — pure `buildSampleRemoteExecutionContext` in the documented wire format.
- `src/azurefunction/sendTestContext.ts` — command: prompt (function / message / entity) → POST to `http://localhost:7071/api/<function>` → show the response.
- Wired onto the Functions card overflow (registry/activation/package.json parity green).

## Verification
`lint` clean · `compile` clean · `test:coverage` **680/680** (+5). Requires the local host running (`func start`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)