### PR TITLE
0.14.29 (pre-release) — PCF scaffold template + framework quick-pick (#141)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to the "dataverse-powertools" extension will be documented in this file.
 
+## 0.14.29 (pre-release)
+
+PCF (#141) — **choose the control template + framework when scaffolding.** Adding a PCF component previously always ran `pac pcf init --template field --framework none`. It now asks two quick-picks up front — **template** (Field vs Dataset) and **framework** (Standard vs React) — and scaffolds accordingly. Dismissing either pick falls back to the previous field/none default, so nothing breaks. The choice values come from fixed enums (no free-text reaches the command line). Pure choice lists + argv builder unit-tested. +4 tests (726).
+
 ## 0.14.28 (pre-release)
 
 Test harness — **pin the VS Code version for the ExTester UI / e2e / supervised runs.** ExTester defaulted to downloading the "latest" stable VS Code, and a fresh release (1.129.0) shipped an archive layout the installed `vscode-extension-tester@8.23.0` couldn't parse (`Cannot find module …/resources/app/out/cli.js`), breaking harness *setup* before any test ran. All three launchers now pin a known-good version via a single shared constant (`scripts/vscodeTestVersion.mjs`, `--code_version`), overridable per-run with `DVPT_TEST_CODE_VERSION`. No change to the shipped extension.

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "type": "git",
     "url": "https://github.com/pete-mc/dataverse-powertools"
   },
-  "version": "0.14.28",
+  "version": "0.14.29",
   "engines": {
     "vscode": "^1.95.0"
   },

--- a/src/general/restoreDependencies.ts
+++ b/src/general/restoreDependencies.ts
@@ -5,6 +5,7 @@ import DataversePowerToolsContext, { PowertoolsTemplate, ProjectTypes } from "..
 import { getTemplateFolderForType } from "../projectTypes/registry";
 import { pacInvocation } from "./pac";
 import { activeComponentRoot } from "../components/componentDiscovery";
+import { promptPcfInitArgs } from "../pcf/pcfInitPrompt";
 
 // Lines from restore tooling (npm mostly) that are noise to a user watching the output channel:
 // funding solicitations, audit summaries, deprecation notices. Stripped so the log shows only what
@@ -31,6 +32,13 @@ export function filterRestoreNoise(text: string): string {
 
 function isPacPluginInit(argv: string[]): boolean {
   return argv[0]?.toLowerCase() === "pac" && argv[1]?.toLowerCase() === "plugin" && argv[2]?.toLowerCase() === "init";
+}
+
+/** The template's `pac pcf init …` scaffold command (#141) — matched so the user's
+ * chosen template/framework can replace the hardcoded field/none flags. */
+export function isPacPcfInit(command: string): boolean {
+  const argv = command.split(/\s+/).filter((t) => t.length > 0);
+  return argv[0]?.toLowerCase() === "pac" && argv[1]?.toLowerCase() === "pcf" && argv[2]?.toLowerCase() === "init";
 }
 
 function hasOutputDirectoryFlag(argv: string[]): boolean {
@@ -128,8 +136,12 @@ export async function restoreDependencies(context: DataversePowerToolsContext, i
       if (vscode.workspace.workspaceFolders !== undefined && context.template !== undefined && context.template.restoreCommands) {
         const workspacePath = activeComponentRoot(context) ?? vscode.workspace.workspaceFolders[0].uri.fsPath;
         const restoreCommands = initialising ? context.template?.initCommands || [] : context.template?.restoreCommands || [];
+        // PCF scaffold (#141): ask once, up front, for the control template + framework so the
+        // pac pcf init below uses the user's choice instead of the hardcoded field/none. The
+        // returned argv is fixed-enum tokens only (safe to run as-is, bypassing the string gate).
+        const pcfInitArgv = initialising && context.projectSettings.type === ProjectTypes.pcf ? await promptPcfInitArgs() : undefined;
         for (const c of restoreCommands) {
-          const resolvedCommand = resolveInitCommand(c.command, workspacePath, context, initialising);
+          const resolvedCommand = pcfInitArgv && isPacPcfInit(c.command) ? pcfInitArgv : resolveInitCommand(c.command, workspacePath, context, initialising);
           const displayCommand = Array.isArray(resolvedCommand) ? resolvedCommand.join(" ") : resolvedCommand;
           await vscode.window.withProgress(
             {

--- a/src/pcf/pcfInitPrompt.spec.ts
+++ b/src/pcf/pcfInitPrompt.spec.ts
@@ -1,0 +1,34 @@
+import { describe, it, expect } from "vitest";
+import { pcfTemplateChoices, pcfFrameworkChoices, PCF_INIT_DEFAULTS } from "./pcfInitPrompt";
+import { pcfInitArgs } from "./pcfArgs";
+
+describe("pcfInitPrompt choices (#141)", () => {
+  it("offers field + dataset templates, each mapped to a valid pac value", () => {
+    const values = pcfTemplateChoices().map((c) => c.value);
+    expect(values).toEqual(["field", "dataset"]);
+    // Every choice value is one pcfInitArgs accepts.
+    for (const value of values) {
+      expect(pcfInitArgs({ template: value, framework: "none" })).toContain(value);
+    }
+  });
+
+  it("offers none + react frameworks, each mapped to a valid pac value", () => {
+    const values = pcfFrameworkChoices().map((c) => c.value);
+    expect(values).toEqual(["none", "react"]);
+    for (const value of values) {
+      expect(pcfInitArgs({ template: "field", framework: value })).toContain(value);
+    }
+  });
+
+  it("every choice has a distinct human label + description", () => {
+    for (const choice of [...pcfTemplateChoices(), ...pcfFrameworkChoices()]) {
+      expect(choice.label.length).toBeGreaterThan(0);
+      expect(choice.description && choice.description.length).toBeGreaterThan(0);
+    }
+  });
+
+  it("defaults match the previous hardcoded scaffold (field/none) so cancelling is safe", () => {
+    expect(PCF_INIT_DEFAULTS).toEqual({ template: "field", framework: "none" });
+    expect(pcfInitArgs(PCF_INIT_DEFAULTS)).toEqual(["pcf", "init", "--template", "field", "--framework", "none"]);
+  });
+});

--- a/src/pcf/pcfInitPrompt.ts
+++ b/src/pcf/pcfInitPrompt.ts
@@ -1,0 +1,59 @@
+import * as vscode from "vscode";
+import { PcfTemplate, PcfFramework, PcfInitOptions, pcfInitArgs } from "./pcfArgs";
+
+// Scaffold-time quick-pick for a new PCF control (#141): let the user choose the control
+// TEMPLATE (field vs dataset) and FRAMEWORK (none vs React) instead of always scaffolding
+// the hardcoded field/none. The pure choice lists + the argv builder are unit-testable; only
+// the two showQuickPick calls touch `vscode`. Runs once, up front, at PCF component init.
+
+interface TemplatePick extends vscode.QuickPickItem {
+  value: PcfTemplate;
+}
+interface FrameworkPick extends vscode.QuickPickItem {
+  value: PcfFramework;
+}
+
+/** Default when the user dismisses a pick — matches the previous hardcoded scaffold, so
+ * cancelling never breaks or surprises. */
+export const PCF_INIT_DEFAULTS: PcfInitOptions = { template: "field", framework: "none" };
+
+/** Control-template choices (pure — unit-tested). field = a single bound property control;
+ * dataset = a grid/data-set control. */
+export function pcfTemplateChoices(): TemplatePick[] {
+  return [
+    { value: "field", label: "Field", description: "Bound to a single column (property control)" },
+    { value: "dataset", label: "Dataset", description: "Bound to a grid / view (data-set control)" },
+  ];
+}
+
+/** Rendering-framework choices (pure — unit-tested). none = vanilla TS/HTML; react = a
+ * virtual/platform React control (pac scaffolds the React deps). */
+export function pcfFrameworkChoices(): FrameworkPick[] {
+  return [
+    { value: "none", label: "Standard (no framework)", description: "Vanilla TypeScript / HTML" },
+    { value: "react", label: "React", description: "Virtual control using the platform React libraries" },
+  ];
+}
+
+/**
+ * Ask for the PCF control template + framework and return the `pac pcf init` argv. Returns the
+ * argv for the chosen options, or for PCF_INIT_DEFAULTS if the user escapes either pick (so the
+ * scaffold still proceeds exactly as it did before). Never returns free-text — the argv tokens
+ * come only from the fixed enums, so nothing user-typed reaches the command line.
+ */
+export async function promptPcfInitArgs(): Promise<string[]> {
+  const template = await vscode.window.showQuickPick(pcfTemplateChoices(), {
+    placeHolder: "PCF control template",
+    ignoreFocusOut: true,
+  });
+  const framework = await vscode.window.showQuickPick(pcfFrameworkChoices(), {
+    placeHolder: "PCF rendering framework",
+    ignoreFocusOut: true,
+  });
+  const options: PcfInitOptions = {
+    template: template?.value ?? PCF_INIT_DEFAULTS.template,
+    framework: framework?.value ?? PCF_INIT_DEFAULTS.framework,
+  };
+  // pcfInitArgs yields ["pcf","init",…]; the restore runner prefixes "pac".
+  return ["pac", ...pcfInitArgs(options)];
+}


### PR DESCRIPTION
Closes the **scaffold flow** item on #141. Adding a PCF component ran a hardcoded `pac pcf init --template field --framework none`; it now asks two quick-picks first:
- **Template** — Field (single bound column) vs Dataset (grid/view)
- **Framework** — Standard (vanilla TS) vs React (platform React libraries)

and scaffolds with the chosen `pac pcf init` flags. Dismissing either pick falls back to the previous field/none default, so the flow never breaks. The argv is built from the existing unit-tested `pcfInitArgs` over fixed enums — no user free-text reaches the command line, so it's safe to run as-is (bypassing the ALLOWED_ARGV string gate).

- `src/pcf/pcfInitPrompt.ts` — pure `pcfTemplateChoices()`/`pcfFrameworkChoices()` + `promptPcfInitArgs()`
- `restoreDependencies` prompts once up front for a PCF init and substitutes the chosen argv
- `isPacPcfInit()` matches the template's scaffold command

**726/726.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)