### PR TITLE
0.14.21 (pre-release) — typed portal Web API client (#150 #4)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 All notable changes to the "dataverse-powertools" extension will be documented in this file.
 
+## 0.14.21 (pre-release)
+
+Power Pages / Portals (#150) — **typed portal Web API client** (issue #4, second half). Completes the end-to-end typing story: portal JS hitting Dataverse tables gets IntelliSense instead of untyped string-bashing.
+
+- **New portal Web API definition** seeds a `*.portalapi.json` (entity set + typed fields). **Generate portal Web API client** emits `<entitySet>.webapi.ts` — a typed record interface plus `create`/`retrieve`/`retrieveMultiple`/`update`/`delete` helpers over the documented portal Web API (`webapi.safeAjax` — the CSRF wrapper — against `/_api/<entitySet>`, with `create` returning the new record id from the `entityid` header). Pure codegen, 6 unit tests.
+
+> The `webapi.safeAjax` pattern + verbs/URLs are taken verbatim from the [official portal Web API docs](https://learn.microsoft.com/power-pages/configure/write-update-delete-operations) — I earlier deferred this thinking the CSRF mechanism was undocumented; it isn't. With the Server Logic client (0.14.18), **both** typed-caller halves of #150 #4 now exist. Pre-release: not yet exercised against a live site.
+
 ## 0.14.20 (pre-release)
 
 Azure Functions (#145) — **Send test context** (issue #7), the local inner loop for webhook functions.

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "type": "git",
     "url": "https://github.com/pete-mc/dataverse-powertools"
   },
-  "version": "0.14.20",
+  "version": "0.14.21",
   "engines": {
     "vscode": "^1.95.0"
   },
@@ -706,6 +706,15 @@
       {
         "command": "dataverse-powertools.generateServerLogicClient",
         "title": "Dataverse PowerTools: Generate Power Pages Server Logic client",
+        "enablement": "resourceExtname == .json"
+      },
+      {
+        "command": "dataverse-powertools.newPortalWebApiDefinition",
+        "title": "Dataverse PowerTools: New portal Web API definition"
+      },
+      {
+        "command": "dataverse-powertools.generatePortalWebApiClient",
+        "title": "Dataverse PowerTools: Generate portal Web API client",
         "enablement": "resourceExtname == .json"
       },
       {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -14,6 +14,7 @@ import { registerServerLogicLint } from "./portals/lintServerLogicCommand";
 import { registerServerLogicBuild } from "./portals/buildServerLogicCommand";
 import { registerPortalFrontendBuild } from "./portals/buildPortalFrontendCommand";
 import { registerServerLogicClient } from "./portals/serverLogicClientCommand";
+import { registerPortalWebApiClient } from "./portals/portalWebApiClientCommand";
 import { registerMenuPanel } from "./panel/menuPanel";
 import { refreshPanelData } from "./panel/panelDataCache";
 import { registerSystemRequirementCommands } from "./general/systemRequirements";
@@ -40,6 +41,7 @@ export async function activate(vscodeContext: vscode.ExtensionContext) {
   registerServerLogicBuild(context);
   registerPortalFrontendBuild(context);
   registerServerLogicClient(context);
+  registerPortalWebApiClient(context);
   // Class-decoration / filtering-attribute / per-step-profiling CodeLens on plugin .cs files. Registered
   // ONCE here (its commands + provider are global) — never per plugin component, or a
   // second plugin component's initialise throws "command … already exists" (#47).

--- a/src/portals/portalWebApiClient.spec.ts
+++ b/src/portals/portalWebApiClient.spec.ts
@@ -1,0 +1,51 @@
+import { describe, it, expect } from "vitest";
+import { generatePortalWebApiClient, newPortalWebApiDefinition, defaultTypeName, portalWebApiClientFileName, PortalWebApiDefinition } from "./portalWebApiClient";
+
+describe("defaultTypeName", () => {
+  it("singularises the entity set", () => {
+    expect(defaultTypeName("accounts")).toBe("Account");
+    expect(defaultTypeName("opportunities")).toBe("Opportunity");
+    expect(defaultTypeName("contacts")).toBe("Contact");
+  });
+});
+
+describe("newPortalWebApiDefinition / file name", () => {
+  it("seeds a definition and derives the file name", () => {
+    const def = newPortalWebApiDefinition("accounts");
+    expect(def).toMatchObject({ entitySet: "accounts", typeName: "Account" });
+    expect(portalWebApiClientFileName(def)).toBe("accounts.webapi.ts");
+  });
+});
+
+describe("generatePortalWebApiClient", () => {
+  const def: PortalWebApiDefinition = { entitySet: "accounts", typeName: "Account", fields: { name: "string", revenue: "number" } };
+  const code = generatePortalWebApiClient(def);
+
+  it("emits a typed record interface", () => {
+    expect(code).toContain("export interface Account");
+    expect(code).toContain("name?: string;");
+    expect(code).toContain("revenue?: number;");
+  });
+
+  it("emits CRUD helpers using webapi.safeAjax against /_api/<entityset>", () => {
+    expect(code).toContain('url: "/_api/accounts"');
+    expect(code).toContain("export function createAccount(record: Account): Promise<string>");
+    expect(code).toContain("export function retrieveAccount(id: string, select?: string): Promise<Account>");
+    expect(code).toContain("export function updateAccount(id: string, record: Account): Promise<void>");
+    expect(code).toContain("export function deleteAccount(id: string): Promise<void>");
+    expect(code).toContain("webapi.safeAjax");
+  });
+
+  it("uses the documented verbs for each operation", () => {
+    expect(code).toContain('type: "POST"');
+    expect(code).toContain('type: "PATCH"');
+    expect(code).toContain('type: "DELETE"');
+    expect(code).toContain('xhr.getResponseHeader("entityid")'); // create returns the new id
+  });
+
+  it("falls back to an index signature when no fields are given", () => {
+    const bare = generatePortalWebApiClient({ entitySet: "widgets" });
+    expect(bare).toContain("[field: string]: unknown;");
+    expect(bare).toContain("export interface Widget");
+  });
+});

--- a/src/portals/portalWebApiClient.ts
+++ b/src/portals/portalWebApiClient.ts
@@ -1,0 +1,131 @@
+// Pure codegen for a typed portal Web API client (#150, issue #4 — typed Portal
+// Web API). A `*.portalapi.json` definition (entity set + typed fields) generates
+// typed CRUD helpers over the documented portal Web API — `webapi.safeAjax` (the
+// CSRF wrapper) against `/_api/<entityset>` — so portal JS hitting Dataverse tables
+// gets IntelliSense instead of untyped string-bashing. Pattern is verbatim from:
+//   https://learn.microsoft.com/power-pages/configure/write-update-delete-operations
+//   https://learn.microsoft.com/power-pages/configure/web-api-http-requests-handle-errors
+// No `vscode` import → unit-tested.
+
+export interface PortalWebApiDefinition {
+  /** The Dataverse entity set name, e.g. "accounts" — the `/_api/<entitySet>` path. */
+  entitySet: string;
+  /** The generated record interface name, e.g. "Account". Defaults from entitySet. */
+  typeName?: string;
+  /** Field logical name → TS type (e.g. "string", "number", "boolean"). */
+  fields?: Record<string, string>;
+}
+
+export const PORTAL_API_FILE_SUFFIX = ".portalapi.json";
+
+function pascal(name: string): string {
+  const cleaned = name.replace(/[^A-Za-z0-9]+(.)?/g, (_m, c: string | undefined) => (c ? c.toUpperCase() : ""));
+  return cleaned.charAt(0).toUpperCase() + cleaned.slice(1);
+}
+
+/** Default a record type name from an entity set (drop a trailing plural "s"). */
+export function defaultTypeName(entitySet: string): string {
+  const singular = entitySet.replace(/ies$/i, "y").replace(/s$/i, "");
+  return pascal(singular || entitySet);
+}
+
+export function newPortalWebApiDefinition(entitySet: string): PortalWebApiDefinition {
+  return { entitySet, typeName: defaultTypeName(entitySet), fields: { name: "string" } };
+}
+
+function fieldLines(fields: Record<string, string> | undefined): string {
+  const entries = Object.entries(fields ?? {});
+  if (entries.length === 0) {
+    return "  [field: string]: unknown;";
+  }
+  return entries.map(([key, type]) => `  ${key}?: ${type};`).join("\n");
+}
+
+/** Generate the typed portal Web API CRUD client module for a definition. */
+export function generatePortalWebApiClient(def: PortalWebApiDefinition): string {
+  const type = def.typeName ? pascal(def.typeName) : defaultTypeName(def.entitySet);
+  const set = def.entitySet;
+
+  return `// Auto-generated typed portal Web API client for "${set}".
+// Regenerate from ${set}${PORTAL_API_FILE_SUFFIX} when the definition changes.
+// Uses the portal Web API wrapper 'webapi.safeAjax' (handles the CSRF token).
+
+/* eslint-disable */
+declare const webapi: any;
+
+export interface ${type} {
+${fieldLines(def.fields)}
+}
+
+/** Create a ${type}; resolves with the new record's id. */
+export function create${type}(record: ${type}): Promise<string> {
+  return new Promise<string>((resolve, reject) => {
+    webapi.safeAjax({
+      type: "POST",
+      url: "/_api/${set}",
+      contentType: "application/json",
+      data: JSON.stringify(record),
+      success: (_res: unknown, _status: unknown, xhr: { getResponseHeader(name: string): string }) => resolve(xhr.getResponseHeader("entityid")),
+      error: (xhr: unknown) => reject(xhr),
+    });
+  });
+}
+
+/** Retrieve a single ${type} by id (optionally an OData \\$select). */
+export function retrieve${type}(id: string, select?: string): Promise<${type}> {
+  return new Promise<${type}>((resolve, reject) => {
+    webapi.safeAjax({
+      type: "GET",
+      url: "/_api/${set}(" + id + ")" + (select ? "?\\$select=" + select : ""),
+      contentType: "application/json",
+      success: (res: ${type}) => resolve(res),
+      error: (xhr: unknown) => reject(xhr),
+    });
+  });
+}
+
+/** Retrieve multiple ${type} records (pass an OData query, e.g. "?\\$select=name&\\$top=10"). */
+export function retrieveMultiple${type}(query = ""): Promise<{ value: ${type}[] }> {
+  return new Promise<{ value: ${type}[] }>((resolve, reject) => {
+    webapi.safeAjax({
+      type: "GET",
+      url: "/_api/${set}" + query,
+      contentType: "application/json",
+      success: (res: { value: ${type}[] }) => resolve(res),
+      error: (xhr: unknown) => reject(xhr),
+    });
+  });
+}
+
+/** Update a ${type} by id (partial). */
+export function update${type}(id: string, record: ${type}): Promise<void> {
+  return new Promise<void>((resolve, reject) => {
+    webapi.safeAjax({
+      type: "PATCH",
+      url: "/_api/${set}(" + id + ")",
+      contentType: "application/json",
+      data: JSON.stringify(record),
+      success: () => resolve(),
+      error: (xhr: unknown) => reject(xhr),
+    });
+  });
+}
+
+/** Delete a ${type} by id. */
+export function delete${type}(id: string): Promise<void> {
+  return new Promise<void>((resolve, reject) => {
+    webapi.safeAjax({
+      type: "DELETE",
+      url: "/_api/${set}(" + id + ")",
+      contentType: "application/json",
+      success: () => resolve(),
+      error: (xhr: unknown) => reject(xhr),
+    });
+  });
+}
+`;
+}
+
+export function portalWebApiClientFileName(def: PortalWebApiDefinition): string {
+  return `${def.entitySet}.webapi.ts`;
+}

--- a/src/portals/portalWebApiClientCommand.ts
+++ b/src/portals/portalWebApiClientCommand.ts
@@ -1,0 +1,63 @@
+// Commands: scaffold a `*.portalapi.json` definition and generate a typed portal
+// Web API client from it (#150 #4). Mirrors the Server Logic client commands.
+// Registered once, globally. Pure codegen in portalWebApiClient.ts.
+
+import * as vscode from "vscode";
+import * as fs from "fs";
+import * as path from "path";
+import DataversePowerToolsContext from "../context";
+import { PORTAL_API_FILE_SUFFIX, PortalWebApiDefinition, generatePortalWebApiClient, portalWebApiClientFileName, newPortalWebApiDefinition } from "./portalWebApiClient";
+
+export function registerPortalWebApiClient(context: DataversePowerToolsContext): void {
+  context.vscode.subscriptions.push(vscode.commands.registerCommand("dataverse-powertools.generatePortalWebApiClient", () => generateFromActive(context)));
+  context.vscode.subscriptions.push(vscode.commands.registerCommand("dataverse-powertools.newPortalWebApiDefinition", () => scaffold(context)));
+}
+
+async function scaffold(context: DataversePowerToolsContext): Promise<void> {
+  const folders = vscode.workspace.workspaceFolders;
+  if (!folders || folders.length === 0) {
+    vscode.window.showErrorMessage("Open a folder first.");
+    return;
+  }
+  const entitySet = await vscode.window.showInputBox({
+    prompt: "Dataverse entity set name (the /_api/<entitySet> path, e.g. accounts).",
+    validateInput: (v) => (/^[a-z][a-z0-9_]*$/.test(v.trim()) ? undefined : "Lower-case entity set name (e.g. accounts, contacts)."),
+  });
+  if (!entitySet) {
+    return;
+  }
+  const filePath = path.join(folders[0].uri.fsPath, `${entitySet.trim()}${PORTAL_API_FILE_SUFFIX}`);
+  if (fs.existsSync(filePath)) {
+    vscode.window.showErrorMessage(`${path.basename(filePath)} already exists.`);
+    return;
+  }
+  fs.writeFileSync(filePath, JSON.stringify(newPortalWebApiDefinition(entitySet.trim()), null, 2) + "\n", "utf8");
+  context.channel.appendLine(`Created portal Web API definition: ${filePath}`);
+  await vscode.window.showTextDocument(await vscode.workspace.openTextDocument(vscode.Uri.file(filePath)));
+}
+
+async function generateFromActive(context: DataversePowerToolsContext): Promise<void> {
+  const editor = vscode.window.activeTextEditor;
+  if (!editor || !editor.document.fileName.toLowerCase().endsWith(PORTAL_API_FILE_SUFFIX)) {
+    vscode.window.showInformationMessage(`Open a ${PORTAL_API_FILE_SUFFIX} definition, or run "New Portal Web API definition" first.`);
+    return;
+  }
+
+  let def: PortalWebApiDefinition;
+  try {
+    def = JSON.parse(editor.document.getText()) as PortalWebApiDefinition;
+  } catch (error) {
+    vscode.window.showErrorMessage(`${path.basename(editor.document.fileName)} is not valid JSON: ${(error as Error).message}`);
+    return;
+  }
+  if (!def.entitySet || !/^[a-z][a-z0-9_]*$/.test(def.entitySet)) {
+    vscode.window.showErrorMessage("The definition needs a valid lower-case 'entitySet' (e.g. accounts).");
+    return;
+  }
+
+  const outPath = path.join(path.dirname(editor.document.fileName), portalWebApiClientFileName(def));
+  fs.writeFileSync(outPath, generatePortalWebApiClient(def), "utf8");
+  context.channel.appendLine(`Generated portal Web API client: ${outPath}`);
+  await vscode.window.showTextDocument(await vscode.workspace.openTextDocument(vscode.Uri.file(outPath)));
+  vscode.window.showInformationMessage(`Generated ${path.basename(outPath)} — copy it into your portal front-end / PCF project.`);
+}


### PR DESCRIPTION
Portals (#150) #4 (second half) — typed **portal Web API** client. `New portal Web API definition` + `Generate portal Web API client` emit typed CRUD helpers over the documented `webapi.safeAjax` `/_api/<entitySet>` pattern (create returns the entityid header). Pure codegen, 6 tests. **686/686**. Pattern taken verbatim from the [portal Web API docs](https://learn.microsoft.com/power-pages/configure/write-update-delete-operations) — the CSRF wrapper was documented after all. With 0.14.18 (Server Logic client), both typed-caller halves of #150 #4 exist. Pre-release: live-site round-trip unverified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)