### PR TITLE
0.14.31 (pre-release) — extend Dataverse mock to trace-log viewer (#143)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to the "dataverse-powertools" extension will be documented in this file.
 
+## 0.14.31 (pre-release)
+
+Testing (#143) — **extend the Dataverse Web API mock to the plugin trace-log viewer.** Building on 0.14.30, the mock now serves `plugintracelogs` and a new spec drives `getPluginTraceLogs` against it (rows, empty-org, `$orderby`/`$top`/Bearer, and identical behaviour under service-principal vs OAuth). Closes another of the epic's "specific flow gaps" with deterministic, no-live-org coverage. +5 tests (737).
+
 ## 0.14.30 (pre-release)
 
 Testing (#143 Move 2) — **mock the Dataverse Web API.** A reusable in-memory Web API mock (`test/dataverseFetchMock.ts`) lets the extension's Dataverse clients run in CI with no live org — it models the org row (trace-level GET/PATCH) + WhoAmI over configurable state and records every request. The first spec exercises the trace-log read/write client against it and, crucially, asserts it behaves **identically under service-principal and interactive (OAuth) connections** — the recurring bug class (#128/#129/#135) was gating Dataverse calls on `tenantId`, which OAuth doesn't carry. No new dependency (a plain `fetch` shim, restored per test). +6 tests (732).

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "type": "git",
     "url": "https://github.com/pete-mc/dataverse-powertools"
   },
-  "version": "0.14.30",
+  "version": "0.14.31",
   "engines": {
     "vscode": "^1.95.0"
   },

--- a/src/general/dataverse/getPluginTraceLogs.mock.spec.ts
+++ b/src/general/dataverse/getPluginTraceLogs.mock.spec.ts
@@ -1,0 +1,67 @@
+import { describe, it, expect, afterEach } from "vitest";
+import { getPluginTraceLogs } from "./getPluginTraceLogs";
+import { installDataverseFetchMock, DataverseFetchMock } from "../../../test/dataverseFetchMock";
+import type DataversePowerToolsContext from "../../context";
+
+// #143 flow-gap coverage — the plugin trace-log viewer (#63/#137) run against the Web API mock,
+// no live org. Like the trace-level client, it must work identically under service-principal and
+// interactive (OAuth) connections (never gate a Dataverse call on tenantId — #128/#129/#135).
+
+const ORG_URL = "https://contoso.crm.dynamics.com";
+
+function fakeContext(over: { isValid?: boolean; token?: string } = {}): DataversePowerToolsContext {
+  return {
+    channel: { appendLine: () => undefined, show: () => undefined },
+    dataverse: {
+      organizationUrl: ORG_URL,
+      isValid: over.isValid ?? true,
+      getAuthorizationToken: async () => over.token ?? "test-token",
+    },
+    projectSettings: {},
+  } as unknown as DataversePowerToolsContext;
+}
+
+const rows = [
+  { plugintracelogid: "11111111-0000-0000-0000-000000000001", typename: "Acme.MyPlugin", messagename: "Update", createdon: "2026-07-17T00:00:00Z" },
+  { plugintracelogid: "11111111-0000-0000-0000-000000000002", typename: "Acme.Other", messagename: "Create", createdon: "2026-07-16T00:00:00Z" },
+];
+
+describe("getPluginTraceLogs against the Web API mock (#143 flow gaps)", () => {
+  let mock: DataverseFetchMock | undefined;
+  afterEach(() => mock?.restore());
+
+  it("returns the trace-log rows the API serves", async () => {
+    mock = installDataverseFetchMock({ pluginTraceLogs: rows });
+    const result = await getPluginTraceLogs(fakeContext());
+    expect(result).toHaveLength(2);
+    expect(result?.[0].typename).toBe("Acme.MyPlugin");
+  });
+
+  it("returns [] when the org has no trace logs (not undefined)", async () => {
+    mock = installDataverseFetchMock({ pluginTraceLogs: [] });
+    expect(await getPluginTraceLogs(fakeContext())).toEqual([]);
+  });
+
+  it("requests plugintracelogs with $orderby desc + $top, carrying the Bearer token", async () => {
+    mock = installDataverseFetchMock({ pluginTraceLogs: rows });
+    await getPluginTraceLogs(fakeContext({ token: "oauth-token" }), 10);
+    const req = mock.requests.find((r) => r.method === "GET");
+    expect(req?.url).toContain("plugintracelogs?");
+    expect(req?.url).toContain("$orderby=createdon");
+    expect(req?.url).toContain("$top=10");
+    expect(req?.authorization).toBe("Bearer oauth-token");
+  });
+
+  it("works under OAuth (no tenantId) exactly as under a service principal", async () => {
+    mock = installDataverseFetchMock({ pluginTraceLogs: rows });
+    // Same call, only the token differs — both connect the same way.
+    expect((await getPluginTraceLogs(fakeContext({ token: "sp-token" })))?.length).toBe(2);
+    expect((await getPluginTraceLogs(fakeContext({ token: "oauth-token" })))?.length).toBe(2);
+  });
+
+  it("returns undefined and makes no network call when the connection is invalid", async () => {
+    mock = installDataverseFetchMock({ pluginTraceLogs: rows });
+    expect(await getPluginTraceLogs(fakeContext({ isValid: false }))).toBeUndefined();
+    expect(mock.requests.length).toBe(0);
+  });
+});

--- a/test/dataverseFetchMock.ts
+++ b/test/dataverseFetchMock.ts
@@ -17,6 +17,8 @@ export interface DataverseMockState {
   /** WhoAmI response fields. */
   userId: string;
   businessUnitId: string;
+  /** Rows returned by GET plugintracelogs (the trace-log viewer, #63/#137). */
+  pluginTraceLogs: Array<Record<string, unknown>>;
 }
 
 export interface RecordedRequest {
@@ -38,6 +40,7 @@ export const DEFAULT_MOCK_STATE: DataverseMockState = {
   pluginTraceLogSetting: 0,
   userId: "aaaaaaaa-1111-2222-3333-444444444444",
   businessUnitId: "bbbbbbbb-5555-6666-7777-888888888888",
+  pluginTraceLogs: [],
 };
 
 function json(body: unknown, status = 200): Response {
@@ -86,6 +89,10 @@ export function installDataverseFetchMock(initial: Partial<DataverseMockState> =
         state.pluginTraceLogSetting = patch.plugintracelogsetting;
       }
       return new Response(null, { status: 204 });
+    }
+    // GET plugintracelogs?$select=…&$orderby=…&$top=… → the trace-log rows.
+    if (method === "GET" && resource.startsWith("plugintracelogs?")) {
+      return json({ value: state.pluginTraceLogs });
     }
     // GET WhoAmI → identity (auth-agnostic; the token is what authorises).
     if (method === "GET" && resource.startsWith("WhoAmI")) {


### PR DESCRIPTION
Builds on the 0.14.30 Web API mock (#143 Move 2). The mock now models `GET plugintracelogs`, and `getPluginTraceLogs.mock.spec.ts` drives the real trace-log viewer client against it:
- returns the served rows; returns `[]` (not undefined) for an empty org;
- requests `plugintracelogs?…$orderby=createdon…&$top=N` carrying the Bearer token;
- behaves identically under service-principal and OAuth (no tenantId);
- makes **zero** network calls when the connection is invalid.

Closes another of #143's 'specific flow gaps' with deterministic, CI-runnable, no-live-org coverage. **737/737.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)