### PR TITLE
ci(#143 Move 5): nightly live-tier workflow (self-skips without secrets)

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -1,0 +1,52 @@
+# Nightly live-tier tests (#143 Move 5 — "get a subset into CI").
+#
+# Runs the cross-platform, headless LIVE suite (`npm run test:live`) on a schedule.
+# Every live spec self-skips when its inputs are absent (`const live = env ? describe
+# : describe.skip`), so with NO repository secrets this job is a clean no-op — it
+# only exercises Dataverse once the maintainer adds the secrets below. This keeps
+# the recurring flaky/expensive live coverage OUT of the per-PR gate (CI stays unit +
+# integration + UI) while still catching Dataverse-side regressions automatically.
+#
+# To enable: add these repository secrets (values from your sandbox/.env). Without
+# them the run passes with everything skipped.
+#   DVPT_TEST_CONNECTION_STRING  DVPT_TEST_TENANT_ID  DVPT_TEST_URL
+#   DVPT_TEST_CLIENT_ID          DVPT_TEST_CLIENT_SECRET
+#   DVPT_TEST_USERNAME           DVPT_TEST_PASSWORD   (interactive/OAuth suites)
+#
+# Windows-only paths (net48 profiler capture, Edge automation) are NOT run here —
+# those stay on the manual VM e2e. The suites gate themselves on platform / pac /
+# toolchain, so this ubuntu job runs only what it can.
+
+name: Nightly live tests
+
+on:
+  schedule:
+    - cron: "0 3 * * *" # 03:00 UTC daily
+  workflow_dispatch: {}
+
+concurrency:
+  group: nightly-live
+  cancel-in-progress: true
+
+jobs:
+  live:
+    name: Live Dataverse tests (self-skip without secrets)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 20
+          cache: npm
+      - name: Install dependencies
+        run: npm ci
+      - name: Live tests (skip cleanly if no creds are configured)
+        run: xvfb-run -a npm run test:live
+        env:
+          DVPT_TEST_CONNECTION_STRING: ${{ secrets.DVPT_TEST_CONNECTION_STRING }}
+          DVPT_TEST_TENANT_ID: ${{ secrets.DVPT_TEST_TENANT_ID }}
+          DVPT_TEST_URL: ${{ secrets.DVPT_TEST_URL }}
+          DVPT_TEST_CLIENT_ID: ${{ secrets.DVPT_TEST_CLIENT_ID }}
+          DVPT_TEST_CLIENT_SECRET: ${{ secrets.DVPT_TEST_CLIENT_SECRET }}
+          DVPT_TEST_USERNAME: ${{ secrets.DVPT_TEST_USERNAME }}
+          DVPT_TEST_PASSWORD: ${{ secrets.DVPT_TEST_PASSWORD }}


### PR DESCRIPTION
## What & why
#143 **Move 5** — "get a subset into CI." A new **Nightly live tests** workflow runs the cross-platform, headless live suite (`npm run test:live`) on a daily schedule (+ manual dispatch), so Dataverse-side regressions are caught automatically instead of only via the manual VM e2e.

## Safe by construction
Every live spec self-gates — `const live = env ? describe : describe.skip`. Verified locally with no creds: **27 pass / 15 skip / 0 fail** (exit 0). So with **no repository secrets this job is a clean no-op**; it only exercises Dataverse once the maintainer adds `DVPT_TEST_*` secrets (documented in the workflow header). This keeps the flaky/expensive live tier **out of the per-PR gate** (CI stays unit + integration + UI) — the audit's goal.

## Scope
- Not a version bump / publish — CI infra only, the shipped extension is unchanged.
- Windows-only paths (net48 profiler capture, Edge automation) stay on the manual VM e2e; the suites self-gate on platform / pac / toolchain, so the ubuntu job runs only what it can.
- The workflow triggers on `schedule`/`workflow_dispatch` only, so it doesn't run on this PR.

## Design decision (my call, per full authority)
Move 4 (trim/demote redundant e2e) is deliberately **not** in this PR: deleting live e2e I can't run risks silently dropping coverage — better done when the e2e can be executed to confirm the authoritative proof still passes. Move 5 (this) is purely additive and safe.

🤖 Generated with [Claude Code](https://claude.com/claude-code)