### PR TITLE
0.14.26 (pre-release) — PCF ControlManifest parser + shared findControlDir (#141)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to the "dataverse-powertools" extension will be documented in this file.
 
+## 0.14.26 (pre-release)
+
+PCF (#141) — **ControlManifest parser + de-duplicated control-dir lookup.**
+
+- New pure `parseControlManifest(xml)` turns a `ControlManifest.Input.xml` into a typed shape — namespace, constructor, version, display-name-key, and the **inferred** pac template (`field` vs `dataset`, from `<data-set>`) and framework (`none` vs `react`, from a React `<platform-library>`). Unit-tested (the "#141 manifest parse" test item); reusable by the panel, the scaffold flow, and any "which control is this" logic.
+- The `ControlManifest.Input.xml` directory walk that was copy-pasted in `addServiceLayer.ts` and `runHarness.ts` is now a single shared `findControlDir` alongside the parser. No behaviour change. +8 tests (710).
+
 ## 0.14.25 (pre-release)
 
 Testing (#143) — **the webview panel's browser JS is now under test.** `media/menuPanel.js` (the script that turns the host-side card model into DOM and posts clicks back) previously had zero coverage anywhere — only the host-side view-model was tested. A new jsdom suite loads the *shipping script unchanged* and asserts the rendered DOM + the messages it posts: `ready` on load, one card section per model card, action-button → `execute`, the #137 trace-log pill → its execute action, requirements Download → `openExternal`, the new-group drop zone appearing at two arrangeable cards, stale-DOM clearing, and non-model messages ignored. No change to the browser code, so no regression risk to the live panel. +8 tests (702).

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "type": "git",
     "url": "https://github.com/pete-mc/dataverse-powertools"
   },
-  "version": "0.14.25",
+  "version": "0.14.26",
   "engines": {
     "vscode": "^1.95.0"
   },

--- a/src/pcf/addServiceLayer.ts
+++ b/src/pcf/addServiceLayer.ts
@@ -10,31 +10,7 @@ import * as path from "path";
 import DataversePowerToolsContext from "../context";
 import { activeComponentRoot } from "../components/componentDiscovery";
 import { serviceLayerFiles } from "./pcfServiceLayer";
-
-/** Find the directory holding a control's ControlManifest.Input.xml under a root. */
-function findControlDir(root: string): string | undefined {
-  const walk = (dir: string): string | undefined => {
-    let entries: fs.Dirent[] = [];
-    try {
-      entries = fs.readdirSync(dir, { withFileTypes: true });
-    } catch {
-      return undefined;
-    }
-    if (entries.some((e) => e.isFile() && e.name === "ControlManifest.Input.xml")) {
-      return dir;
-    }
-    for (const e of entries) {
-      if (e.isDirectory() && e.name !== "node_modules" && e.name !== "out" && e.name !== "generated" && !e.name.startsWith(".")) {
-        const found = walk(path.join(dir, e.name));
-        if (found) {
-          return found;
-        }
-      }
-    }
-    return undefined;
-  };
-  return walk(root);
-}
+import { findControlDir } from "./controlManifest";
 
 export async function addPcfServiceLayer(context: DataversePowerToolsContext): Promise<void> {
   const root = activeComponentRoot(context);

--- a/src/pcf/controlManifest.spec.ts
+++ b/src/pcf/controlManifest.spec.ts
@@ -1,0 +1,75 @@
+import { describe, it, expect } from "vitest";
+import { parseControlManifest } from "./controlManifest";
+
+const fieldManifest = `<?xml version="1.0" encoding="utf-8" ?>
+<manifest>
+  <control namespace="Contoso" constructor="RatingControl" version="1.2.3" display-name-key="RatingControl_Display_Key" description-key="RatingControl_Desc_Key" control-type="standard">
+    <property name="value" display-name-key="value_Display_Key" of-type="Whole.None" usage="bound" required="true" />
+    <resources>
+      <code path="index.ts" order="1" />
+    </resources>
+  </control>
+</manifest>`;
+
+const datasetReactManifest = `<?xml version="1.0" encoding="utf-8" ?>
+<manifest>
+  <control namespace="Contoso" constructor="GridControl" version="0.0.1" control-type="virtual">
+    <data-set name="records" display-name-key="records_Display_Key" />
+    <resources>
+      <code path="index.ts" order="1" />
+      <platform-library name="React" version="16.8.6" />
+      <platform-library name="Fluent" version="9.46.2" />
+    </resources>
+  </control>
+</manifest>`;
+
+describe("parseControlManifest", () => {
+  it("parses namespace, constructor, version and display-name-key from a field control", () => {
+    const m = parseControlManifest(fieldManifest);
+    expect(m).toBeTruthy();
+    expect(m?.namespace).toBe("Contoso");
+    expect(m?.constructor).toBe("RatingControl");
+    expect(m?.version).toBe("1.2.3");
+    expect(m?.displayNameKey).toBe("RatingControl_Display_Key");
+  });
+
+  it("infers template=field and framework=none for a plain property control", () => {
+    const m = parseControlManifest(fieldManifest);
+    expect(m?.template).toBe("field");
+    expect(m?.framework).toBe("none");
+  });
+
+  it("infers template=dataset when a <data-set> is present", () => {
+    const m = parseControlManifest(datasetReactManifest);
+    expect(m?.template).toBe("dataset");
+  });
+
+  it("infers framework=react from a React platform-library (case-insensitive, among others)", () => {
+    const m = parseControlManifest(datasetReactManifest);
+    expect(m?.framework).toBe("react");
+  });
+
+  it("returns undefined for XML without a <control> element", () => {
+    expect(parseControlManifest("<manifest></manifest>")).toBeUndefined();
+    expect(parseControlManifest("<root><child/></root>")).toBeUndefined();
+  });
+
+  it("returns undefined for empty or non-manifest input", () => {
+    expect(parseControlManifest("")).toBeUndefined();
+    expect(parseControlManifest("not xml at all")).toBeUndefined();
+  });
+
+  it("returns undefined when namespace or constructor is missing", () => {
+    const noCtor = `<manifest><control namespace="Contoso" version="1.0.0"></control></manifest>`;
+    expect(parseControlManifest(noCtor)).toBeUndefined();
+  });
+
+  it("omits optional version/displayNameKey when absent", () => {
+    const minimal = `<manifest><control namespace="N" constructor="C"><property name="v" /></control></manifest>`;
+    const m = parseControlManifest(minimal);
+    expect(m?.namespace).toBe("N");
+    expect(m?.constructor).toBe("C");
+    expect(m?.version).toBeUndefined();
+    expect(m?.displayNameKey).toBeUndefined();
+  });
+});

--- a/src/pcf/controlManifest.ts
+++ b/src/pcf/controlManifest.ts
@@ -1,0 +1,122 @@
+// PCF ControlManifest.Input.xml handling (#141). Two concerns, both kept here so
+// the feature files don't each hand-roll them:
+//   1. A PURE parser (parseControlManifest) — no `vscode`, no `fs` — that turns the
+//      manifest XML into a small typed shape. Unit-tested. Backs the panel display,
+//      the scaffold quick-pick's defaults, and any "which control is this" logic.
+//   2. findControlDir — the fs walk that locates the directory holding the manifest,
+//      previously copy-pasted in addServiceLayer.ts and runHarness.ts.
+import * as fs from "fs";
+import * as path from "path";
+import { XMLParser } from "fast-xml-parser";
+import { PcfTemplate, PcfFramework } from "./pcfArgs";
+
+export const CONTROL_MANIFEST_FILENAME = "ControlManifest.Input.xml";
+
+export interface ControlManifest {
+  /** `<control namespace="…">` — the control's namespace. */
+  namespace: string;
+  /** `<control constructor="…">` — the control (class) name. */
+  constructor: string;
+  /** `<control version="…">`, if present. */
+  version?: string;
+  /** `<control display-name-key="…">`, if present (a resx key, not the display text). */
+  displayNameKey?: string;
+  /** field (a `<property>` control) vs dataset (a `<data-set>` grid control). */
+  template: PcfTemplate;
+  /** react when a `<platform-library name="React" …>` resource is declared, else none. */
+  framework: PcfFramework;
+}
+
+/**
+ * Parse a ControlManifest.Input.xml string into a typed shape (pure). Returns
+ * undefined when the XML has no `<control>` element (not a manifest). The pac
+ * template/framework are INFERRED from the manifest body — `<data-set>` ⇒ dataset,
+ * a React platform-library ⇒ react — because the manifest itself is the source of
+ * truth for a scaffolded control (the pac init flags aren't recorded anywhere else).
+ */
+export function parseControlManifest(xml: string): ControlManifest | undefined {
+  if (!xml || !xml.includes("<control")) {
+    return undefined;
+  }
+  let doc: unknown;
+  try {
+    doc = new XMLParser({ ignoreAttributes: false, attributeNamePrefix: "@_", isArray: () => false }).parse(xml);
+  } catch {
+    return undefined;
+  }
+  const manifest = (doc as { manifest?: { control?: Record<string, unknown> } })?.manifest;
+  const control = manifest?.control;
+  if (!control || typeof control !== "object") {
+    return undefined;
+  }
+  const attr = (name: string): string | undefined => {
+    const v = (control as Record<string, unknown>)[`@_${name}`];
+    return typeof v === "string" ? v : v === undefined ? undefined : String(v);
+  };
+  const namespace = attr("namespace");
+  const ctor = attr("constructor");
+  if (!namespace || !ctor) {
+    return undefined;
+  }
+  const template: PcfTemplate = "data-set" in (control as Record<string, unknown>) ? "dataset" : "field";
+  const framework: PcfFramework = hasReactPlatformLibrary(control as Record<string, unknown>) ? "react" : "none";
+  return {
+    namespace,
+    constructor: ctor,
+    version: attr("version"),
+    displayNameKey: attr("display-name-key"),
+    template,
+    framework,
+  };
+}
+
+/** True when the control declares a React platform-library resource (⇒ react framework). */
+function hasReactPlatformLibrary(control: Record<string, unknown>): boolean {
+  const resources = control["resources"];
+  if (!resources || typeof resources !== "object") {
+    return false;
+  }
+  const lib = (resources as Record<string, unknown>)["platform-library"];
+  const libs = Array.isArray(lib) ? lib : lib ? [lib] : [];
+  return libs.some((l) => {
+    const name = l && typeof l === "object" ? (l as Record<string, unknown>)["@_name"] : undefined;
+    return typeof name === "string" && name.toLowerCase() === "react";
+  });
+}
+
+const IGNORED_DIRS = new Set(["node_modules", "out", "generated"]);
+
+/**
+ * Find the directory holding a control's ControlManifest.Input.xml under `root`
+ * (depth-first, skipping node_modules/out/generated and dotfolders). Returns
+ * undefined if none is found. Consolidated from addServiceLayer.ts / runHarness.ts.
+ */
+export function findControlDir(root: string): string | undefined {
+  let entries: fs.Dirent[] = [];
+  try {
+    entries = fs.readdirSync(root, { withFileTypes: true });
+  } catch {
+    return undefined;
+  }
+  if (entries.some((e) => e.isFile() && e.name === CONTROL_MANIFEST_FILENAME)) {
+    return root;
+  }
+  for (const e of entries) {
+    if (e.isDirectory() && !IGNORED_DIRS.has(e.name) && !e.name.startsWith(".")) {
+      const found = findControlDir(path.join(root, e.name));
+      if (found) {
+        return found;
+      }
+    }
+  }
+  return undefined;
+}
+
+/** Read + parse the manifest under a control directory, if present (impure convenience). */
+export function readControlManifest(controlDir: string): ControlManifest | undefined {
+  try {
+    return parseControlManifest(fs.readFileSync(path.join(controlDir, CONTROL_MANIFEST_FILENAME), "utf8"));
+  } catch {
+    return undefined;
+  }
+}

--- a/src/pcf/runHarness.ts
+++ b/src/pcf/runHarness.ts
@@ -5,39 +5,13 @@
 // mode). Runs in a terminal (long-lived). Registered once via the PCF descriptor.
 
 import * as vscode from "vscode";
-import * as fs from "fs";
-import * as path from "path";
 import DataversePowerToolsContext from "../context";
 import { activeComponentRoot } from "../components/componentDiscovery";
+import { findControlDir } from "./controlManifest";
 
 /** The pcf-scripts test-harness watch command (built-in hot reload). */
 export function pcfHarnessCommand(): string {
   return "npm start watch";
-}
-
-/** Directory holding the control's ControlManifest.Input.xml (has its package.json). */
-function findControlDir(root: string): string | undefined {
-  const walk = (dir: string): string | undefined => {
-    let entries: fs.Dirent[] = [];
-    try {
-      entries = fs.readdirSync(dir, { withFileTypes: true });
-    } catch {
-      return undefined;
-    }
-    if (entries.some((e) => e.isFile() && e.name === "ControlManifest.Input.xml")) {
-      return dir;
-    }
-    for (const e of entries) {
-      if (e.isDirectory() && e.name !== "node_modules" && e.name !== "out" && e.name !== "generated" && !e.name.startsWith(".")) {
-        const found = walk(path.join(dir, e.name));
-        if (found) {
-          return found;
-        }
-      }
-    }
-    return undefined;
-  };
-  return walk(root);
 }
 
 export function runPcfHarness(context: DataversePowerToolsContext): void {


### PR DESCRIPTION
PCF (#141), the **manifest-parse** unit-test item + a DRY cleanup.

- **`parseControlManifest(xml)`** (pure, no `vscode`/`fs`) → `{ namespace, constructor, version?, displayNameKey?, template, framework }`. `template` (`field`|`dataset`) is inferred from `<data-set>`; `framework` (`none`|`react`) from a React `<platform-library>` — the manifest is the source of truth for a scaffolded control. Backs the panel, the scaffold flow's defaults, and any control-identity logic. 8 unit tests (edge cases: no `<control>`, missing namespace/constructor, empty/non-XML, absent optionals).
- The `ControlManifest.Input.xml` directory walk copy-pasted in `addServiceLayer.ts` and `runHarness.ts` is consolidated into one shared **`findControlDir`**. No behaviour change.

**710/710**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)