### PR TITLE
0.14.34 (pre-release) — PCF build/watch at project root (#141, live-verified)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to the "dataverse-powertools" extension will be documented in this file.
 
+## 0.14.34 (pre-release)
+
+PCF (#141) — **fix: run the build/watch at the PCF project root, not the manifest folder** (found by live verification). `pac pcf init` puts `ControlManifest.Input.xml` in a `<Constructor>/` subfolder while `package.json` / `.pcfproj` / `out/` sit at the project root, so both the new live-form debug (0.14.33) *and* the standalone harness (0.14.24) were pointing at the wrong directory — the harness's `npm start watch` would fail ("no package.json") and the live-form debug looked for `bundle.js` under the manifest dir. New `findPcfProjectRoot` helper resolves the real root; the build/watch and the local `out/controls/<Constructor>/bundle.js` now use it. **Verified end-to-end on a live org:** a deployed control's real bundle URL (`cc_<Namespace>.<Constructor>/bundle.js`) is matched and the local build is served into the browser. +3 tests (750).
+
 ## 0.14.33 (pre-release)
 
 PCF (#141 #5) — **Debug a control on a live form (hot reload).** New **Debug on live form (hot)** command runs a locally-built PCF control *inside the real model-driven app*: it launches Edge/Chrome under the DevTools Protocol, bypasses the app's service worker (#64), and intercepts the **deployed** control's `bundle.js` request — fulfilling it from your local pcf-scripts build (`out/controls/<Constructor>/bundle.js`), which a `build --watch` rebuilds on save (the page reloads). Nothing is written to the server; it's the CDP analogue of the official Fiddler/Requestly AutoResponder debug flow. This is the live-form half of the hot-reload story (the standalone harness, 0.14.24, is the other half). The control must be deployed (`pac pcf push`) and added to a form first. The bundle-URL matcher is grounded in the documented control-bundle scheme and unit-tested; the shared CDP/browser plumbing is factored out of the web-resource debugger (`cdpProcess.ts`) and reused. +10 tests (747).

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "type": "git",
     "url": "https://github.com/pete-mc/dataverse-powertools"
   },
-  "version": "0.14.33",
+  "version": "0.14.34",
   "engines": {
     "vscode": "^1.95.0"
   },

--- a/src/pcf/controlManifest.spec.ts
+++ b/src/pcf/controlManifest.spec.ts
@@ -1,5 +1,8 @@
-import { describe, it, expect } from "vitest";
-import { parseControlManifest } from "./controlManifest";
+import { describe, it, expect, afterEach } from "vitest";
+import * as fs from "fs";
+import * as os from "os";
+import * as path from "path";
+import { parseControlManifest, findPcfProjectRoot, findControlDir } from "./controlManifest";
 
 const fieldManifest = `<?xml version="1.0" encoding="utf-8" ?>
 <manifest>
@@ -71,5 +74,50 @@ describe("parseControlManifest", () => {
     expect(m?.constructor).toBe("C");
     expect(m?.version).toBeUndefined();
     expect(m?.displayNameKey).toBeUndefined();
+  });
+});
+
+// findPcfProjectRoot / findControlDir against the real `pac pcf init` layout: the manifest lives in
+// a <Constructor>/ subfolder while package.json/.pcfproj/out/ sit at the project root (the split that
+// caused a real bundle-path bug — verified live). Uses a throwaway tmp tree.
+describe("findPcfProjectRoot vs findControlDir (#141 project-root split)", () => {
+  const roots: string[] = [];
+  afterEach(() => {
+    for (const r of roots.splice(0)) {
+      try {
+        fs.rmSync(r, { recursive: true, force: true });
+      } catch {
+        /* best-effort */
+      }
+    }
+  });
+
+  function scaffold(): string {
+    const base = fs.mkdtempSync(path.join(os.tmpdir(), "dvpt-pcf-"));
+    roots.push(base);
+    fs.writeFileSync(path.join(base, "package.json"), "{}");
+    fs.writeFileSync(path.join(base, "MyControl.pcfproj"), "<Project/>");
+    const controlDir = path.join(base, "HotReloadProbe");
+    fs.mkdirSync(controlDir);
+    fs.writeFileSync(path.join(controlDir, "ControlManifest.Input.xml"), "<manifest><control namespace='N' constructor='C'/></manifest>");
+    return base;
+  }
+
+  it("finds the .pcfproj project root (not the nested manifest dir)", () => {
+    const base = scaffold();
+    expect(findPcfProjectRoot(base)).toBe(base);
+  });
+
+  it("findControlDir returns the nested manifest dir, which is NOT the project root", () => {
+    const base = scaffold();
+    const controlDir = findControlDir(base);
+    expect(controlDir).toBe(path.join(base, "HotReloadProbe"));
+    expect(controlDir).not.toBe(findPcfProjectRoot(base)); // the split the fix depends on
+  });
+
+  it("returns undefined when there is no .pcfproj", () => {
+    const base = fs.mkdtempSync(path.join(os.tmpdir(), "dvpt-nopcf-"));
+    roots.push(base);
+    expect(findPcfProjectRoot(base)).toBeUndefined();
   });
 });

--- a/src/pcf/controlManifest.ts
+++ b/src/pcf/controlManifest.ts
@@ -112,6 +112,35 @@ export function findControlDir(root: string): string | undefined {
   return undefined;
 }
 
+/**
+ * Find the PCF PROJECT ROOT under `root` — the directory holding the `.pcfproj` (and the
+ * `package.json` with the pcf-scripts build + the `out/` build output). This is DISTINCT from
+ * the control (manifest) directory: `pac pcf init` puts `ControlManifest.Input.xml` in a
+ * `<Constructor>/` subfolder while `package.json`/`.pcfproj`/`out/` sit at the project root. So
+ * the build/watch must run here, and the bundle lands at `<root>/out/controls/<Constructor>/…`.
+ * Returns undefined if no `.pcfproj` is found.
+ */
+export function findPcfProjectRoot(root: string): string | undefined {
+  let entries: fs.Dirent[] = [];
+  try {
+    entries = fs.readdirSync(root, { withFileTypes: true });
+  } catch {
+    return undefined;
+  }
+  if (entries.some((e) => e.isFile() && e.name.toLowerCase().endsWith(".pcfproj"))) {
+    return root;
+  }
+  for (const e of entries) {
+    if (e.isDirectory() && !IGNORED_DIRS.has(e.name) && !e.name.startsWith(".")) {
+      const found = findPcfProjectRoot(path.join(root, e.name));
+      if (found) {
+        return found;
+      }
+    }
+  }
+  return undefined;
+}
+
 /** Read + parse the manifest under a control directory, if present (impure convenience). */
 export function readControlManifest(controlDir: string): ControlManifest | undefined {
   try {

--- a/src/pcf/debug/debugPcfLiveForm.ts
+++ b/src/pcf/debug/debugPcfLiveForm.ts
@@ -9,7 +9,7 @@ import { resolveBrowser, BrowserPreference } from "../../webresources/debug/brow
 import { buildBrowserArgs } from "../../webresources/debug/browserArgs";
 import { findFreePort, killProcessTree, connectCdpWithRetry } from "../../webresources/debug/cdpProcess";
 import { activeComponentRoot } from "../../components/componentDiscovery";
-import { findControlDir, readControlManifest } from "../controlManifest";
+import { findControlDir, findPcfProjectRoot, readControlManifest } from "../controlManifest";
 import { isPcfBundleUrl, pcfBundleCdpPattern, pcfBundleContentType, pcfLocalBundlePath } from "./pcfBundleUrl";
 
 // "Debug PCF (live form)": run a locally-built PCF control INSIDE the real model-driven app —
@@ -72,6 +72,9 @@ export async function debugPcfLiveForm(context: DataversePowerToolsContext): Pro
     vscode.window.showErrorMessage("Couldn't read the control's ControlManifest.Input.xml (namespace/constructor).");
     return;
   }
+  // The build/watch runs at the PCF PROJECT root (package.json + .pcfproj + out/), which is
+  // a level ABOVE the manifest dir — `pac pcf init` nests the manifest in a <Constructor>/ folder.
+  const projectRoot = findPcfProjectRoot(componentRoot) ?? componentRoot;
 
   // Need a live connection to know the org URL to open (the control must be deployed there).
   if (!context.dataverse || !context.dataverse.isValid) {
@@ -87,7 +90,7 @@ export async function debugPcfLiveForm(context: DataversePowerToolsContext): Pro
     return;
   }
 
-  const bundlePath = pcfLocalBundlePath(controlDir, manifest.constructor);
+  const bundlePath = pcfLocalBundlePath(projectRoot, manifest.constructor);
   const bundleDir = path.dirname(bundlePath);
 
   const settings = vscode.workspace.getConfiguration("dataverse-powertools");
@@ -133,7 +136,8 @@ export async function debugPcfLiveForm(context: DataversePowerToolsContext): Pro
 
   await vscode.window.withProgress({ location: vscode.ProgressLocation.Notification, title: "Starting PCF live-form debug session…" }, async () => {
     // 1. pcf-scripts build --watch → out/controls/<Constructor>/bundle.js on every save.
-    watchProc = cp.spawn(PCF_WATCH_LAUNCHER, PCF_WATCH_ARGS, { cwd: controlDir, shell: process.platform === "win32" });
+    //    Runs at the project root (where package.json / pcf-scripts live), NOT the manifest dir.
+    watchProc = cp.spawn(PCF_WATCH_LAUNCHER, PCF_WATCH_ARGS, { cwd: projectRoot, shell: process.platform === "win32" });
     watchProc.stdout?.on("data", (d) => context.channel.appendLine(`[pcf build] ${String(d).trimEnd()}`));
     watchProc.stderr?.on("data", (d) => context.channel.appendLine(`[pcf build] ${String(d).trimEnd()}`));
 

--- a/src/pcf/runHarness.ts
+++ b/src/pcf/runHarness.ts
@@ -7,7 +7,7 @@
 import * as vscode from "vscode";
 import DataversePowerToolsContext from "../context";
 import { activeComponentRoot } from "../components/componentDiscovery";
-import { findControlDir } from "./controlManifest";
+import { findPcfProjectRoot } from "./controlManifest";
 
 /** The pcf-scripts test-harness watch command (built-in hot reload). */
 export function pcfHarnessCommand(): string {
@@ -20,9 +20,12 @@ export function runPcfHarness(context: DataversePowerToolsContext): void {
     vscode.window.showErrorMessage("Open or select a PCF component first.");
     return;
   }
-  const controlDir = findControlDir(root) ?? root;
+  // `npm start watch` needs the project's package.json (pcf-scripts), which lives at the PCF
+  // project root — a level above the manifest dir (pac pcf init nests the manifest in a
+  // <Constructor>/ subfolder). Running in the manifest dir would fail "no package.json".
+  const projectRoot = findPcfProjectRoot(root) ?? root;
   context.channel.appendLine("Starting the PCF test harness with hot reload (npm start watch) — see the terminal. Stop it with Ctrl+C.");
-  const terminal = vscode.window.createTerminal({ name: "PCF harness (watch)", cwd: controlDir });
+  const terminal = vscode.window.createTerminal({ name: "PCF harness (watch)", cwd: projectRoot });
   terminal.show(true);
   terminal.sendText(pcfHarnessCommand());
 }


### PR DESCRIPTION
**Found by live verification on a real org** (the point of the supervised session). `pac pcf init` nests `ControlManifest.Input.xml` in a `<Constructor>/` subfolder, but `package.json` / `.pcfproj` / `out/` sit at the **project root**. Both:
- the **standalone harness** (0.14.24) — `npm start watch` ran in the manifest dir → would fail *no package.json*; and
- the **live-form debug** (0.14.33) — looked for `out/controls/<Constructor>/bundle.js` under the manifest dir

pointed at the wrong directory. New `findPcfProjectRoot` (the dir with the `.pcfproj`) resolves the real root; build/watch cwd and the local bundle path now use it.

**End-to-end proof on a live org** (deployed `DvptVerify.HotReloadProbe` via `pac pcf push`):
- the deployed bundle web resource is `cc_DvptVerify.HotReloadProbe/bundle.js`; `isPcfBundleUrl` matches its served URL ✅
- a CDP-driven browser navigating to that real URL received the **local** (marker-stamped) build — the SW-bypass + Fetch interception served the local bundle for the real deployed control ✅

Unit tests for the project-root/manifest-dir split added. **750/750.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)