### PR TITLE
0.14.36 (pre-release) — PCF in the two-of-each e2e (#141)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to the "dataverse-powertools" extension will be documented in this file.
 
+## 0.14.36 (pre-release)
+
+Tests (#141) — **PCF added to the two-of-each multi-component e2e.** The blank-root suite now adds **two PCF components** (with the 0.14.29 template/framework quick-pick) alongside two of every other type, asserting each scaffolds, is type-scoped with no inherited connection, and the second doesn't collide with the first. Verified on the VM — both PCF components scaffold and discovery reports them correctly. (PCF registers no per-component TestController, so it's structurally immune to the duplicate-controller class the suite guards; this locks that in.) No change to the shipped extension.
+
 ## 0.14.35 (pre-release)
 
 Docs (#136/#138) — **plug-in debugging demo GIF + screenshots.** A slideshow GIF (the Debugging block → the generated **Replay & debug** unit test → a rendered **trace log**) now leads the README's new "Debug plug-ins in VS Code" section and the wiki's Debugging Plugins page, with the individual function screenshots placed at their sections. Captured from the real UI against the demo (contoso) connection via the screenshots generator (new capture cases + a pure-JS GIF assembler, `scripts/assembleGif.mjs`). No change to the shipped extension code.

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "type": "git",
     "url": "https://github.com/pete-mc/dataverse-powertools"
   },
-  "version": "0.14.35",
+  "version": "0.14.36",
   "engines": {
     "vscode": "^1.95.0"
   },

--- a/src/ui-test/e2e/blankRootComponents.e2e.ts
+++ b/src/ui-test/e2e/blankRootComponents.e2e.ts
@@ -336,12 +336,43 @@ describe("Blank root + two components of each type (e2e)", function () {
     await waitForAddComplete(9); // root + two of every type
   });
 
+  it("adds a PCF component into a subfolder (pac pcf init + template/framework quick-pick)", async () => {
+    await startAddComponent("PCF Control");
+    await answerText("pcf"); // subfolder
+    // The 0.14.29 scaffold quick-picks: control template, then rendering framework.
+    await pickByLabel("Field");
+    await pickByLabel("Standard (no framework)");
+    expect(await waitForFile(path.join(workspace, "pcf", "dataverse-powertools.json"), 300000), "pcf settings").to.equal(true);
+    // pac pcf init writes the .pcfproj at the component root (the manifest goes in a
+    // <Constructor>/ subfolder) — the .pcfproj uniquely proves the scaffold ran.
+    expect(await waitForMatch(path.join(workspace, "pcf"), (file) => file.endsWith(".pcfproj"), 300000), "a .pcfproj scaffolded by pac pcf init").to.equal(true);
+    const settings = readSettings("pcf");
+    expect(settings.type).to.equal("pcf");
+    expect(settings.connectionString).to.equal(undefined);
+    await waitForAddComplete(10); // root + 2 webresources + 2 plugins + 2 solutions + 2 portals + pcf
+  });
+
+  it("adds a SECOND PCF component into a distinct subfolder", async () => {
+    await startAddComponent("PCF Control");
+    await answerText("pcf2"); // second PCF component alongside the first
+    await pickByLabel("Field");
+    await pickByLabel("Standard (no framework)");
+    expect(await waitForFile(path.join(workspace, "pcf2", "dataverse-powertools.json"), 300000), "pcf2 settings").to.equal(true);
+    expect(await waitForMatch(path.join(workspace, "pcf2"), (file) => file.endsWith(".pcfproj"), 300000), "pcf2 .pcfproj scaffolded").to.equal(true);
+    const settings = readSettings("pcf2");
+    expect(settings.type).to.equal("pcf");
+    expect(settings.connectionString).to.equal(undefined);
+    await waitForAddComplete(11); // root + two of every type
+    // Two same-type PCF components must not collide (register-once commands, scoped ids) — #47/#141.
+    await assertCommandDidNotError("second PCF add");
+  });
+
   it("root stays a typeless connection-only file after all additions", async () => {
     const settings = readSettings(".");
     expect(settings.type).to.equal(undefined);
     expect(settings.connectionString).to.be.a("string").and.not.equal("");
-    // Eight components discovered off the root: two of every type, each type-scoped, none owning a connection.
-    for (const rel of ["webresources", "webresources2", "plugin", "plugin2", "solution", "solution2", "portal", "portal2"]) {
+    // Ten components discovered off the root: two of every type, each type-scoped, none owning a connection.
+    for (const rel of ["webresources", "webresources2", "plugin", "plugin2", "solution", "solution2", "portal", "portal2", "pcf", "pcf2"]) {
       expect(readSettings(rel).connectionString, `${rel} inherits (owns no connection)`).to.equal(undefined);
     }
   });


### PR DESCRIPTION
Adds the **two-of-each** PCF coverage from #141's Tests checklist. The blank-root multi-component e2e (`blankRootComponents.e2e.ts`) now adds **two PCF components** — driving the 0.14.29 template/framework quick-pick — alongside two of every other type, and asserts each scaffolds (`.pcfproj`), is type-scoped with no inherited connection, discovery counts are right, and the second add doesn't collide or error.

**Verified live on the VM** (focused run): both PCF components scaffold and discovery logs `(root), pcf` then `(root), pcf, pcf2` — no collision. (The initial run surfaced only a too-strict test assertion — it checked `ControlManifest.Input.xml` at the component-root level, but `pac pcf init` nests it in a `<Constructor>/` subfolder; the `.pcfproj` at the root is the correct scaffold marker. Fixed.)

**Interactive-auth note:** PCF's OAuth Dataverse commands (`pac pcf push`/deploy) go through the same `ensurePacAuthForCurrentConnection` path the plugin/web-resource `*InteractiveLifecycle` suites already verify, and `pac pcf push` under a live org was exercised this session (the #141 live-form verification) — so a dedicated PCF-under-OAuth lifecycle would be redundant heavy coverage. Test-only; no shipped-extension change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)