### PR TITLE
0.14.30 (pre-release) — mock the Dataverse Web API (#143 Move 2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to the "dataverse-powertools" extension will be documented in this file.
 
+## 0.14.30 (pre-release)
+
+Testing (#143 Move 2) — **mock the Dataverse Web API.** A reusable in-memory Web API mock (`test/dataverseFetchMock.ts`) lets the extension's Dataverse clients run in CI with no live org — it models the org row (trace-level GET/PATCH) + WhoAmI over configurable state and records every request. The first spec exercises the trace-log read/write client against it and, crucially, asserts it behaves **identically under service-principal and interactive (OAuth) connections** — the recurring bug class (#128/#129/#135) was gating Dataverse calls on `tenantId`, which OAuth doesn't carry. No new dependency (a plain `fetch` shim, restored per test). +6 tests (732).
+
 ## 0.14.29 (pre-release)
 
 PCF (#141) — **choose the control template + framework when scaffolding.** Adding a PCF component previously always ran `pac pcf init --template field --framework none`. It now asks two quick-picks up front — **template** (Field vs Dataset) and **framework** (Standard vs React) — and scaffolds accordingly. Dismissing either pick falls back to the previous field/none default, so nothing breaks. The choice values come from fixed enums (no free-text reaches the command line). Pure choice lists + argv builder unit-tested. +4 tests (726).

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "type": "git",
     "url": "https://github.com/pete-mc/dataverse-powertools"
   },
-  "version": "0.14.29",
+  "version": "0.14.30",
   "engines": {
     "vscode": "^1.95.0"
   },

--- a/src/general/dataverse/traceLogSetting.mock.spec.ts
+++ b/src/general/dataverse/traceLogSetting.mock.spec.ts
@@ -1,0 +1,79 @@
+import { describe, it, expect, afterEach } from "vitest";
+import { getTraceLogSetting, setTraceLogSetting } from "./traceLogSetting";
+import { installDataverseFetchMock, DataverseFetchMock } from "../../../test/dataverseFetchMock";
+import type DataversePowerToolsContext from "../../context";
+
+// #143 Move 2 — exercise a real Dataverse client (trace-log read/write) against the in-memory
+// Web API mock, with NO live org. The point beyond "it parses": prove the call works
+// IDENTICALLY under service-principal and interactive (OAuth) connections — the recurring
+// bug class (#128/#129/#135) was gating Dataverse calls on tenantId, which OAuth doesn't carry.
+// The clients gate on canCallDataverseApi({ organizationUrl, isValid }); the token authorises.
+
+const ORG_URL = "https://contoso.crm.dynamics.com";
+
+/** A fake context whose only Dataverse-relevant facts are the org URL, validity, and a token.
+ * SP and OAuth differ only in authType/tenantId — which must NOT change behaviour. */
+function fakeContext(over: { isValid?: boolean; tenantId?: string; authType?: string; token?: string } = {}): DataversePowerToolsContext {
+  const logs: string[] = [];
+  return {
+    channel: { appendLine: (m: string) => logs.push(m), show: () => undefined },
+    dataverse: {
+      organizationUrl: ORG_URL,
+      isValid: over.isValid ?? true,
+      getAuthorizationToken: async () => over.token ?? "test-token",
+    },
+    projectSettings: { tenantId: over.tenantId },
+  } as unknown as DataversePowerToolsContext;
+}
+
+const servicePrincipal = () => fakeContext({ tenantId: "aaaa-tenant", authType: "clientsecret", token: "sp-token" });
+const interactive = () => fakeContext({ tenantId: undefined, authType: "oauth", token: "oauth-token" }); // OAuth carries NO tenantId
+
+describe("Dataverse trace-log client against the Web API mock (#143 Move 2)", () => {
+  let mock: DataverseFetchMock | undefined;
+  afterEach(() => mock?.restore());
+
+  it("reads the org trace level and parses it", async () => {
+    mock = installDataverseFetchMock({ pluginTraceLogSetting: 2 });
+    expect(await getTraceLogSetting(servicePrincipal())).toBe(2);
+  });
+
+  it("writes the trace level via PATCH and the mock reflects it", async () => {
+    mock = installDataverseFetchMock({ pluginTraceLogSetting: 0 });
+    const ok = await setTraceLogSetting(servicePrincipal(), 1);
+    expect(ok).toBe(true);
+    expect(mock.state.pluginTraceLogSetting).toBe(1);
+    // A follow-up read sees the new value.
+    expect(await getTraceLogSetting(servicePrincipal())).toBe(1);
+  });
+
+  it("behaves IDENTICALLY under OAuth (no tenantId) and service principal — the #128/#129/#135 guard", async () => {
+    mock = installDataverseFetchMock({ pluginTraceLogSetting: 1 });
+    expect(await getTraceLogSetting(interactive())).toBe(1);
+    expect(await setTraceLogSetting(interactive(), 2)).toBe(true);
+    expect(mock.state.pluginTraceLogSetting).toBe(2);
+    // The interactive context never carried a tenantId, yet every call worked.
+  });
+
+  it("sends the connection's Bearer token on every call (the token authorises, not the tenant)", async () => {
+    mock = installDataverseFetchMock();
+    await getTraceLogSetting(interactive());
+    expect(mock.requests.length).toBeGreaterThan(0);
+    expect(mock.requests.every((r) => r.authorization === "Bearer oauth-token")).toBe(true);
+  });
+
+  it("targets the org Web API URL (base + /api/data/<version>/organizations)", async () => {
+    mock = installDataverseFetchMock();
+    await getTraceLogSetting(servicePrincipal());
+    const get = mock.requests.find((r) => r.method === "GET");
+    expect(get?.url).toContain(`${ORG_URL}/api/data/`);
+    expect(get?.url).toContain("organizations?");
+  });
+
+  it("does not touch the network when the connection is not valid", async () => {
+    mock = installDataverseFetchMock();
+    expect(await getTraceLogSetting(fakeContext({ isValid: false }))).toBeUndefined();
+    expect(await setTraceLogSetting(fakeContext({ isValid: false }), 2)).toBe(false);
+    expect(mock.requests.length).toBe(0);
+  });
+});

--- a/test/dataverseFetchMock.ts
+++ b/test/dataverseFetchMock.ts
@@ -1,0 +1,98 @@
+// Reusable in-memory Dataverse Web API mock for unit tests (#143 Move 2).
+//
+// The extension's Dataverse clients (src/general/dataverse/*) all call the global `fetch`
+// with a Bearer token from `context.dataverse.getAuthorizationToken()`. This installs a fake
+// `global.fetch` that models a handful of Dataverse Web API endpoints over configurable
+// in-memory state, so command/handler logic — especially the OAuth-vs-service-principal
+// branching that has bitten repeatedly (#128/#129/#135) — is testable in CI without a live
+// org. It records every request (URL, method, Authorization) so tests can assert the auth
+// path. No new dependency: it's a plain fetch shim, restored on teardown.
+
+export type TraceLevel = 0 | 1 | 2;
+
+export interface DataverseMockState {
+  /** The single `organization` row id + its plug-in trace level. */
+  organizationId: string;
+  pluginTraceLogSetting: TraceLevel;
+  /** WhoAmI response fields. */
+  userId: string;
+  businessUnitId: string;
+}
+
+export interface RecordedRequest {
+  url: string;
+  method: string;
+  /** The Authorization header, e.g. "Bearer <token>" — lets tests assert the token reached the API. */
+  authorization?: string;
+  body?: unknown;
+}
+
+export interface DataverseFetchMock {
+  state: DataverseMockState;
+  requests: RecordedRequest[];
+  restore(): void;
+}
+
+export const DEFAULT_MOCK_STATE: DataverseMockState = {
+  organizationId: "12345678-1234-1234-1234-1234567890ab",
+  pluginTraceLogSetting: 0,
+  userId: "aaaaaaaa-1111-2222-3333-444444444444",
+  businessUnitId: "bbbbbbbb-5555-6666-7777-888888888888",
+};
+
+function json(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), { status, headers: { "Content-Type": "application/json" } });
+}
+
+/**
+ * Install the mock over `global.fetch`. Returns the mutable state, the recorded requests,
+ * and a `restore()` to put the original fetch back (call it in afterEach).
+ */
+export function installDataverseFetchMock(initial: Partial<DataverseMockState> = {}): DataverseFetchMock {
+  const state: DataverseMockState = { ...DEFAULT_MOCK_STATE, ...initial };
+  const requests: RecordedRequest[] = [];
+  const original = global.fetch;
+
+  global.fetch = (async (input: RequestInfo | URL, init?: RequestInit): Promise<Response> => {
+    const url = typeof input === "string" ? input : input instanceof URL ? input.toString() : (input as Request).url;
+    const method = (init?.method ?? "GET").toUpperCase();
+    const headers = new Headers(init?.headers as HeadersInit | undefined);
+    let body: unknown;
+    if (init?.body && typeof init.body === "string") {
+      try {
+        body = JSON.parse(init.body);
+      } catch {
+        body = init.body;
+      }
+    }
+    requests.push({ url, method, authorization: headers.get("Authorization") ?? undefined, body });
+
+    // Only the Dataverse Web API path is modelled; anything else 404s (a test hitting an
+    // unmodelled endpoint should fail loudly rather than silently pass).
+    const apiIndex = url.indexOf("/api/data/");
+    if (apiIndex === -1) {
+      return json({ error: { message: "not a Dataverse Web API url" } }, 404);
+    }
+    const resource = url.slice(url.indexOf("/", apiIndex + "/api/data/".length) + 1); // after the version segment
+
+    // GET organizations?$select=… → the single org row.
+    if (method === "GET" && resource.startsWith("organizations?")) {
+      return json({ value: [{ organizationid: state.organizationId, plugintracelogsetting: state.pluginTraceLogSetting }] });
+    }
+    // PATCH organizations(<id>) → update the trace level (204 No Content).
+    if (method === "PATCH" && resource.startsWith(`organizations(${state.organizationId})`)) {
+      const patch = body as { plugintracelogsetting?: number } | undefined;
+      if (patch && (patch.plugintracelogsetting === 0 || patch.plugintracelogsetting === 1 || patch.plugintracelogsetting === 2)) {
+        state.pluginTraceLogSetting = patch.plugintracelogsetting;
+      }
+      return new Response(null, { status: 204 });
+    }
+    // GET WhoAmI → identity (auth-agnostic; the token is what authorises).
+    if (method === "GET" && resource.startsWith("WhoAmI")) {
+      return json({ UserId: state.userId, BusinessUnitId: state.businessUnitId, OrganizationId: state.organizationId });
+    }
+    return json({ error: { message: `unmodelled ${method} ${resource}` } }, 404);
+  }) as typeof fetch;
+
+  return { state, requests, restore: () => void (global.fetch = original) };
+}


### PR DESCRIPTION
Delivers **Move 2** of the testing epic (#143): a way to run the extension's Dataverse clients in CI **without a live org**.

- `test/dataverseFetchMock.ts` — a reusable, dependency-free `fetch` shim modelling the Dataverse Web API over mutable in-memory state (org row trace-level GET/PATCH, WhoAmI). It records every request (URL, method, Authorization) and restores the real `fetch` on teardown.
- `traceLogSetting.mock.spec.ts` — drives the real trace-log read/write client against the mock and asserts:
  - it parses the level and PATCHes correctly (mock state updates; a follow-up read sees it);
  - **it behaves identically under service-principal and interactive (OAuth) connections** — the OAuth context carries **no tenantId**, yet every call works. This is the deterministic, CI-runnable guard for the recurring bug class (#128/#129/#135: never gate a Dataverse call on tenantId);
  - the connection's Bearer token reaches the API on every call;
  - a not-valid connection makes **zero** network calls.

Chose a plain fetch shim over `msw` to match the repo's minimal-dependency style. The mock is reusable for future handler tests (portal/webresource/plugin Dataverse paths). **732/732.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)