### PR TITLE
0.14.24 (pre-release) — PCF test harness hot reload (#141/#150 #5 standalone mode)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 All notable changes to the "dataverse-powertools" extension will be documented in this file.
 
+## 0.14.24 (pre-release)
+
+PCF (#141) — **Run PCF test harness (hot reload)**, the standalone-harness half of the debug/hot-reload story (#5).
+
+- **Run PCF test harness (hot reload)** (PCF card / palette) launches `npm start watch` — the pcf-scripts test-harness dev server with its **built-in hot reload** — in a terminal. Edit your control's TS and the harness rebuilds and reloads instantly. This is the easy inner loop for isolated UI work (not a live model-driven form).
+
+> The **live-form** hot reload (redirecting a *deployed* control's bundle into a real form via CDP + the #64 service-worker bypass) is the separate, harder half — it needs a live control on a running app to verify, so it stays for a supervised session. The standalone harness (this) is the no-CDP path and works today.
+
 ## 0.14.23 (pre-release)
 
 PCF (#141) / testing (#150 #6) — the **service-layer template now ships with a Jest test**. **Add PCF service-layer structure** additionally writes `services/<Entity>Service.spec.ts` — a Jest unit test that exercises the service with a mocked `ComponentFramework.WebApi`, demonstrating that the domain layer is testable in isolation (no PCF host, no live Dataverse). This is the "service-layer templates have Jest tests" piece of the test story; the extension's existing Jest TestController (`parseJestJson`) then surfaces it once `npx jest` is wired in the control. +1 test.

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "type": "git",
     "url": "https://github.com/pete-mc/dataverse-powertools"
   },
-  "version": "0.14.23",
+  "version": "0.14.24",
   "engines": {
     "vscode": "^1.95.0"
   },
@@ -770,6 +770,11 @@
       {
         "command": "dataverse-powertools.addPcfServiceLayer",
         "title": "Dataverse PowerTools: Add PCF service-layer structure",
+        "enablement": "dataverse-powertools.showLoaded && dataverse-powertools.isPcf"
+      },
+      {
+        "command": "dataverse-powertools.runPcfHarness",
+        "title": "Dataverse PowerTools: Run PCF test harness (hot reload)",
         "enablement": "dataverse-powertools.showLoaded && dataverse-powertools.isPcf"
       },
       {

--- a/src/pcf/runHarness.spec.ts
+++ b/src/pcf/runHarness.spec.ts
@@ -1,0 +1,8 @@
+import { describe, it, expect } from "vitest";
+import { pcfHarnessCommand } from "./runHarness";
+
+describe("pcfHarnessCommand", () => {
+  it("is the pcf-scripts watch harness command", () => {
+    expect(pcfHarnessCommand()).toBe("npm start watch");
+  });
+});

--- a/src/pcf/runHarness.ts
+++ b/src/pcf/runHarness.ts
@@ -1,0 +1,54 @@
+// Command: run the PCF test harness with watch/hot-reload (#141 / #150 #5, the
+// "standalone harness" mode). `npm start watch` launches the pcf-scripts dev
+// server (localhost) with its built-in hot reload — the easy inner loop for
+// isolated UI work, no CDP and no live form needed (that's the separate live-form
+// mode). Runs in a terminal (long-lived). Registered once via the PCF descriptor.
+
+import * as vscode from "vscode";
+import * as fs from "fs";
+import * as path from "path";
+import DataversePowerToolsContext from "../context";
+import { activeComponentRoot } from "../components/componentDiscovery";
+
+/** The pcf-scripts test-harness watch command (built-in hot reload). */
+export function pcfHarnessCommand(): string {
+  return "npm start watch";
+}
+
+/** Directory holding the control's ControlManifest.Input.xml (has its package.json). */
+function findControlDir(root: string): string | undefined {
+  const walk = (dir: string): string | undefined => {
+    let entries: fs.Dirent[] = [];
+    try {
+      entries = fs.readdirSync(dir, { withFileTypes: true });
+    } catch {
+      return undefined;
+    }
+    if (entries.some((e) => e.isFile() && e.name === "ControlManifest.Input.xml")) {
+      return dir;
+    }
+    for (const e of entries) {
+      if (e.isDirectory() && e.name !== "node_modules" && e.name !== "out" && e.name !== "generated" && !e.name.startsWith(".")) {
+        const found = walk(path.join(dir, e.name));
+        if (found) {
+          return found;
+        }
+      }
+    }
+    return undefined;
+  };
+  return walk(root);
+}
+
+export function runPcfHarness(context: DataversePowerToolsContext): void {
+  const root = activeComponentRoot(context);
+  if (!root) {
+    vscode.window.showErrorMessage("Open or select a PCF component first.");
+    return;
+  }
+  const controlDir = findControlDir(root) ?? root;
+  context.channel.appendLine("Starting the PCF test harness with hot reload (npm start watch) — see the terminal. Stop it with Ctrl+C.");
+  const terminal = vscode.window.createTerminal({ name: "PCF harness (watch)", cwd: controlDir });
+  terminal.show(true);
+  terminal.sendText(pcfHarnessCommand());
+}

--- a/src/projectTypes/activation.ts
+++ b/src/projectTypes/activation.ts
@@ -55,6 +55,7 @@ import { pushPcf } from "../pcf/pushPcf";
 import { deployPcf } from "../pcf/deployPcf";
 import { refreshPcfTypes } from "../pcf/refreshPcfTypes";
 import { addPcfServiceLayer } from "../pcf/addServiceLayer";
+import { runPcfHarness } from "../pcf/runHarness";
 import { initialiseAzureFunction } from "../azurefunction/initialiseAzureFunction";
 import { buildAzureFunction } from "../azurefunction/buildAzureFunction";
 import { registerWebhookStep } from "../azurefunction/registerWebhookStep";
@@ -315,6 +316,7 @@ export const projectTypeActivations: Record<ProjectTypes, ProjectTypeActivation>
       "dataverse-powertools.deployPcf": tracked("Add to solution", deployPcf),
       "dataverse-powertools.refreshPcfTypes": (context) => refreshPcfTypes(context),
       "dataverse-powertools.addPcfServiceLayer": (context) => addPcfServiceLayer(context),
+      "dataverse-powertools.runPcfHarness": (context) => runPcfHarness(context),
     },
   },
   [ProjectTypes.azurefunction]: {

--- a/src/projectTypes/registry.ts
+++ b/src/projectTypes/registry.ts
@@ -268,13 +268,14 @@ export const projectTypeRegistry: readonly ProjectTypeDescriptor[] = [
     // Foundational slice (#141): scaffold + build + push + deploy (hand-to-solution) +
     // refresh-types. Debug/hot-reload, service-layer template and Jest Test Explorer are
     // explicit fast-follows.
-    commandIds: [`${prefix}buildPcf`, `${prefix}pushPcf`, `${prefix}deployPcf`, `${prefix}refreshPcfTypes`, `${prefix}addPcfServiceLayer`],
+    commandIds: [`${prefix}buildPcf`, `${prefix}pushPcf`, `${prefix}deployPcf`, `${prefix}refreshPcfTypes`, `${prefix}addPcfServiceLayer`, `${prefix}runPcfHarness`],
     menu() {
       return {
         // Push (pac pcf push) is the one-click dev inner loop.
         primary: { command: `${prefix}pushPcf`, label: "Push to {environment}" },
         secondary: [
           { command: `${prefix}buildPcf`, label: "Local Build" },
+          { command: `${prefix}runPcfHarness`, label: "Run harness (hot reload)" },
           { command: `${prefix}refreshPcfTypes`, label: "Refresh Types" },
           { command: `${prefix}deployPcf`, label: "Add to Solution" },
         ],


### PR DESCRIPTION
PCF (#141) — **Run PCF test harness (hot reload)**: launches `npm start watch` (pcf-scripts dev server with built-in hot reload) in a terminal. The **standalone-harness** half of the #5 hot-reload story — the easy, no-CDP inner loop. The **live-form** half (CDP redirect of a deployed bundle into a real form + #64 SW bypass) needs a live control to verify and stays for a supervised session. Pure command helper unit-tested. **694/694**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)