### PR TITLE
0.14.27 (pre-release) — in-panel pac device-code sign-in affordance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 All notable changes to the "dataverse-powertools" extension will be documented in this file.
 
+## 0.14.27 (pre-release)
+
+Panel UX — **in-panel pac sign-in affordance.** When a pac command (e.g. Generate Earlybound under OAuth on a machine with no pac profile) triggers a device-code sign-in, the Dataverse PowerTools panel now shows it directly instead of relying on a toast that auto-dismisses and an output channel that isn't open by default.
+
+- While a pac operation runs, a **busy banner** ("Signing in to Power Platform CLI…") appears at the top of the panel.
+- Once pac prints the device code, that becomes a **prominent, persistent sign-in card** showing the code in large mono type plus **Copy code** and **Open sign-in page** buttons. It's the first card in the panel — impossible to miss — and clears automatically when the sign-in completes or fails.
+- Security: the buttons only signal intent; the host copies the code / opens the URL from its own trusted state, never from the webview message, so the panel can't be coaxed into copying or opening arbitrary values.
+- The existing toast + output-channel messages stay as a fallback. New pure state module (`pacActivityState`) + `signin` card, unit-tested (pure model) and jsdom-tested (rendered DOM + posted intents). +12 tests (722).
+
 ## 0.14.26 (pre-release)
 
 PCF (#141) — **ControlManifest parser + de-duplicated control-dir lookup.**

--- a/media/menuPanel.css
+++ b/media/menuPanel.css
@@ -26,6 +26,29 @@ body {
   border-style: dashed;
 }
 
+/* Pending pac device-code sign-in: an accented, impossible-to-miss card. */
+.card.signin {
+  border-color: var(--vscode-focusBorder, #007fd4);
+  border-width: 1px;
+  background-color: var(--vscode-inputValidation-infoBackground, var(--vscode-editorWidget-background, transparent));
+}
+
+.card.signin .devicecode {
+  font-family: var(--vscode-editor-font-family, monospace);
+  font-size: 1.6em;
+  font-weight: 600;
+  letter-spacing: 0.12em;
+  user-select: all;
+  margin: 6px 0 2px;
+  color: var(--vscode-foreground);
+}
+
+.card.signin .signin-actions {
+  display: flex;
+  gap: 6px;
+  margin-top: 8px;
+}
+
 .card.slim button.action {
   margin: 0;
 }

--- a/media/menuPanel.js
+++ b/media/menuPanel.js
@@ -100,6 +100,37 @@
     return c;
   }
 
+  // Pending pac device-code sign-in (#UX): a prominent, persistent card with the code
+  // and a link. The buttons only SIGNAL intent — the host copies/open the code+url from
+  // its own trusted state, so the webview never handles the actual values as commands.
+  function renderSignin(card) {
+    const c = el("section", "card signin");
+    c.appendChild(el("h3", null, card.title));
+    if (card.hint) {
+      c.appendChild(el("p", "status", card.hint));
+    }
+    const code = el("div", "devicecode");
+    code.textContent = card.code;
+    code.setAttribute("aria-label", "Sign-in code " + card.code);
+    c.appendChild(code);
+    c.appendChild(el("div", "small", card.url));
+    const row = el("div", "signin-actions");
+    const copy = el("button", "action primary", "Copy code");
+    copy.type = "button";
+    copy.addEventListener("click", function () {
+      vscode.postMessage({ type: "copyDeviceCode" });
+    });
+    const open = el("button", "action", "Open sign-in page");
+    open.type = "button";
+    open.addEventListener("click", function () {
+      vscode.postMessage({ type: "openSignInPage" });
+    });
+    row.appendChild(copy);
+    row.appendChild(open);
+    c.appendChild(row);
+    return c;
+  }
+
   function renderActions(card) {
     const c = el("section", "card slim");
     card.actions.forEach(function (action) {
@@ -604,6 +635,7 @@
   // renderers — never a prototype member (js/unvalidated-dynamic-method-call).
   const renderers = new Map([
     ["notice", renderNotice],
+    ["signin", renderSignin],
     ["actions", renderActions],
     ["getStarted", renderGetStarted],
     ["requirements", renderRequirements],

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "type": "git",
     "url": "https://github.com/pete-mc/dataverse-powertools"
   },
-  "version": "0.14.26",
+  "version": "0.14.27",
   "engines": {
     "vscode": "^1.95.0"
   },

--- a/src/general/pacAuth.ts
+++ b/src/general/pacAuth.ts
@@ -4,6 +4,7 @@ import DataversePowerToolsContext from "../context";
 import { parseConnectionString, normalizeOrganizationUrl } from "./connectionString";
 import { pacInvocation } from "./pac";
 import { parseAuthType, DataverseAuthType } from "./dataverse/authTypes";
+import { beginPacOperation, setDeviceCodeSignIn, endPacOperation } from "../panel/pacActivityState";
 
 // Shared pac authentication for every feature that shells out to `pac`
 // (solutions, plugin modelbuilder). A single, clearly-named profile is
@@ -342,48 +343,58 @@ export async function createInteractivePacProfile(context: DataversePowerToolsCo
   // Clear a stale profile of the same name (ignore the result — it may not exist).
   await runPacResult(pacAuthDeleteArgs(AUTH_PROFILE_NAME), workspacePath);
 
+  // Surface the sign-in in the panel itself, not just a toast (which auto-dismisses) and the
+  // output channel (not open by default). beginPacOperation shows a busy banner immediately;
+  // once pac prints the device code, setDeviceCodeSignIn turns it into a prominent, actionable
+  // card (copy code / open page). endPacOperation clears both, whatever the outcome.
+  beginPacOperation(context, "Signing in to Power Platform CLI");
   context.channel.show();
-  const result = await vscode.window.withProgress(
-    {
-      location: vscode.ProgressLocation.Notification,
-      title: "Signing in to pac (device code)…",
-    },
-    async () => {
-      let promptedDeviceCode = false;
-      const onChunk = (chunk: string) => {
-        if (promptedDeviceCode) {
-          return;
-        }
-        const device = parseDeviceCode(chunk);
-        if (!device) {
-          return;
-        }
-        promptedDeviceCode = true;
-        // Also write the code prominently to the channel in case the toast is missed.
-        context.channel.appendLine("");
-        context.channel.appendLine(`>>> To finish signing in to pac, open ${device.url} and enter the code ${device.code}`);
-        void vscode.window.showInformationMessage(`To finish signing in, open ${device.url} and enter code ${device.code}`, "Open sign-in page").then((choice) => {
-          if (choice === "Open sign-in page") {
-            void vscode.env.openExternal(vscode.Uri.parse(device.url));
+  try {
+    const result = await vscode.window.withProgress(
+      {
+        location: vscode.ProgressLocation.Notification,
+        title: "Signing in to pac (device code)…",
+      },
+      async () => {
+        let promptedDeviceCode = false;
+        const onChunk = (chunk: string) => {
+          if (promptedDeviceCode) {
+            return;
           }
-        });
-      };
-      return runPacStreaming(context, pacAuthCreateInteractiveArgs(AUTH_PROFILE_NAME, environmentUrl, { deviceCode: true }), workspacePath, onChunk);
-    },
-  );
+          const device = parseDeviceCode(chunk);
+          if (!device) {
+            return;
+          }
+          promptedDeviceCode = true;
+          // The persistent, hard-to-miss affordance: the panel card. Toast + channel stay as fallback.
+          setDeviceCodeSignIn(context, { url: device.url, code: device.code });
+          context.channel.appendLine("");
+          context.channel.appendLine(`>>> To finish signing in to pac, open ${device.url} and enter the code ${device.code}`);
+          void vscode.window.showInformationMessage(`To finish signing in, open ${device.url} and enter code ${device.code}`, "Open sign-in page").then((choice) => {
+            if (choice === "Open sign-in page") {
+              void vscode.env.openExternal(vscode.Uri.parse(device.url));
+            }
+          });
+        };
+        return runPacStreaming(context, pacAuthCreateInteractiveArgs(AUTH_PROFILE_NAME, environmentUrl, { deviceCode: true }), workspacePath, onChunk);
+      },
+    );
 
-  if (pacSucceeded(result)) {
-    context.channel.appendLine(`Created the '${AUTH_PROFILE_NAME}' pac profile for ${environmentUrl}.`);
-    return true;
-  }
+    if (pacSucceeded(result)) {
+      context.channel.appendLine(`Created the '${AUTH_PROFILE_NAME}' pac profile for ${environmentUrl}.`);
+      return true;
+    }
 
-  // Browser fallback: pac opens the system browser for an interactive sign-in.
-  context.channel.appendLine("Device-code sign-in didn't complete — falling back to a browser sign-in.");
-  const created = await runPacLogged(context, pacAuthCreateInteractiveArgs(AUTH_PROFILE_NAME, environmentUrl, { deviceCode: false }), workspacePath);
-  if (!created) {
-    vscode.window.showErrorMessage("Could not sign in to pac. See the Dataverse PowerTools output for details.");
+    // Browser fallback: pac opens the system browser for an interactive sign-in.
+    context.channel.appendLine("Device-code sign-in didn't complete — falling back to a browser sign-in.");
+    const created = await runPacLogged(context, pacAuthCreateInteractiveArgs(AUTH_PROFILE_NAME, environmentUrl, { deviceCode: false }), workspacePath);
+    if (!created) {
+      vscode.window.showErrorMessage("Could not sign in to pac. See the Dataverse PowerTools output for details.");
+    }
+    return created;
+  } finally {
+    endPacOperation(context);
   }
-  return created;
 }
 
 /**

--- a/src/panel/menuModel.spec.ts
+++ b/src/panel/menuModel.spec.ts
@@ -54,6 +54,50 @@ describe("environmentName", () => {
   });
 });
 
+describe("pac in-flight banner (device-code sign-in)", () => {
+  it("shows a busy notice at the top while a pac operation runs with no code yet", () => {
+    const s = state({ pacOperation: { label: "Signing in to Power Platform CLI" } });
+    const cards = buildMenuModel(s).cards;
+    expect(cards[0].id).toBe("pacBusy");
+    expect(cards[0].kind).toBe("notice");
+    expect((cards[0] as { text: string; spinner?: boolean }).text).toBe("Signing in to Power Platform CLI…");
+    expect((cards[0] as { spinner?: boolean }).spinner).toBe(true);
+  });
+
+  it("shows a prominent sign-in card (code + url) once the device code is known", () => {
+    const s = state({
+      pacOperation: { label: "Signing in to Power Platform CLI" },
+      deviceCodeSignIn: { url: "https://microsoft.com/devicelogin", code: "ABCD-EFGH" },
+    });
+    const signin = card(s, "signin");
+    expect(signin.code).toBe("ABCD-EFGH");
+    expect(signin.url).toBe("https://microsoft.com/devicelogin");
+    expect(signin.title).toBe("Signing in to Power Platform CLI");
+    // It is the very first card — impossible to miss.
+    expect(buildMenuModel(s).cards[0].id).toBe("signin");
+  });
+
+  it("prefers the sign-in card over the busy notice when both would apply", () => {
+    const s = state({
+      pacOperation: { label: "Signing in to Power Platform CLI" },
+      deviceCodeSignIn: { url: "u", code: "X-Y" },
+    });
+    const ids = cardIds(s);
+    expect(ids).toContain("signin");
+    expect(ids).not.toContain("pacBusy");
+  });
+
+  it("renders the sign-in banner even before a project is loaded (top-level branch)", () => {
+    const s = state({ loaded: false, projects: [], deviceCodeSignIn: { url: "u", code: "X-Y" } });
+    expect(buildMenuModel(s).cards[0].id).toBe("signin");
+  });
+
+  it("has no banner when no pac operation is in flight", () => {
+    expect(cardIds(state())).not.toContain("signin");
+    expect(cardIds(state())).not.toContain("pacBusy");
+  });
+});
+
 describe("top-level states", () => {
   it("shows only a spinner notice while folder settings load", () => {
     const model = buildMenuModel(state({ detecting: true }));

--- a/src/panel/menuModel.ts
+++ b/src/panel/menuModel.ts
@@ -84,6 +84,9 @@ export const MAX_REGISTRATION_ROWS = 8;
 
 export type Card =
   | { kind: "notice"; id: string; text: string; spinner?: boolean }
+  /** A pending pac device-code sign-in (persistent, prominent) — the code + link the
+   * user must act on, with copy-code / open-page buttons. Cleared when the op finishes. */
+  | { kind: "signin"; id: "signin"; title: string; hint: string; url: string; code: string }
   | { kind: "getStarted"; id: "getStarted"; text: string; actions: MenuAction[] }
   | { kind: "actions"; id: string; actions: MenuAction[] }
   | { kind: "requirements"; id: "requirements"; scanning: boolean; rows: RequirementRow[]; recheck?: MenuAction }
@@ -198,6 +201,12 @@ export interface PanelState {
   rootIsEmpty?: boolean;
   /** More than one discovered component — cards default to minimised (#156). */
   multiComponent?: boolean;
+  /** A long pac command is in flight (e.g. "Signing in to Power Platform CLI") — shows a
+   * persistent busy banner at the top of the panel. Cleared when the command finishes. */
+  pacOperation?: { label: string };
+  /** A pac device-code sign-in is pending — the panel shows a prominent card with the code
+   * and link so the user isn't left waiting on an easy-to-miss toast. Undefined otherwise. */
+  deviceCodeSignIn?: { url: string; code: string };
 }
 
 /** Full walkthrough reference: <publisher>.<extension>#<walkthrough id in package.json>. */
@@ -353,10 +362,39 @@ function footerFor(state: PanelState, cards: Card[]): MenuModel["footer"] {
   return { requirementsOk: allRequirementsOk(state) && !cardShown, log: { command: "dataverse-powertools.showLog", label: "Show Log" }, help: HELP_LINKS };
 }
 
+/** In-flight pac state, rendered at the very TOP of the panel so a pending sign-in
+ * or a long command is impossible to miss (the toast auto-dismisses; the output
+ * channel isn't open by default). The device-code card takes precedence over the
+ * plain busy banner — once pac prints the code, the banner becomes the actionable card. */
+function bannerCards(state: PanelState): Card[] {
+  if (state.deviceCodeSignIn) {
+    return [
+      {
+        kind: "signin",
+        id: "signin",
+        title: state.pacOperation?.label ?? "Signing in to Power Platform CLI",
+        hint: "Open the sign-in page and enter this code to continue:",
+        url: state.deviceCodeSignIn.url,
+        code: state.deviceCodeSignIn.code,
+      },
+    ];
+  }
+  if (state.pacOperation) {
+    return [{ kind: "notice", id: "pacBusy", text: `${state.pacOperation.label}…`, spinner: true }];
+  }
+  return [];
+}
+
+/** Assemble the final model, prepending any in-flight pac banner to the branch's cards. */
+function model(state: PanelState, cards: Card[]): MenuModel {
+  const withBanner = [...bannerCards(state), ...cards];
+  return { cards: withBanner, multiComponent: !!state.multiComponent, footer: footerFor(state, withBanner) };
+}
+
 export function buildMenuModel(state: PanelState): MenuModel {
   if (state.detecting) {
     const cards: Card[] = [{ kind: "notice", id: "detecting", text: "Getting things ready — detecting your Dataverse project…", spinner: true }];
-    return { cards, multiComponent: !!state.multiComponent, footer: footerFor(state, cards) };
+    return model(state, cards);
   }
 
   if (!state.loaded) {
@@ -372,7 +410,7 @@ export function buildMenuModel(state: PanelState): MenuModel {
       },
       requirementsCard(state),
     ];
-    return { cards, multiComponent: !!state.multiComponent, footer: footerFor(state, cards) };
+    return model(state, cards);
   }
 
   const cards: Card[] = [environmentCard(state)];
@@ -468,5 +506,5 @@ export function buildMenuModel(state: PanelState): MenuModel {
     cards.push(requirementsCard(state));
   }
 
-  return { cards, multiComponent: !!state.multiComponent, footer: footerFor(state, cards) };
+  return model(state, cards);
 }

--- a/src/panel/menuPanel.dom.spec.ts
+++ b/src/panel/menuPanel.dom.spec.ts
@@ -107,6 +107,36 @@ describe("menuPanel.js (webview DOM, #143)", () => {
     expect(posted).toEqual([{ type: "execute", command: "dvpt.setTraceLogLevel", args: [] }]);
   });
 
+  it("renders the device-code sign-in card and posts copy/open intents (no values in the message)", () => {
+    const { posted } = loadPanel();
+    postModel({
+      cards: [
+        {
+          kind: "signin",
+          id: "signin",
+          title: "Signing in to Power Platform CLI",
+          hint: "Open the sign-in page and enter this code to continue:",
+          url: "https://microsoft.com/devicelogin",
+          code: "ABCD-EFGH",
+        },
+      ],
+      footer,
+    });
+    const signin = document.querySelector(".card.signin") as HTMLElement;
+    expect(signin).toBeTruthy();
+    expect(signin.querySelector(".devicecode")?.textContent).toBe("ABCD-EFGH");
+    expect(signin.textContent).toContain("https://microsoft.com/devicelogin");
+
+    posted.length = 0;
+    (signin.querySelector(".signin-actions button.primary") as HTMLButtonElement).click();
+    expect(posted).toEqual([{ type: "copyDeviceCode" }]);
+
+    posted.length = 0;
+    const buttons = signin.querySelectorAll(".signin-actions button");
+    (buttons[buttons.length - 1] as HTMLButtonElement).click();
+    expect(posted).toEqual([{ type: "openSignInPage" }]);
+  });
+
   it("renders a requirements card and posts openExternal for a missing tool's Download link", () => {
     const { posted } = loadPanel();
     postModel({

--- a/src/panel/menuPanel.ts
+++ b/src/panel/menuPanel.ts
@@ -8,6 +8,7 @@ import { onDebugSessionChanged } from "../webresources/debug/debugWebresources";
 import { openScannedRegistration } from "./registrationsScanner";
 import { refreshPanelData } from "./panelDataCache";
 import { stopActiveProfileByIndex } from "../plugins/profilerToggle";
+import { getDeviceCodeSignIn } from "./pacActivityState";
 
 // Commands the webview may ask the host to run. The webview is our own code
 // behind a strict CSP, but treat its messages as untrusted anyway.
@@ -110,6 +111,23 @@ export class MenuPanelViewProvider implements vscode.WebviewViewProvider {
           await vscode.env.openExternal(vscode.Uri.parse(message.url));
         }
         break;
+      case "copyDeviceCode": {
+        // The webview only signals intent; the code comes from trusted host state, never the message.
+        const signin = getDeviceCodeSignIn();
+        if (signin) {
+          await vscode.env.clipboard.writeText(signin.code);
+          vscode.window.showInformationMessage(`Copied sign-in code ${signin.code} to the clipboard.`);
+        }
+        break;
+      }
+      case "openSignInPage": {
+        // Same: open the URL from host state, so the webview can't ask us to open an arbitrary page.
+        const signin = getDeviceCodeSignIn();
+        if (signin) {
+          await vscode.env.openExternal(vscode.Uri.parse(signin.url));
+        }
+        break;
+      }
       case "updateLayout":
         // Re-arranged in the webview (#118): persist the sanitised layout on the root settings.
         await this.saveLayout(sanitizeLayout(message.layout));

--- a/src/panel/pacActivityState.spec.ts
+++ b/src/panel/pacActivityState.spec.ts
@@ -1,0 +1,59 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { beginPacOperation, setDeviceCodeSignIn, endPacOperation, getPacOperation, getDeviceCodeSignIn, resetPacActivity } from "./pacActivityState";
+import type DataversePowerToolsContext from "../context";
+
+function fakeContext(): { context: DataversePowerToolsContext; refreshes: () => number } {
+  let refreshes = 0;
+  const context = { refreshPanel: () => (refreshes += 1) } as unknown as DataversePowerToolsContext;
+  return { context, refreshes: () => refreshes };
+}
+
+describe("pacActivityState", () => {
+  beforeEach(() => resetPacActivity());
+
+  it("begins with no operation or sign-in", () => {
+    expect(getPacOperation()).toBeUndefined();
+    expect(getDeviceCodeSignIn()).toBeUndefined();
+  });
+
+  it("beginPacOperation sets the busy label and re-renders", () => {
+    const f = fakeContext();
+    beginPacOperation(f.context, "Signing in to Power Platform CLI");
+    expect(getPacOperation()).toEqual({ label: "Signing in to Power Platform CLI" });
+    expect(getDeviceCodeSignIn()).toBeUndefined();
+    expect(f.refreshes()).toBe(1);
+  });
+
+  it("setDeviceCodeSignIn surfaces the code + url and re-renders", () => {
+    const f = fakeContext();
+    beginPacOperation(f.context, "Signing in to Power Platform CLI");
+    setDeviceCodeSignIn(f.context, { url: "https://microsoft.com/devicelogin", code: "ABCD-EFGH" });
+    expect(getDeviceCodeSignIn()).toEqual({ url: "https://microsoft.com/devicelogin", code: "ABCD-EFGH" });
+    // Operation label persists alongside the sign-in.
+    expect(getPacOperation()).toEqual({ label: "Signing in to Power Platform CLI" });
+    expect(f.refreshes()).toBe(2);
+  });
+
+  it("endPacOperation clears both operation and sign-in, and re-renders", () => {
+    const f = fakeContext();
+    beginPacOperation(f.context, "Signing in to Power Platform CLI");
+    setDeviceCodeSignIn(f.context, { url: "https://microsoft.com/devicelogin", code: "ABCD-EFGH" });
+    endPacOperation(f.context);
+    expect(getPacOperation()).toBeUndefined();
+    expect(getDeviceCodeSignIn()).toBeUndefined();
+    expect(f.refreshes()).toBe(3);
+  });
+
+  it("beginPacOperation clears a stale device code from a previous run", () => {
+    const f = fakeContext();
+    setDeviceCodeSignIn(f.context, { url: "u", code: "OLD-CODE" });
+    beginPacOperation(f.context, "Signing in to Power Platform CLI");
+    expect(getDeviceCodeSignIn()).toBeUndefined();
+  });
+
+  it("tolerates a context without refreshPanel", () => {
+    const context = {} as unknown as DataversePowerToolsContext;
+    expect(() => beginPacOperation(context, "x")).not.toThrow();
+    expect(getPacOperation()).toEqual({ label: "x" });
+  });
+});

--- a/src/panel/pacActivityState.ts
+++ b/src/panel/pacActivityState.ts
@@ -1,0 +1,62 @@
+import DataversePowerToolsContext from "../context";
+
+// In-flight pac operation state for the actions panel. The panel is network-free
+// (computePanelState reads caches only), so a long-running pac command — and the
+// device-code sign-in it may trigger — records its progress HERE and re-renders,
+// giving the panel a persistent, obvious affordance instead of relying on a toast
+// that auto-dismisses and an output channel that isn't open by default.
+//
+// Two layers:
+//   - a pac OPERATION banner ("Generating early-bound classes…") for any long command;
+//   - the device-code SIGN-IN sub-state (url + code), shown as a prominent card with
+//     copy-code / open-page buttons while pac waits for the user to authenticate.
+// Ending the operation clears both. Session-scoped, in-memory by design.
+
+export interface DeviceCodeSignIn {
+  /** The device-login page (e.g. https://microsoft.com/devicelogin). */
+  url: string;
+  /** The one-time code the user enters there (e.g. ABCD-EFGH). */
+  code: string;
+}
+
+export interface PacOperation {
+  /** Human label for the in-flight command, e.g. "Signing in to Power Platform CLI". */
+  label: string;
+}
+
+let pacOperation: PacOperation | undefined;
+let deviceCodeSignIn: DeviceCodeSignIn | undefined;
+
+export function getPacOperation(): PacOperation | undefined {
+  return pacOperation;
+}
+
+export function getDeviceCodeSignIn(): DeviceCodeSignIn | undefined {
+  return deviceCodeSignIn;
+}
+
+/** Mark a long pac operation as started and re-render (shows the busy banner). */
+export function beginPacOperation(context: DataversePowerToolsContext, label: string): void {
+  pacOperation = { label };
+  deviceCodeSignIn = undefined;
+  context.refreshPanel?.();
+}
+
+/** Surface a pending device-code sign-in on the panel (prominent card) and re-render. */
+export function setDeviceCodeSignIn(context: DataversePowerToolsContext, signin: DeviceCodeSignIn): void {
+  deviceCodeSignIn = signin;
+  context.refreshPanel?.();
+}
+
+/** Clear all in-flight pac state (operation done/failed) and re-render. */
+export function endPacOperation(context: DataversePowerToolsContext): void {
+  pacOperation = undefined;
+  deviceCodeSignIn = undefined;
+  context.refreshPanel?.();
+}
+
+/** Test/reload hook — clears state without a re-render. */
+export function resetPacActivity(): void {
+  pacOperation = undefined;
+  deviceCodeSignIn = undefined;
+}

--- a/src/panel/panelState.ts
+++ b/src/panel/panelState.ts
@@ -9,6 +9,7 @@ import { getSystemRequirementsStatus } from "../general/systemRequirements";
 import { getRecentOperations } from "./operationTracker";
 import { getScannedRegistrations } from "./registrationsScanner";
 import { getTraceLogCache, getActiveProfilesCache } from "./panelDataCache";
+import { getPacOperation, getDeviceCodeSignIn } from "./pacActivityState";
 import { isDebugSessionActive } from "../webresources/debug/debugWebresources";
 import { ComponentSettings } from "../components/discovery";
 import { clock, buildProjectCard } from "./panelCards";
@@ -101,5 +102,9 @@ export function computePanelState(context: DataversePowerToolsContext): PanelSta
     rootIsEmpty: loaded ? !settings.type : undefined,
     // More than one discovered component → the panel minimises cards by default (#156).
     multiComponent: (context.components?.length ?? 0) > 1,
+    // In-flight pac operation / pending device-code sign-in — a persistent, obvious panel
+    // affordance while a pac command (sign-in, generate, build, deploy) runs.
+    pacOperation: getPacOperation(),
+    deviceCodeSignIn: getDeviceCodeSignIn(),
   };
 }


### PR DESCRIPTION
**Problem** (seen in supervised UI testing): during Generate Earlybound under OAuth on a machine with no pac profile, pac starts a device-code sign-in — but the Dataverse PowerTools panel shows **nothing**. The only cues were a `showInformationMessage` toast (easy to miss, auto-dismisses) and the output channel (not open by default), so a watching user had no idea a sign-in was pending or what to do.

**Fix** — a persistent, obvious in-panel affordance while a pac op / sign-in is in flight:
- A **busy banner** at the top of the panel while any pac operation runs (`Signing in to Power Platform CLI…`).
- Once pac emits the device code, a **prominent sign-in card** (first card in the panel): the code in large mono type + **Copy code** and **Open sign-in page** buttons. Cleared automatically when the op completes or errors (`finally`).
- Existing toast + output-channel messages kept as fallback.

**Design**
- New pure state module `src/panel/pacActivityState.ts` (`beginPacOperation` / `setDeviceCodeSignIn` / `endPacOperation`), read by `computePanelState` — the panel stays network-free.
- New `signin` `Card` kind in the pure view-model, rendered at the top of every branch via a `bannerCards` helper.
- `createInteractivePacProfile` wires begin→set(code)→end around the device-code flow.
- **Security:** the webview buttons post bare `copyDeviceCode` / `openSignInPage` intents; the host acts on its own trusted `getDeviceCodeSignIn()` state, never a webview-supplied value — no arbitrary copy/open.

**Tests:** `pacActivityState.spec` (state transitions + re-render), `menuModel.spec` (banner precedence, top-of-panel placement, pre-load branch), `menuPanel.dom.spec` (jsdom: renders the code, posts the right intents with no values in the message). **722/722.**

Acceptance met: during Generate Earlybound under OAuth with no pac profile, the panel itself surfaces the sign-in with the code + link.

🤖 Generated with [Claude Code](https://claude.com/claude-code)