### PR TITLE
0.14.37 (pre-release) — security patch (adm-zip CVE + pac secret hardening + CI perms)

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -24,6 +24,11 @@ on:
     - cron: "0 3 * * *" # 03:00 UTC daily
   workflow_dispatch: {}
 
+# Least privilege: this workflow only reads the repo to run tests — no writes to
+# contents, issues, PRs, packages, etc. (CodeQL actions/missing-workflow-permissions).
+permissions:
+  contents: read
+
 concurrency:
   group: nightly-live
   cancel-in-progress: true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 All notable changes to the "dataverse-powertools" extension will be documented in this file.
 
+## 0.14.37 (pre-release)
+
+Security patch.
+
+- **adm-zip 0.5.18 → 0.6.0** — fixes **CVE-2026-39244** (a crafted archive declaring a huge uncompressed size could force an unbounded `Buffer.alloc` and OOM the process). adm-zip is used to pack the plugin deploy package and read the profiler solution `.cab`. Our usage is unaffected by the release's behavior changes (we don't use `extractEntryTo`).
+- **Hardened the pac client-secret path (defense-in-depth).** pac already runs via the resolved executable with no shell; the only path that could interpret a value is the rare `cmd.exe /c pac …` fallback (when `pac.exe` isn't resolvable). The client id / tenant / URL were already shape-validated — the secret now is too: it's rejected if it contains cmd.exe metacharacters (`& | < > ^ " % \`` / newlines) that could break out of that fallback command line. Real Azure client secrets never contain these, so valid credentials are never rejected.
+- **Least-privilege permissions on the nightly workflow** (`contents: read`).
+
 ## 0.14.36 (pre-release)
 
 Tests (#141) — **PCF added to the two-of-each multi-component e2e.** The blank-root suite now adds **two PCF components** (with the 0.14.29 template/framework quick-pick) alongside two of every other type, asserting each scaffolds, is type-scoped with no inherited connection, and the second doesn't collide with the first. Verified on the VM — both PCF components scaffold and discovery reports them correctly. (PCF registers no per-component TestController, so it's structurally immune to the duplicate-controller class the suite guards; this locks that in.) No change to the shipped extension.

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "type": "git",
     "url": "https://github.com/pete-mc/dataverse-powertools"
   },
-  "version": "0.14.36",
+  "version": "0.14.37",
   "engines": {
     "vscode": "^1.95.0"
   },

--- a/src/general/pacAuth.spec.ts
+++ b/src/general/pacAuth.spec.ts
@@ -10,6 +10,7 @@ import {
   pacOutputHasError,
   pacSucceeded,
   listHasNamedProfile,
+  hasShellMetacharacters,
 } from "./pacAuth";
 
 describe("pacAuthCreateInteractiveArgs", () => {
@@ -130,5 +131,19 @@ describe("listHasNamedProfile — parse `pac auth list` (it exits 0 even with no
       "Index Active Kind      Name                 Friendly Name        Url\n[1]   *      UNIVERSAL      dataverse-powertools dataverse-powertools https://org.crm.dynamics.com";
     expect(listHasNamedProfile(list, "dataverse-powertools")).toBe(true);
     expect(listHasNamedProfile(list, "some-other-profile")).toBe(false);
+  });
+});
+
+describe("hasShellMetacharacters — client-secret guard for the cmd.exe pac fallback (CodeQL #47)", () => {
+  it("accepts real Azure client-secret shapes (base64url alphabet, never rejected)", () => {
+    for (const secret of ["abc123XYZ~_.-", "Q~aBcD3fGhIjKlMnOpQrStUvWxYz0123456789.-_", "8Q~kLmNoP.qRsTuVwXyZ_-0123", "Zm9vYmFyMTIz+/=", "s3cr3t.value~with-dashes_and.dots"]) {
+      expect(hasShellMetacharacters(secret), secret).toBe(false);
+    }
+  });
+
+  it("rejects cmd.exe metacharacters that could break out of the fallback command line", () => {
+    for (const bad of ["secret&whoami", "secret|calc", "secret>out.txt", "secret<in", "a^b", 'a"b', "50%off", "back`tick", "line1\nline2", "line1\rline2"]) {
+      expect(hasShellMetacharacters(bad), bad).toBe(true);
+    }
   });
 });

--- a/src/general/pacAuth.ts
+++ b/src/general/pacAuth.ts
@@ -94,6 +94,17 @@ const GUID_PATTERN = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{
 const TENANT_PATTERN = /^[0-9a-z.-]{1,100}$/i; // GUID or AAD domain
 const ENVIRONMENT_URL_PATTERN = /^https:\/\/[0-9a-z][0-9a-z.-]*(:\d+)?\/?$/i;
 
+// Defense-in-depth for the client secret. pac runs via the resolved pac executable with NO shell
+// (args aren't interpreted); the ONLY path that could interpret a value is the rare `cmd.exe /c pac …`
+// fallback used when pac.exe can't be resolved. The client id / tenant / URL are already shape-validated,
+// so the secret is the one arg that isn't — this rejects the cmd.exe metacharacters that enable command
+// chaining / redirection / env-var expansion. Real Azure client secrets never contain these, so a valid
+// credential is never rejected. (CodeQL js/shell-command-injection-from-environment.)
+const SHELL_METACHARACTERS = /[&|<>^"%`\r\n]/;
+export function hasShellMetacharacters(value: string): boolean {
+  return SHELL_METACHARACTERS.test(value);
+}
+
 export async function ensurePacAuth(context: DataversePowerToolsContext, workspacePath: string): Promise<boolean> {
   const parts = parseConnectionString(context.connectionString);
   const environmentUrl = normalizeOrganizationUrl(parts.url);
@@ -112,6 +123,14 @@ export async function ensurePacAuth(context: DataversePowerToolsContext, workspa
   if (!GUID_PATTERN.test(parts.clientId) || !TENANT_PATTERN.test(tenantId) || !ENVIRONMENT_URL_PATTERN.test(environmentUrl)) {
     context.channel.appendLine("Cannot authenticate with pac: client id, tenant, or environment URL has an unexpected format. Update the connection string and retry.");
     vscode.window.showErrorMessage("Dataverse connection settings look malformed; cannot authenticate with pac.");
+    return false;
+  }
+
+  // The secret is the one pac arg not shape-validated above — reject shell metacharacters so it can
+  // never break out of the cmd.exe fallback command line (real Azure secrets never contain these).
+  if (hasShellMetacharacters(parts.clientSecret)) {
+    context.channel.appendLine("Cannot authenticate with pac: the client secret contains characters that aren't allowed (regenerate the secret and update the connection string).");
+    vscode.window.showErrorMessage("The client secret contains unexpected characters; cannot authenticate with pac.");
     return false;
   }
 


### PR DESCRIPTION
Security patch addressing the GitHub security alerts.

## HIGH — fixed
- **adm-zip 0.5.18 → 0.6.0** (CVE-2026-39244 — DoS/OOM via a crafted archive's declared uncompressed size). Merged to main via #202; used to pack the plugin deploy package + read the profiler `.cab`. Our usage is unaffected by the release's behavior changes.

## MEDIUM — hardened / fixed
- **pac client-secret guard** (CodeQL #47, `js/shell-command-injection-from-environment`). pac runs via the resolved executable with **no shell**; only the rare `cmd.exe /c pac …` fallback could interpret a value. clientId/tenant/URL were already shape-validated — the **secret** now is too (rejects `& | < > ^ " % ` ` + newlines). Real Azure secrets never contain these, so valid creds are never rejected. Pure `hasShellMetacharacters` + unit tests.
- **nightly.yml least-privilege permissions** (CodeQL #48) — `contents: read`.

## The rest (dismissing separately, with justification)
The remaining MEDIUM CodeQL alerts are either **test-only** code (not shipped in the VSIX — `src/ui-test/e2e/*`, `test/live/*`) or **mitigated false positives** (e.g. `restoreDependencies.ts:69` — the csproj path goes to `dotnet` via `execFile` with `shell:false` and the project name is sanitized). Being dismissed on the security tab with reasons.

**752/752**, lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)