### PR TITLE
0.14.28 (pre-release) — pin VS Code version for ExTester harnesses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to the "dataverse-powertools" extension will be documented in this file.
 
+## 0.14.28 (pre-release)
+
+Test harness — **pin the VS Code version for the ExTester UI / e2e / supervised runs.** ExTester defaulted to downloading the "latest" stable VS Code, and a fresh release (1.129.0) shipped an archive layout the installed `vscode-extension-tester@8.23.0` couldn't parse (`Cannot find module …/resources/app/out/cli.js`), breaking harness *setup* before any test ran. All three launchers now pin a known-good version via a single shared constant (`scripts/vscodeTestVersion.mjs`, `--code_version`), overridable per-run with `DVPT_TEST_CODE_VERSION`. No change to the shipped extension.
+
 ## 0.14.27 (pre-release)
 
 Panel UX — **in-panel pac sign-in affordance.** When a pac command (e.g. Generate Earlybound under OAuth on a machine with no pac profile) triggers a device-code sign-in, the Dataverse PowerTools panel now shows it directly instead of relying on a toast that auto-dismisses and an output channel that isn't open by default.

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "type": "git",
     "url": "https://github.com/pete-mc/dataverse-powertools"
   },
-  "version": "0.14.27",
+  "version": "0.14.28",
   "engines": {
     "vscode": "^1.95.0"
   },
@@ -881,7 +881,7 @@
     "test:live": "vitest run --config vitest.live.config.ts",
     "test:integration": "npm run compile-tests && vscode-test",
     "pretest:ui": "npm run compile-tests && npm run compile",
-    "test:ui": "extest setup-and-run \"out/ui-test/**/*.test.js\" --code_settings test/ui-settings.json --extensions_dir test-resources/extensions --mocha_config .mocharc-ui.json",
+    "test:ui": "extest setup-and-run \"out/ui-test/**/*.test.js\" --code_version 1.128.1 --code_settings test/ui-settings.json --extensions_dir test-resources/extensions --mocha_config .mocharc-ui.json",
     "pretest:e2e": "npm run compile-tests && npm run compile",
     "test:e2e": "node scripts/runE2E.mjs",
     "test": "npm run test:unit && npm run test:integration",

--- a/scripts/runE2E.mjs
+++ b/scripts/runE2E.mjs
@@ -11,6 +11,7 @@ import { createRequire } from "module";
 import fs from "fs";
 import path from "path";
 import { fileURLToPath } from "url";
+import { codeVersionArgs } from "./vscodeTestVersion.mjs";
 
 const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
 
@@ -35,7 +36,7 @@ if (seed.status !== 0) {
   console.warn("[e2e] interactive cache not seeded — interactive-auth suites will self-skip (service-principal suites still run).");
 }
 
-const extestArgs = ["extest", "setup-and-run", ...globs, "--code_settings", "test/ui-settings.json", "--extensions_dir", "sandbox/ext-dir-clean", "--mocha_config", ".mocharc-e2e.json"];
+const extestArgs = ["extest", "setup-and-run", ...globs, ...codeVersionArgs(), "--code_settings", "test/ui-settings.json", "--extensions_dir", "sandbox/ext-dir-clean", "--mocha_config", ".mocharc-e2e.json"];
 console.log(`[e2e] launching: npx ${extestArgs.join(" ")}`);
 const run = spawnSync("npx", extestArgs, { cwd: root, env, stdio: "inherit", shell: process.platform === "win32" });
 

--- a/scripts/runSupervised.mjs
+++ b/scripts/runSupervised.mjs
@@ -18,6 +18,7 @@ import { spawnSync } from "child_process";
 import fs from "fs";
 import path from "path";
 import { fileURLToPath } from "url";
+import { codeVersionArgs } from "./vscodeTestVersion.mjs";
 
 const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
 const reuse = process.argv.includes("--reuse") || process.env.DVPT_SUPERVISED_REUSE === "1";
@@ -83,6 +84,6 @@ const env = {
   DVPT_SUPERVISED_SOLUTION: supervisedSolution,
 };
 
-const extestArgs = ["extest", "setup-and-run", ...globs, "--code_settings", "test/ui-settings.json", "--extensions_dir", "sandbox/ext-dir-clean", "--mocha_config", ".mocharc-supervised.json"];
+const extestArgs = ["extest", "setup-and-run", ...globs, ...codeVersionArgs(), "--code_settings", "test/ui-settings.json", "--extensions_dir", "sandbox/ext-dir-clean", "--mocha_config", ".mocharc-supervised.json"];
 const run = spawnSync("npx", extestArgs, { cwd: root, env, stdio: "inherit", shell: process.platform === "win32" });
 process.exit(run.status ?? 1);

--- a/scripts/vscodeTestVersion.mjs
+++ b/scripts/vscodeTestVersion.mjs
@@ -1,0 +1,19 @@
+// Pinned VS Code version for the ExTester UI / e2e / supervised harnesses.
+//
+// By default ExTester downloads the "latest" stable VS Code. When a fresh VS Code
+// release ships an archive layout the installed `vscode-extension-tester` doesn't yet
+// understand, setup breaks BEFORE any test runs — e.g. 1.129.0 against
+// vscode-extension-tester@8.23.0 failed with "Cannot find module …/resources/app/out/cli.js"
+// (the extracted folder hash didn't match what ExTester probed for). Pinning a known-good
+// version makes the harness deterministic and immune to that class of breakage.
+//
+// To bump: confirm a newer VS Code drives the panel webview with the installed
+// vscode-extension-tester (run `npm run test:ui` / `test:e2e`), then update BOTH this
+// constant AND the inline `--code_version` in package.json's `test:ui` script (JSON can't
+// import this module). Override for a one-off run with DVPT_TEST_CODE_VERSION.
+export const VSCODE_TEST_VERSION = "1.128.1";
+
+/** The `--code_version <v>` args for an `extest setup-and-run` invocation. */
+export function codeVersionArgs() {
+  return ["--code_version", process.env.DVPT_TEST_CODE_VERSION || VSCODE_TEST_VERSION];
+}


### PR DESCRIPTION
**Problem:** ExTester (`vscode-extension-tester@8.23.0`) auto-downloads the *latest* stable VS Code. VS Code **1.129.0** shipped an archive layout ExTester couldn't parse — setup failed with `Cannot find module …/resources/app/out/cli.js` **before any test ran**. Hit while verifying the 0.14.27 sign-in card on the VM; pinning `--code_version 1.128.1` fixed it.

**Fix:** pin a known-good VS Code version across all three ExTester launchers via a single shared constant:
- `scripts/vscodeTestVersion.mjs` — `VSCODE_TEST_VERSION` + `codeVersionArgs()`, overridable per-run with `DVPT_TEST_CODE_VERSION`.
- `scripts/runE2E.mjs` and `scripts/runSupervised.mjs` import it and splice `--code_version` into the extest args.
- `test:ui` inlines the same pin (JSON can't import the module; the constant's doc-comment notes to keep them in sync).

To bump: confirm a newer VS Code drives the panel webview with the installed `vscode-extension-tester`, then update the constant + the `test:ui` inline pin. No change to the shipped extension (scripts/tests are excluded from the VSIX). This PR's **UI tests (ExTester)** job exercises the pin on CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)