### PR TITLE
0.14.33 (pre-release) — PCF live-form hot reload (#141 #5)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to the "dataverse-powertools" extension will be documented in this file.
 
+## 0.14.33 (pre-release)
+
+PCF (#141 #5) — **Debug a control on a live form (hot reload).** New **Debug on live form (hot)** command runs a locally-built PCF control *inside the real model-driven app*: it launches Edge/Chrome under the DevTools Protocol, bypasses the app's service worker (#64), and intercepts the **deployed** control's `bundle.js` request — fulfilling it from your local pcf-scripts build (`out/controls/<Constructor>/bundle.js`), which a `build --watch` rebuilds on save (the page reloads). Nothing is written to the server; it's the CDP analogue of the official Fiddler/Requestly AutoResponder debug flow. This is the live-form half of the hot-reload story (the standalone harness, 0.14.24, is the other half). The control must be deployed (`pac pcf push`) and added to a form first. The bundle-URL matcher is grounded in the documented control-bundle scheme and unit-tested; the shared CDP/browser plumbing is factored out of the web-resource debugger (`cdpProcess.ts`) and reused. +10 tests (747).
+
 ## 0.14.32 (pre-release)
 
 Docs (#127) — **Empty/multi-component project screenshot added to the Marketplace listing.** The README now shows the *Empty* project panel (an "Or start empty — mix components in one repo" callout) alongside the three project-type images; the wiki gets the same clean cropped image and a cropped Get-Started shot. Adds a `blank` case + fixture to the screenshots generator (`src/ui-test/screenshots.ts`). No code change to the shipped extension.

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "type": "git",
     "url": "https://github.com/pete-mc/dataverse-powertools"
   },
-  "version": "0.14.32",
+  "version": "0.14.33",
   "engines": {
     "vscode": "^1.95.0"
   },
@@ -775,6 +775,16 @@
       {
         "command": "dataverse-powertools.runPcfHarness",
         "title": "Dataverse PowerTools: Run PCF test harness (hot reload)",
+        "enablement": "dataverse-powertools.showLoaded && dataverse-powertools.isPcf"
+      },
+      {
+        "command": "dataverse-powertools.debugPcfLiveForm",
+        "title": "Dataverse PowerTools: Debug PCF control on a live form (serve local build into the app)",
+        "enablement": "dataverse-powertools.showLoaded && dataverse-powertools.isPcf"
+      },
+      {
+        "command": "dataverse-powertools.stopPcfLiveDebug",
+        "title": "Dataverse PowerTools: Stop PCF live-form debug",
         "enablement": "dataverse-powertools.showLoaded && dataverse-powertools.isPcf"
       },
       {

--- a/src/pcf/debug/debugPcfLiveForm.ts
+++ b/src/pcf/debug/debugPcfLiveForm.ts
@@ -1,0 +1,215 @@
+/* eslint-disable @typescript-eslint/naming-convention */ // CDP domain names (Fetch, Page, Network) are PascalCase by protocol convention.
+import * as vscode from "vscode";
+import * as fs from "fs";
+import * as path from "path";
+import * as cp from "child_process";
+import CDP = require("chrome-remote-interface");
+import DataversePowerToolsContext from "../../context";
+import { resolveBrowser, BrowserPreference } from "../../webresources/debug/browserResolver";
+import { buildBrowserArgs } from "../../webresources/debug/browserArgs";
+import { findFreePort, killProcessTree, connectCdpWithRetry } from "../../webresources/debug/cdpProcess";
+import { activeComponentRoot } from "../../components/componentDiscovery";
+import { findControlDir, readControlManifest } from "../controlManifest";
+import { isPcfBundleUrl, pcfBundleCdpPattern, pcfBundleContentType, pcfLocalBundlePath } from "./pcfBundleUrl";
+
+// "Debug PCF (live form)": run a locally-built PCF control INSIDE the real model-driven app —
+// the live-form half of #141 #5 (the standalone harness is the other half, `npm start watch`).
+// It reuses the exact web-resource debug plumbing (#64): launch Edge/Chrome under CDP, bypass the
+// model-driven app's service worker, and intercept the DEPLOYED control's bundle.js request,
+// fulfilling it from the local pcf-scripts build (out/controls/<Constructor>/bundle.js). A build
+// --watch rebuilds on save and the page reloads. Nothing is written to the server (ephemeral,
+// browser-scoped) — the CDP analogue of the official Fiddler/Requestly AutoResponder debug flow.
+//
+// The control must already be DEPLOYED (pac pcf push) and added to a form; this redirects its
+// bundle to your local build. Build in development mode so the bundle stays small enough to serve.
+
+interface ActivePcfDebugSession {
+  dispose(): Promise<void>;
+}
+
+let activeSession: ActivePcfDebugSession | undefined;
+
+// Rebuild-on-save via the project's LOCAL pcf-scripts build in watch mode → out/controls/.../bundle.js
+// (the DEPLOYABLE bundle, not the test-harness output). `npm run build -- --watch` runs the project's
+// pcf-scripts; npm is a `.cmd` shim on Windows, hence shell:true at the spawn site.
+export const PCF_WATCH_LAUNCHER = "npm";
+export const PCF_WATCH_ARGS = ["run", "build", "--", "--watch"];
+
+export function isPcfDebugSessionActive(): boolean {
+  return activeSession !== undefined;
+}
+
+/** Stop the running PCF live-form debug session (browser, pcf build watch, CDP, watchers). */
+export async function stopPcfLiveDebug(): Promise<void> {
+  const session = activeSession;
+  if (!session) {
+    return;
+  }
+  activeSession = undefined;
+  await session.dispose();
+}
+
+export async function debugPcfLiveForm(context: DataversePowerToolsContext): Promise<void> {
+  if (activeSession) {
+    context.channel.appendLine("[pcf-debug] Stopping the previous live-form session before starting a new one.");
+    await stopPcfLiveDebug();
+  }
+
+  const folders = vscode.workspace.workspaceFolders;
+  if (!folders || folders.length === 0) {
+    vscode.window.showErrorMessage("Open a PCF component folder before debugging.");
+    return;
+  }
+  const workspaceFolder = folders[0];
+  const componentRoot = activeComponentRoot(context) ?? workspaceFolder.uri.fsPath;
+  const controlDir = findControlDir(componentRoot);
+  if (!controlDir) {
+    vscode.window.showErrorMessage("Couldn't find a ControlManifest.Input.xml — is this a PCF control?");
+    return;
+  }
+  const manifest = readControlManifest(controlDir);
+  if (!manifest) {
+    vscode.window.showErrorMessage("Couldn't read the control's ControlManifest.Input.xml (namespace/constructor).");
+    return;
+  }
+
+  // Need a live connection to know the org URL to open (the control must be deployed there).
+  if (!context.dataverse || !context.dataverse.isValid) {
+    const initialised = context.dataverse ? await context.dataverse.initialize() : false;
+    if (!initialised) {
+      vscode.window.showErrorMessage("Connect to Dataverse before debugging a PCF control on a live form.");
+      return;
+    }
+  }
+  const orgUrl = context.dataverse.organizationUrl;
+  if (!orgUrl) {
+    vscode.window.showErrorMessage("No Dataverse organisation URL is available. Check the connection and try again.");
+    return;
+  }
+
+  const bundlePath = pcfLocalBundlePath(controlDir, manifest.constructor);
+  const bundleDir = path.dirname(bundlePath);
+
+  const settings = vscode.workspace.getConfiguration("dataverse-powertools");
+  const prefer = (settings.get<string>("debugBrowser") || "auto") as BrowserPreference;
+  const overridePath = settings.get<string>("debugBrowserPath") || undefined;
+  let browser;
+  try {
+    browser = resolveBrowser(prefer, overridePath, { platform: process.platform, env: process.env, exists: fs.existsSync });
+  } catch (error: any) {
+    vscode.window.showErrorMessage(error?.message || "Could not find a browser to debug with.");
+    return;
+  }
+
+  let watchProc: cp.ChildProcess | undefined;
+  let browserProc: cp.ChildProcess | undefined;
+  let client: CDP.Client | undefined;
+  let fsWatcher: fs.FSWatcher | undefined;
+  let reloadTimer: NodeJS.Timeout | undefined;
+  let disposed = false;
+
+  const dispose = async () => {
+    if (disposed) {
+      return;
+    }
+    disposed = true;
+    if (reloadTimer) {
+      clearTimeout(reloadTimer);
+    }
+    try {
+      fsWatcher?.close();
+    } catch {
+      /* ignore */
+    }
+    try {
+      await client?.close();
+    } catch {
+      /* ignore */
+    }
+    killProcessTree(watchProc);
+    killProcessTree(browserProc);
+    context.channel.appendLine("PCF live-form debug session stopped.");
+  };
+
+  await vscode.window.withProgress({ location: vscode.ProgressLocation.Notification, title: "Starting PCF live-form debug session…" }, async () => {
+    // 1. pcf-scripts build --watch → out/controls/<Constructor>/bundle.js on every save.
+    watchProc = cp.spawn(PCF_WATCH_LAUNCHER, PCF_WATCH_ARGS, { cwd: controlDir, shell: process.platform === "win32" });
+    watchProc.stdout?.on("data", (d) => context.channel.appendLine(`[pcf build] ${String(d).trimEnd()}`));
+    watchProc.stderr?.on("data", (d) => context.channel.appendLine(`[pcf build] ${String(d).trimEnd()}`));
+
+    // 2. Persistent browser profile so the Dataverse login survives between sessions.
+    const userDataDir = path.join(context.vscode.globalStorageUri.fsPath, "pcf-debug-profile");
+    fs.mkdirSync(userDataDir, { recursive: true });
+
+    // 3. One port serves both interception and the VS Code debugger.
+    const port = await findFreePort();
+
+    // 4. Launch on about:blank; navigate only after interception is armed (avoids a reload race).
+    browserProc = cp.spawn(browser.executablePath, buildBrowserArgs({ port, userDataDir, url: "about:blank" }), { detached: false, stdio: "ignore" });
+    browserProc.on("exit", () => void stopPcfLiveDebug());
+
+    // 5. Connect CDP, bypass the service worker (#64), intercept the deployed control's bundle.
+    client = await connectCdpWithRetry(port, 20000);
+    const { Fetch, Page, Network } = client;
+    await Page.enable();
+    await Network.enable();
+    await Network.setBypassServiceWorker({ bypass: true });
+    await Fetch.enable({ patterns: [{ urlPattern: pcfBundleCdpPattern(), requestStage: "Request" }] });
+
+    Fetch.requestPaused(async (params) => {
+      const requestId = params.requestId;
+      try {
+        if (isPcfBundleUrl(params.request.url, manifest.namespace, manifest.constructor) && fs.existsSync(bundlePath)) {
+          const body = fs.readFileSync(bundlePath).toString("base64");
+          await Fetch.fulfillRequest({
+            requestId,
+            responseCode: 200,
+            responseHeaders: [
+              { name: "Content-Type", value: pcfBundleContentType() },
+              { name: "Cache-Control", value: "no-store" },
+            ],
+            body,
+          });
+          context.channel.appendLine(`[pcf-debug] served local bundle.js for ${manifest.namespace}.${manifest.constructor} into the live app`);
+        } else {
+          await Fetch.continueRequest({ requestId });
+        }
+      } catch (error: any) {
+        context.channel.appendLine(`[pcf-debug] interception error: ${error?.message || error}`);
+        try {
+          await Fetch.continueRequest({ requestId });
+        } catch {
+          /* the request may already be gone */
+        }
+      }
+    });
+
+    client.on("disconnect", () => void stopPcfLiveDebug());
+
+    await Page.navigate({ url: orgUrl });
+
+    // 6. Hot refresh: reload the page when the built bundle changes (debounced). The build creates
+    //    out/controls/<Constructor>/ on first run, so watch the parent until it exists.
+    fs.mkdirSync(bundleDir, { recursive: true });
+    fsWatcher = fs.watch(bundleDir, (_event, filename) => {
+      if (filename && String(filename) !== "bundle.js") {
+        return;
+      }
+      if (reloadTimer) {
+        clearTimeout(reloadTimer);
+      }
+      reloadTimer = setTimeout(() => {
+        context.channel.appendLine("[pcf-debug] bundle rebuilt — reloading");
+        Page.reload({ ignoreCache: true }).catch(() => undefined);
+      }, 400);
+    });
+
+    activeSession = { dispose };
+    context.channel.appendLine(`[pcf-debug] DevTools endpoint on port ${port}`);
+    context.channel.appendLine(
+      `PCF live-form debug started with ${browser.kind === "chrome" ? "Chrome" : "Edge"}. Log in, open the form/view with your control, and edits will hot-reload the local bundle. Deploy the control first (pac pcf push) if you haven't.`,
+    );
+    context.channel.show();
+    vscode.window.showInformationMessage("PCF live-form debug started — the live app is now running your local control bundle.");
+  });
+}

--- a/src/pcf/debug/pcfBundleUrl.spec.ts
+++ b/src/pcf/debug/pcfBundleUrl.spec.ts
@@ -1,0 +1,65 @@
+import { describe, it, expect } from "vitest";
+import { isPcfBundleUrl, pcfBundleCdpPattern, pcfLocalBundlePath, pcfBundleContentType, controlKey, PCF_BUNDLE_FILENAME } from "./pcfBundleUrl";
+
+// Ground truth: the platform serves a deployed code component's bundle at a URL containing
+// "<Namespace>.<Constructor>" then the resource file (bundle.js) — the same shape the official
+// Fiddler/Requestly AutoResponder debug flow matches. Local build → out/controls/<Constructor>/bundle.js.
+const NS = "SampleNamespace";
+const CTOR = "ChoicesPicker";
+
+describe("isPcfBundleUrl (#141 live-form hot reload)", () => {
+  it("matches the deployed control bundle URL across platform variants", () => {
+    const urls = [
+      "https://org.crm.dynamics.com/webresources/SampleNamespace.ChoicesPicker/bundle.js",
+      "https://org.crm.dynamics.com/%7b637123456789%7d/webresources/SampleNamespace.ChoicesPicker/bundle.js",
+      "https://org.crm.dynamics.com/WebResources/SampleNamespace.ChoicesPicker/bundle.js?ver=1.0.0",
+      "https://org.crm.dynamics.com/uclient/.../SampleNamespace.ChoicesPicker.bundle.js", // dotted variant
+    ];
+    for (const url of urls) {
+      expect(isPcfBundleUrl(url, NS, CTOR), url).toBe(true);
+    }
+  });
+
+  it("is case-insensitive on the control key", () => {
+    expect(isPcfBundleUrl("https://org/webresources/samplenamespace.choicespicker/bundle.js", NS, CTOR)).toBe(true);
+  });
+
+  it("does NOT match the control's css/html sub-resources (only the bundle)", () => {
+    expect(isPcfBundleUrl("https://org/webresources/SampleNamespace.ChoicesPicker/css/ChoicesPicker.css", NS, CTOR)).toBe(false);
+    expect(isPcfBundleUrl("https://org/webresources/SampleNamespace.ChoicesPicker/ControlManifest.xml", NS, CTOR)).toBe(false);
+  });
+
+  it("does NOT match a different control's bundle", () => {
+    expect(isPcfBundleUrl("https://org/webresources/OtherNs.OtherControl/bundle.js", NS, CTOR)).toBe(false);
+  });
+
+  it("does NOT match an unrelated bundle.js (no control key)", () => {
+    expect(isPcfBundleUrl("https://org/webresources/acme_library/bundle.js", NS, CTOR)).toBe(false);
+  });
+
+  it("is false for empty inputs", () => {
+    expect(isPcfBundleUrl("", NS, CTOR)).toBe(false);
+    expect(isPcfBundleUrl("https://org/x/bundle.js", "", CTOR)).toBe(false);
+    expect(isPcfBundleUrl("https://org/x/bundle.js", NS, "")).toBe(false);
+  });
+});
+
+describe("pcf bundle helpers", () => {
+  it("controlKey joins namespace.constructor lower-cased", () => {
+    expect(controlKey(NS, CTOR)).toBe("samplenamespace.choicespicker");
+  });
+
+  it("CDP pattern over-matches on the bundle filename", () => {
+    expect(pcfBundleCdpPattern()).toBe("*bundle.js*");
+    expect(PCF_BUNDLE_FILENAME).toBe("bundle.js");
+  });
+
+  it("local bundle path is out/controls/<Constructor>/bundle.js under the control dir", () => {
+    const p = pcfLocalBundlePath("/repo/control", CTOR).replace(/\\/g, "/");
+    expect(p).toBe("/repo/control/out/controls/ChoicesPicker/bundle.js");
+  });
+
+  it("serves the bundle as JavaScript", () => {
+    expect(pcfBundleContentType()).toBe("application/javascript");
+  });
+});

--- a/src/pcf/debug/pcfBundleUrl.ts
+++ b/src/pcf/debug/pcfBundleUrl.ts
@@ -1,0 +1,66 @@
+// Pure helpers for the PCF live-form hot-reload (#141 #5): match the browser's request for a
+// DEPLOYED code component's bundle and resolve the local build to fulfil it with. This is the
+// CDP-interception analogue of the official Fiddler/Requestly "AutoResponder" debug flow
+// (learn.microsoft.com/power-apps/developer/component-framework/debugging-custom-controls):
+// a deployed control's bundle is served at a URL containing "<Namespace>.<Constructor>" then the
+// resource file (bundle.js), and the local build lands in "out/controls/<Constructor>/bundle.js".
+// Keying on "<Namespace>.<Constructor>" + the filename (NOT a "/webresources/" segment) matches
+// the platform's URL across its version/casing/encoding variants, mirroring the docs' regex.
+import * as path from "path";
+
+export const PCF_BUNDLE_FILENAME = "bundle.js";
+
+function safeDecode(value: string): string {
+  try {
+    return decodeURIComponent(decodeURIComponent(value)); // platform sometimes double-encodes the "/" in css/html subpaths
+  } catch {
+    try {
+      return decodeURIComponent(value);
+    } catch {
+      return value;
+    }
+  }
+}
+
+/** The "<namespace>.<constructor>" control key, lower-cased (how it appears in the served URL). */
+export function controlKey(namespace: string, constructorName: string): string {
+  return `${namespace}.${constructorName}`.toLowerCase();
+}
+
+/**
+ * True when `url` is the deployed control's bundle.js request. Matches when the decoded URL
+ * contains "<namespace>.<constructor>" followed (after a "/" or ".") by the bundle filename —
+ * the shape the platform serves a code component's bundle at, across its URL variants.
+ */
+export function isPcfBundleUrl(url: string, namespace: string, constructorName: string): boolean {
+  if (!url || !namespace || !constructorName) {
+    return false;
+  }
+  const decoded = safeDecode(url).toLowerCase();
+  const key = controlKey(namespace, constructorName);
+  const idx = decoded.indexOf(key);
+  if (idx === -1) {
+    return false;
+  }
+  // After the control key, the next path/query segment must be the bundle filename (allow a
+  // "/" or "." separator, e.g. ".../SampleNs.Control/bundle.js" or a versioned ".../...bundle.js").
+  const rest = decoded.slice(idx + key.length);
+  return new RegExp(`[./]${PCF_BUNDLE_FILENAME.replace(".", "\\.")}(\\?|$)`).test(rest);
+}
+
+/** A broad CDP `Fetch.enable` urlPattern that pauses candidate bundle requests (the precise
+ * decision is `isPcfBundleUrl`). Over-matches on the filename so no path variant is missed. */
+export function pcfBundleCdpPattern(): string {
+  return `*${PCF_BUNDLE_FILENAME}*`;
+}
+
+/** Local build output for a control's bundle: "<controlDir>/out/controls/<Constructor>/bundle.js"
+ * (the pcf-scripts build output; NOT the test-harness output). Pure — path only. */
+export function pcfLocalBundlePath(controlDir: string, constructorName: string): string {
+  return path.join(controlDir, "out", "controls", constructorName, PCF_BUNDLE_FILENAME);
+}
+
+/** Content type to serve the fulfilled bundle with. */
+export function pcfBundleContentType(): string {
+  return "application/javascript";
+}

--- a/src/projectTypes/activation.ts
+++ b/src/projectTypes/activation.ts
@@ -56,6 +56,7 @@ import { deployPcf } from "../pcf/deployPcf";
 import { refreshPcfTypes } from "../pcf/refreshPcfTypes";
 import { addPcfServiceLayer } from "../pcf/addServiceLayer";
 import { runPcfHarness } from "../pcf/runHarness";
+import { debugPcfLiveForm, stopPcfLiveDebug } from "../pcf/debug/debugPcfLiveForm";
 import { initialiseAzureFunction } from "../azurefunction/initialiseAzureFunction";
 import { buildAzureFunction } from "../azurefunction/buildAzureFunction";
 import { registerWebhookStep } from "../azurefunction/registerWebhookStep";
@@ -317,6 +318,8 @@ export const projectTypeActivations: Record<ProjectTypes, ProjectTypeActivation>
       "dataverse-powertools.refreshPcfTypes": (context) => refreshPcfTypes(context),
       "dataverse-powertools.addPcfServiceLayer": (context) => addPcfServiceLayer(context),
       "dataverse-powertools.runPcfHarness": (context) => runPcfHarness(context),
+      "dataverse-powertools.debugPcfLiveForm": (context) => debugPcfLiveForm(context),
+      "dataverse-powertools.stopPcfLiveDebug": () => stopPcfLiveDebug(),
     },
   },
   [ProjectTypes.azurefunction]: {

--- a/src/projectTypes/registry.ts
+++ b/src/projectTypes/registry.ts
@@ -268,7 +268,16 @@ export const projectTypeRegistry: readonly ProjectTypeDescriptor[] = [
     // Foundational slice (#141): scaffold + build + push + deploy (hand-to-solution) +
     // refresh-types. Debug/hot-reload, service-layer template and Jest Test Explorer are
     // explicit fast-follows.
-    commandIds: [`${prefix}buildPcf`, `${prefix}pushPcf`, `${prefix}deployPcf`, `${prefix}refreshPcfTypes`, `${prefix}addPcfServiceLayer`, `${prefix}runPcfHarness`],
+    commandIds: [
+      `${prefix}buildPcf`,
+      `${prefix}pushPcf`,
+      `${prefix}deployPcf`,
+      `${prefix}refreshPcfTypes`,
+      `${prefix}addPcfServiceLayer`,
+      `${prefix}runPcfHarness`,
+      `${prefix}debugPcfLiveForm`,
+      `${prefix}stopPcfLiveDebug`,
+    ],
     menu() {
       return {
         // Push (pac pcf push) is the one-click dev inner loop.
@@ -276,10 +285,14 @@ export const projectTypeRegistry: readonly ProjectTypeDescriptor[] = [
         secondary: [
           { command: `${prefix}buildPcf`, label: "Local Build" },
           { command: `${prefix}runPcfHarness`, label: "Run harness (hot reload)" },
+          { command: `${prefix}debugPcfLiveForm`, label: "Debug on live form (hot)" },
           { command: `${prefix}refreshPcfTypes`, label: "Refresh Types" },
           { command: `${prefix}deployPcf`, label: "Add to Solution" },
         ],
-        overflow: [{ command: `${prefix}addPcfServiceLayer`, label: "Add service-layer structure" }],
+        overflow: [
+          { command: `${prefix}addPcfServiceLayer`, label: "Add service-layer structure" },
+          { command: `${prefix}stopPcfLiveDebug`, label: "Stop live-form debug" },
+        ],
       };
     },
   },

--- a/src/webresources/debug/cdpProcess.ts
+++ b/src/webresources/debug/cdpProcess.ts
@@ -1,0 +1,63 @@
+import * as net from "net";
+import * as cp from "child_process";
+import CDP = require("chrome-remote-interface");
+
+// Generic CDP + child-process plumbing shared by the web-resource (debugWebresources.ts) and
+// PCF (debugPcfLiveForm.ts) hot-reload sessions. No feature specifics here — just: allocate a
+// free debugging port, tree-kill a (possibly shell-wrapped) child, and connect CDP with retry.
+
+/** Allocate a free localhost TCP port for the browser's remote-debugging endpoint. */
+export function findFreePort(): Promise<number> {
+  return new Promise((resolve, reject) => {
+    const server = net.createServer();
+    server.once("error", reject);
+    server.listen(0, "127.0.0.1", () => {
+      const address = server.address();
+      const port = typeof address === "object" && address ? address.port : 0;
+      server.close(() => (port ? resolve(port) : reject(new Error("Could not allocate a debugging port."))));
+    });
+  });
+}
+
+/**
+ * Kill a child process *and its descendants*. On Windows a shell-spawned process (webpack /
+ * pcf-scripts run via a `.cmd` shim, so `shell: true`) makes `child.kill()` terminate only the
+ * `cmd.exe` wrapper, orphaning the real `node --watch` — which then keeps rebuilding and holding
+ * memory forever. `taskkill /T` walks the whole tree. Elsewhere the process isn't shell-wrapped,
+ * so a plain kill suffices.
+ */
+export function killProcessTree(child: cp.ChildProcess | undefined): void {
+  if (!child || child.pid === undefined) {
+    return;
+  }
+  if (process.platform === "win32") {
+    try {
+      cp.execFileSync("taskkill", ["/pid", String(child.pid), "/T", "/F"], { stdio: "ignore" });
+      return;
+    } catch {
+      /* fall through to a best-effort direct kill */
+    }
+  }
+  try {
+    child.kill();
+  } catch {
+    /* already gone */
+  }
+}
+
+/** Connect CDP, retrying until the browser's debugging endpoint is up or the timeout elapses. */
+export async function connectCdpWithRetry(port: number, timeoutMs: number): Promise<CDP.Client> {
+  const deadline = Date.now() + timeoutMs;
+  let lastError: unknown;
+  for (;;) {
+    try {
+      return await CDP({ port });
+    } catch (error) {
+      lastError = error;
+      if (Date.now() > deadline) {
+        throw lastError instanceof Error ? lastError : new Error("Could not connect to the browser's debugging endpoint.");
+      }
+      await new Promise((r) => setTimeout(r, 400));
+    }
+  }
+}

--- a/src/webresources/debug/debugWebresources.ts
+++ b/src/webresources/debug/debugWebresources.ts
@@ -2,7 +2,6 @@
 import * as vscode from "vscode";
 import * as fs from "fs";
 import * as path from "path";
-import * as net from "net";
 import * as cp from "child_process";
 import CDP = require("chrome-remote-interface");
 import DataversePowerToolsContext from "../../context";
@@ -11,6 +10,7 @@ import { buildBrowserArgs } from "./browserArgs";
 import { isWebresourceBundleUrl, bundleCdpPattern, bundleContentType } from "./webresourceUrlMatch";
 import { buildAttachDebugConfig } from "./debugConfig";
 import { activeComponentRoot } from "../../components/componentDiscovery";
+import { findFreePort, killProcessTree, connectCdpWithRetry } from "./cdpProcess";
 
 // "Debug Web Resources": run the local webpack bundle *inside the real model-driven app*.
 // A dedicated Edge/Chrome instance is launched under the DevTools Protocol; the browser's
@@ -36,59 +36,6 @@ export const WEBPACK_WATCH_LAUNCHER = "npx";
 // changed the watch output mid-session and broke the comprehensive e2e's
 // serve-local step; existing projects switch by editing webpack.dev.js.
 export const WEBPACK_WATCH_ARGS = ["webpack", "--config", "webpack.dev.js", "--watch"];
-
-function findFreePort(): Promise<number> {
-  return new Promise((resolve, reject) => {
-    const server = net.createServer();
-    server.once("error", reject);
-    server.listen(0, "127.0.0.1", () => {
-      const address = server.address();
-      const port = typeof address === "object" && address ? address.port : 0;
-      server.close(() => (port ? resolve(port) : reject(new Error("Could not allocate a debugging port."))));
-    });
-  });
-}
-
-/**
- * Kill a child process *and its descendants*. On Windows a shell-spawned process (webpack runs via a
- * `.cmd` shim, so `shell: true`) makes `child.kill()` terminate only the `cmd.exe` wrapper, orphaning
- * the real `node webpack --watch` — which then keeps rebuilding and holding memory forever. `taskkill
- * /T` walks the whole tree. Elsewhere the process isn't shell-wrapped, so a plain kill suffices.
- */
-function killProcessTree(child: cp.ChildProcess | undefined): void {
-  if (!child || child.pid === undefined) {
-    return;
-  }
-  if (process.platform === "win32") {
-    try {
-      cp.execFileSync("taskkill", ["/pid", String(child.pid), "/T", "/F"], { stdio: "ignore" });
-      return;
-    } catch {
-      /* fall through to a best-effort direct kill */
-    }
-  }
-  try {
-    child.kill();
-  } catch {
-    /* already gone */
-  }
-}
-
-async function connectCdpWithRetry(port: number, timeoutMs: number): Promise<CDP.Client> {
-  const deadline = Date.now() + timeoutMs;
-  let lastError: unknown;
-  for (;;) {
-    try {
-      return await CDP({ port });
-    } catch (error) {
-      lastError = error;
-      if (Date.now() > deadline) {
-        throw lastError instanceof Error ? lastError : new Error("Could not connect to the browser's debugging endpoint.");
-      }
-      await new Promise((r) => setTimeout(r, 400));
-    }
-  }
-}
 
 export async function debugWebResources(context: DataversePowerToolsContext): Promise<void> {
   // Re-running restarts cleanly: stop the previous session (browser, webpack


### PR DESCRIPTION
Delivers the **live-form hot reload** half of #141 #5 (the standalone harness, 0.14.24, is the other half).

**Debug on live form (hot)** runs a locally-built PCF control *inside the real model-driven app*: launches Edge/Chrome under CDP, bypasses the app's service worker (#64), and intercepts the **deployed** control's `bundle.js`, fulfilling it from the local pcf-scripts build (`out/controls/<Constructor>/bundle.js`, rebuilt by `build --watch`; the page reloads). Nothing is written to the server — the CDP analogue of the official Fiddler/Requestly AutoResponder flow (docs: *Debug code components*).

**Design**
- `src/pcf/debug/pcfBundleUrl.ts` — pure, **unit-tested** bundle-URL matcher grounded in the documented control-bundle scheme (URL contains `<Namespace>.<Constructor>` + `bundle.js`; local `out/controls/<Constructor>/bundle.js`).
- `src/webresources/debug/cdpProcess.ts` — the generic CDP/browser/process plumbing factored out of the web-resource debugger and shared by both (no behaviour change to the web-resource path).
- `src/pcf/debug/debugPcfLiveForm.ts` — the orchestration, mirroring the proven web-resource session (launch → SW-bypass → Fetch interception → watch/reload → full tree-kill teardown).
- Commands `debugPcfLiveForm` / `stopPcfLiveDebug` wired into the PCF descriptor + activation + package.json (parity green).

**Verification:** pure logic unit-tested (**747/747**); the live-form interception against a real deployed control is confirmed on the VM as the immediate next step (the one thing unit tests can't prove).

🤖 Generated with [Claude Code](https://claude.com/claude-code)