### PR TITLE
0.14.23 (pre-release) — PCF service-layer template ships a Jest test (#141/#150 #6)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to the "dataverse-powertools" extension will be documented in this file.
 
+## 0.14.23 (pre-release)
+
+PCF (#141) / testing (#150 #6) — the **service-layer template now ships with a Jest test**. **Add PCF service-layer structure** additionally writes `services/<Entity>Service.spec.ts` — a Jest unit test that exercises the service with a mocked `ComponentFramework.WebApi`, demonstrating that the domain layer is testable in isolation (no PCF host, no live Dataverse). This is the "service-layer templates have Jest tests" piece of the test story; the extension's existing Jest TestController (`parseJestJson`) then surfaces it once `npx jest` is wired in the control. +1 test.
+
 ## 0.14.22 (pre-release)
 
 PCF (#141) — the **service-layer template** (option 3, the opinionated structure), as a scaffold you can add to any control.

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "type": "git",
     "url": "https://github.com/pete-mc/dataverse-powertools"
   },
-  "version": "0.14.22",
+  "version": "0.14.23",
   "engines": {
     "vscode": "^1.95.0"
   },

--- a/src/pcf/pcfServiceLayer.spec.ts
+++ b/src/pcf/pcfServiceLayer.spec.ts
@@ -1,10 +1,17 @@
 import { describe, it, expect } from "vitest";
-import { serviceLayerFiles, serviceFileContent, hookFileContent, containerComponentContent, indexExampleContent } from "./pcfServiceLayer";
+import { serviceLayerFiles, serviceFileContent, serviceTestContent, hookFileContent, containerComponentContent, indexExampleContent } from "./pcfServiceLayer";
 
 describe("serviceLayerFiles", () => {
-  it("emits service, hook, list, container, and an index example (PascalCased entity)", () => {
+  it("emits service (+ its test), hook, list, container, and an index example (PascalCased entity)", () => {
     const paths = serviceLayerFiles("widget").map((f) => f.path);
-    expect(paths).toEqual(["services/WidgetService.ts", "hooks/useWidgets.ts", "components/WidgetList.tsx", "components/WidgetContainer.tsx", "index.ts.example"]);
+    expect(paths).toEqual([
+      "services/WidgetService.ts",
+      "services/WidgetService.spec.ts",
+      "hooks/useWidgets.ts",
+      "components/WidgetList.tsx",
+      "components/WidgetContainer.tsx",
+      "index.ts.example",
+    ]);
   });
 
   it("defaults the entity to Widget", () => {
@@ -31,6 +38,14 @@ describe("service layer contents", () => {
     expect(c).toContain("export const WidgetContainer");
     expect(c).toContain("useWidgets(service)");
     expect(c).toContain("<WidgetList");
+  });
+
+  it("emits a Jest test for the service with a mocked WebApi", () => {
+    const t = serviceTestContent("Widget");
+    expect(t).toContain('import { WidgetService } from "./WidgetService"');
+    expect(t).toContain('describe("WidgetService"');
+    expect(t).toContain("jest.fn().mockResolvedValue");
+    expect(t).toContain("new WidgetService(webApi).getAll()");
   });
 
   it("index example matches the documented ReactControl contract", () => {

--- a/src/pcf/pcfServiceLayer.ts
+++ b/src/pcf/pcfServiceLayer.ts
@@ -123,6 +123,31 @@ export const ${E}Container: React.FC<{ service: ${E}Service }> = ({ service }) =
 `;
 }
 
+/** A Jest unit test for the service — proves the domain layer is testable in
+ * isolation with a mocked WebApi (the point of the service/hook/component split). */
+export function serviceTestContent(entity: string): string {
+  const E = pascal(entity);
+  return `import { ${E}Service } from "./${E}Service";
+
+// The service is pure TS — unit-test it with a mocked ComponentFramework.WebApi,
+// no PCF host and no live Dataverse needed. Runs under Jest (\`npx jest\`).
+describe("${E}Service", () => {
+  it("maps retrieved records to the domain type", async () => {
+    const webApi = {
+      retrieveMultipleRecords: jest.fn().mockResolvedValue({
+        entities: [{ accountid: "1", name: "Contoso" }],
+      }),
+    } as unknown as ComponentFramework.WebApi;
+
+    const result = await new ${E}Service(webApi).getAll();
+
+    expect(webApi.retrieveMultipleRecords).toHaveBeenCalledWith("account", "?$select=name");
+    expect(result).toEqual([{ id: "1", name: "Contoso" }]);
+  });
+});
+`;
+}
+
 /** A wired index.ts matching the documented ReactControl contract. Written as
  * `.example` — copy the updateView/imports into your generated index.ts. */
 export function indexExampleContent(entity: string): string {
@@ -160,6 +185,7 @@ export function serviceLayerFiles(entity = "Widget"): ServiceLayerFile[] {
   const E = pascal(entity);
   return [
     { path: `services/${E}Service.ts`, content: serviceFileContent(entity) },
+    { path: `services/${E}Service.spec.ts`, content: serviceTestContent(entity) },
     { path: `hooks/use${E}s.ts`, content: hookFileContent(entity) },
     { path: `components/${E}List.tsx`, content: listComponentContent(entity) },
     { path: `components/${E}Container.tsx`, content: containerComponentContent(entity) },


### PR DESCRIPTION
The PCF service-layer scaffold (0.14.22) now also writes `services/<Entity>Service.spec.ts` — a Jest unit test exercising the service with a mocked `ComponentFramework.WebApi`, proving the domain layer is testable without a PCF host or live Dataverse. This is the 'service-layer templates have Jest tests' piece of #6; the existing `parseJestJson` TestController surfaces it once `npx jest` is wired in the control. Pure content unit-tested. **693/693**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)