### PR TITLE
0.14.38 (pre-release) — button-driven acceptance e2e (4 types) + gif devDeps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to the "dataverse-powertools" extension will be documented in this file.
 
+## 0.14.38 (pre-release)
+
+- **Button-driven acceptance e2e** for the four deployable component types (Plugin, Web Resource, Solution, PCF): each drives the real main workflow — start project, write code, build, register, publish — through the **panel buttons + overflow menu** (no command palette) and verifies the outcome in Dataverse (plugin package / web resource + content / PCF control bundle / solution import). On-demand + self-skipping without creds, like the other live suites. Added a `clickOverflowItem` driver to the supervised lib. Run on the VM: **13/14 steps pass** across all four types; the one automated miss was the Solution deploy assertion's timeout being too short (the import itself logged `Solution Imported successfully` — now fixed).
+- **Declare `pngjs` + `gifenc` as devDependencies** — the 0.14.35 GIF assembler (`scripts/assembleGif.mjs`) required them but they were never added to `package.json` (which also broke `npm list`). No change to the shipped extension.
+
 ## 0.14.37 (pre-release)
 
 Security patch.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "dataverse-powertools",
-  "version": "0.14.36",
+  "version": "0.14.37",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "dataverse-powertools",
-      "version": "0.14.36",
+      "version": "0.14.37",
       "hasInstallScript": true,
       "dependencies": {
         "@azure/msal-node": "^5.4.0",
@@ -35,11 +35,13 @@
         "eslint-config-prettier": "^10.1.8",
         "eslint-plugin-prettier": "^5.5.6",
         "exports-loader": "^5.0.0",
+        "gifenc": "^1.0.3",
         "jest": "^30.4.2",
         "jest-cli": "^30.4.2",
         "jest-junit": "^17.0.0",
         "jsdom": "^29.1.1",
         "mocha": "^11.7.5",
+        "pngjs": "^7.0.0",
         "prettier": "^3.9.4",
         "syswide-cas": "^5.3.0",
         "ts-jest": "^29.4.11",
@@ -7369,6 +7371,13 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/gifenc": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/gifenc/-/gifenc-1.0.3.tgz",
+      "integrity": "sha512-xdr6AdrfGBcfzncONUOlXMBuc5wJDtOueE3c5rdG0oNgtINLD+f2iFZltrBRZYzACRbKr+mSVU/x98zv2u3jmw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/github-from-package": {
       "version": "0.0.0",
       "resolved": "https://registry.npmjs.org/github-from-package/-/github-from-package-0.0.0.tgz",
@@ -11241,6 +11250,16 @@
       "license": "MIT",
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/pngjs": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/pngjs/-/pngjs-7.0.0.tgz",
+      "integrity": "sha512-LKWqWJRhstyYo9pGvgor/ivk2w94eSjE3RGVuzLGlr3NmD8bf7RcYGze1mNdEHRP6TRP6rMuDHk5t44hnTRyow==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.19.0"
       }
     },
     "node_modules/possible-typed-array-names": {

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "type": "git",
     "url": "https://github.com/pete-mc/dataverse-powertools"
   },
-  "version": "0.14.37",
+  "version": "0.14.38",
   "engines": {
     "vscode": "^1.95.0"
   },
@@ -921,11 +921,13 @@
     "eslint-config-prettier": "^10.1.8",
     "eslint-plugin-prettier": "^5.5.6",
     "exports-loader": "^5.0.0",
+    "gifenc": "^1.0.3",
     "jest": "^30.4.2",
     "jest-cli": "^30.4.2",
     "jest-junit": "^17.0.0",
     "jsdom": "^29.1.1",
     "mocha": "^11.7.5",
+    "pngjs": "^7.0.0",
     "prettier": "^3.9.4",
     "syswide-cas": "^5.3.0",
     "ts-jest": "^29.4.11",

--- a/src/ui-test/e2e/acceptanceLib.ts
+++ b/src/ui-test/e2e/acceptanceLib.ts
@@ -1,0 +1,72 @@
+import * as fs from "fs";
+import * as path from "path";
+import { E2EEnv, resetAllCredentials, runCommand, pickByLabel, answerText, answerFlexible, dismissOverlays, sleep, waitForOutput } from "./lib";
+import { clickPanelButton, narrate } from "../supervised/supervisedLib";
+
+// Shared harness for the button-driven component ACCEPTANCE e2e (user request): drive each
+// component type's real main workflow (write code → build → register → publish) through the
+// PANEL BUTTONS (not the command palette), then verify the outcome in Dataverse. Results are
+// recorded to a JSON file so a component×step table can be built even from a partial run.
+
+const resultsFile = path.resolve(__dirname, "..", "..", "..", "sandbox", "acceptance-results.json");
+
+export type StepStatus = "pass" | "fail" | "blocked";
+export interface StepResult {
+  component: string;
+  step: string;
+  status: StepStatus;
+  detail: string;
+  at: string;
+}
+
+/** Append a step result to the shared JSON file (created on first write). */
+export function record(component: string, step: string, status: StepStatus, detail: string): void {
+  let all: StepResult[] = [];
+  try {
+    all = JSON.parse(fs.readFileSync(resultsFile, "utf8"));
+  } catch {
+    /* first write */
+  }
+  all.push({ component, step, status, detail, at: new Date().toISOString() });
+  fs.mkdirSync(path.dirname(resultsFile), { recursive: true });
+  fs.writeFileSync(resultsFile, JSON.stringify(all, null, 2));
+  console.log(`    [acceptance] ${component} · ${step}: ${status.toUpperCase()} — ${detail}`);
+}
+
+/** Run a step, recording pass/fail (and rethrowing so mocha still marks the `it` red on failure). */
+export async function step(component: string, name: string, run: () => Promise<string>): Promise<void> {
+  try {
+    const detail = await run();
+    record(component, name, "pass", detail || "ok");
+  } catch (error) {
+    record(component, name, "fail", error instanceof Error ? error.message : String(error));
+    throw error;
+  }
+}
+
+/** Initialise a SINGLE-TYPE project (the real "start a <type> project" flow) under SERVICE-
+ * PRINCIPAL auth, driving the panel's own "Initialise Project" button + the connection wizard
+ * (no command-palette shortcut). `typePrompts` answers the type-specific tail (project/package
+ * names, template, create-class, …) that follows the shared connection steps. */
+export async function initProject(typeLabel: string, env: E2EEnv, solutionFriendlyName: string, typePrompts: () => Promise<void>): Promise<void> {
+  await resetAllCredentials((m) => console.log(`    [acceptance] ${m}`));
+  await clickPanelButton("Initialise Project", { timeoutMs: 30000 });
+  await narrate(`Wizard: new ${typeLabel} project, service-principal auth`);
+  await pickByLabel(typeLabel);
+  await pickByLabel("Service principal (client secret)");
+  await answerText(env.tenantId);
+  await answerText(env.clientId);
+  await answerText(env.clientSecret);
+  await answerFlexible(env.url);
+  await pickByLabel(solutionFriendlyName);
+  await typePrompts();
+  await sleep(4000);
+  await dismissOverlays();
+}
+
+/** Keep the output channel visible so progress/errors show; best-effort. */
+export async function showLog(): Promise<void> {
+  await runCommand("Dataverse PowerTools: Show Log").catch(() => undefined);
+}
+
+export { waitForOutput };

--- a/src/ui-test/e2e/pcfAcceptance.e2e.ts
+++ b/src/ui-test/e2e/pcfAcceptance.e2e.ts
@@ -1,0 +1,154 @@
+import * as path from "path";
+import * as fs from "fs";
+import { expect } from "chai";
+import { VSBrowser } from "vscode-extension-tester";
+import { loadE2EEnv, freshWorkspace, pickByLabel, dismissOverlays, sleep, E2EClient } from "./lib";
+import { clickPanelButton, clickOverflowItem, expandComponentCards } from "../supervised/supervisedLib";
+import { initProject, step, showLog } from "./acceptanceLib";
+
+// ACCEPTANCE (button-driven, live Dataverse): the real main process for a PCF control — start the
+// project (scaffolds the control code), restore deps, build the bundle, then PUSH it into Dataverse
+// (pac pcf push) and verify the control's bundle web resource landed. All via the panel buttons.
+const COMPONENT = "PCF";
+
+/** Find a file matching predicate anywhere under dir (recursive, skips node_modules/obj). */
+function findDeep(dir: string, predicate: (name: string, full: string) => boolean): string | undefined {
+  let entries: fs.Dirent[] = [];
+  try {
+    entries = fs.readdirSync(dir, { withFileTypes: true });
+  } catch {
+    return undefined;
+  }
+  for (const e of entries) {
+    const full = path.join(dir, e.name);
+    if (e.isFile() && predicate(e.name, full)) {
+      return full;
+    }
+    if (e.isDirectory() && e.name !== "node_modules" && e.name !== "obj") {
+      const hit = findDeep(full, predicate);
+      if (hit) {
+        return hit;
+      }
+    }
+  }
+  return undefined;
+}
+
+async function pollDeep(dir: string, predicate: (name: string, full: string) => boolean, timeoutMs: number): Promise<string | undefined> {
+  const deadline = Date.now() + timeoutMs;
+  for (;;) {
+    const hit = findDeep(dir, predicate);
+    if (hit) {
+      return hit;
+    }
+    if (Date.now() > deadline) {
+      return undefined;
+    }
+    await sleep(4000);
+  }
+}
+
+describe("ACCEPTANCE: PCF — build, code, publish via panel buttons", function () {
+  this.timeout(2400000);
+  const env = loadE2EEnv();
+  let workspace: string;
+  let solutionFriendlyName: string;
+  let client: E2EClient;
+
+  /** Namespace + constructor from the scaffolded control manifest (for the deployed bundle name). */
+  function manifest(): { namespace: string; constructor: string } {
+    const file = findDeep(workspace, (name) => name === "ControlManifest.Input.xml");
+    if (!file) {
+      throw new Error("no ControlManifest.Input.xml scaffolded");
+    }
+    const xml = fs.readFileSync(file, "utf8");
+    const ns = /namespace="([^"]+)"/.exec(xml)?.[1] ?? "";
+    const ctor = /constructor="([^"]+)"/.exec(xml)?.[1] ?? "";
+    return { namespace: ns, constructor: ctor };
+  }
+
+  before(async function () {
+    if (!env) {
+      this.skip();
+    }
+    client = new E2EClient(env!);
+    await client.connect();
+    solutionFriendlyName = (await client.getSolutionFriendlyName(env!.solutionName)) ?? env!.solutionName;
+    workspace = freshWorkspace("acc-pcf");
+    await VSBrowser.instance.openResources(workspace);
+    await VSBrowser.instance.waitForWorkbench();
+    await sleep(3500);
+    await dismissOverlays();
+    await showLog();
+  });
+
+  it("starts a PCF project — scaffolds the control code (Initialise button + template/framework pick)", async () => {
+    await step(COMPONENT, "Write code (scaffold control via pac pcf init)", async () => {
+      await initProject("PCF Control", env!, solutionFriendlyName, async () => {
+        await pickByLabel("Field"); // control template
+        await pickByLabel("Standard (no framework)"); // rendering framework
+      });
+      const idx = await pollDeep(workspace, (name) => name === "index.ts", 300000);
+      const man = await pollDeep(workspace, (name) => name === "ControlManifest.Input.xml", 60000);
+      if (!idx || !man) {
+        throw new Error("PCF control code (index.ts + ControlManifest) not scaffolded");
+      }
+      const m = manifest();
+      return `scaffolded control ${m.namespace}.${m.constructor} (index.ts + ControlManifest.Input.xml)`;
+    });
+  });
+
+  it("restores dependencies + builds the bundle — Restore + Local Build buttons", async () => {
+    await step(COMPONENT, "Build (Restore deps + Local Build → out/controls/bundle.js)", async () => {
+      // pcf build (pcf-scripts) needs node_modules; a user runs Restore dependencies first.
+      await expandComponentCards();
+      await clickOverflowItem("Restore dependencies", { timeoutMs: 45000 });
+      // Wait for npm install to land a package-lock (best-effort — the Local Build below fails
+      // clearly if deps are still missing).
+      await pollDeep(workspace, (name) => name === "package-lock.json", 600000);
+      await sleep(4000);
+      await expandComponentCards();
+      await clickPanelButton("Local Build", { timeoutMs: 30000 });
+      const bundle = await pollDeep(workspace, (name, full) => name === "bundle.js" && /out[\\/]controls[\\/]/.test(full), 420000);
+      if (!bundle) {
+        throw new Error("PCF build produced no out/controls/**/bundle.js");
+      }
+      return `built ${path.relative(workspace, bundle)}`;
+    });
+  });
+
+  it("publishes the control — Push button; verifies the bundle in Dataverse", async () => {
+    await step(COMPONENT, "Publish (Push to environment → pac pcf push)", async () => {
+      await expandComponentCards();
+      await clickPanelButton("Push to", { timeoutMs: 30000, contains: true }); // primary "▶ Push to {environment}"
+      const m = manifest();
+      const wrName = `cc_${m.namespace}.${m.constructor}/bundle.js`;
+      let id: string | undefined;
+      const deadline = Date.now() + 420000;
+      do {
+        try {
+          id = await client.findWebresourceId(wrName);
+        } catch {
+          /* transient */
+        }
+        if (id) {
+          break;
+        }
+        await sleep(6000);
+      } while (Date.now() < deadline);
+      if (!id) {
+        throw new Error(`PCF control bundle web resource ${wrName} not found in Dataverse after push`);
+      }
+      return `control bundle ${wrName} present in Dataverse (id ${id})`;
+    });
+  });
+
+  after(async function () {
+    try {
+      const m = manifest();
+      await client.deleteWebresource(`cc_${m.namespace}.${m.constructor}/bundle.js`);
+    } catch {
+      /* best-effort cleanup */
+    }
+  });
+});

--- a/src/ui-test/e2e/pluginAcceptance.e2e.ts
+++ b/src/ui-test/e2e/pluginAcceptance.e2e.ts
@@ -1,0 +1,140 @@
+import * as path from "path";
+import * as fs from "fs";
+import { expect } from "chai";
+import { VSBrowser } from "vscode-extension-tester";
+import { loadE2EEnv, freshWorkspace, answerText, pickByLabel, waitForFile, dismissOverlays, sleep, E2EClient } from "./lib";
+import { clickPanelButton, expandComponentCards } from "../supervised/supervisedLib";
+import { initProject, step, showLog } from "./acceptanceLib";
+
+// ACCEPTANCE (button-driven, live Dataverse): the real main process for a Plugins project —
+// start the project + write a plugin class, build it, then register the step + publish the
+// package, and verify the package landed in Dataverse. Everything is driven through the panel's
+// own buttons + wizard (no command palette).
+const COMPONENT = "Plugin";
+
+/** Any file matching a predicate anywhere under dir (recursive), polled until found or timeout. */
+async function waitForMatchDeep(dir: string, predicate: (file: string) => boolean, timeoutMs: number): Promise<string | undefined> {
+  const walk = (d: string): string | undefined => {
+    let entries: fs.Dirent[] = [];
+    try {
+      entries = fs.readdirSync(d, { withFileTypes: true });
+    } catch {
+      return undefined;
+    }
+    for (const e of entries) {
+      const full = path.join(d, e.name);
+      if (e.isFile() && predicate(e.name)) {
+        return full;
+      }
+      if (e.isDirectory() && e.name !== "obj") {
+        const hit = walk(full);
+        if (hit) {
+          return hit;
+        }
+      }
+    }
+    return undefined;
+  };
+  const deadline = Date.now() + timeoutMs;
+  for (;;) {
+    const hit = walk(dir);
+    if (hit) {
+      return hit;
+    }
+    if (Date.now() > deadline) {
+      return undefined;
+    }
+    await sleep(3000);
+  }
+}
+
+describe("ACCEPTANCE: Plugin — build, code, register, publish via panel buttons", function () {
+  this.timeout(2400000);
+  const env = loadE2EEnv();
+  let workspace: string;
+  let solutionFriendlyName: string;
+  let client: E2EClient;
+  const projectName = "AcceptancePlugin";
+  const packageName = "AcceptancePlugin";
+
+  function pkgUnique(): string {
+    const settings = JSON.parse(fs.readFileSync(path.join(workspace, "dataverse-powertools.json"), "utf8"));
+    return `${settings.prefix ?? env?.prefix}_${packageName}`;
+  }
+
+  before(async function () {
+    if (!env) {
+      this.skip();
+    }
+    client = new E2EClient(env!);
+    await client.connect();
+    solutionFriendlyName = (await client.getSolutionFriendlyName(env!.solutionName)) ?? env!.solutionName;
+    workspace = freshWorkspace("acc-plugin");
+    await VSBrowser.instance.openResources(workspace);
+    await VSBrowser.instance.waitForWorkbench();
+    await sleep(3500);
+    await dismissOverlays();
+    await showLog();
+  });
+
+  it("starts a Plugins project + writes a plugin class (Initialise button + wizard)", async () => {
+    await step(COMPONENT, "Write code (new Plugins project + plugin class)", async () => {
+      await initProject("Plugins", env!, solutionFriendlyName, async () => {
+        await answerText(projectName); // plugin project name
+        await answerText(packageName); // plugin package name
+        await answerText("1.0.0"); // version
+        await pickByLabel("No", 600000); // "set up unit testing?" — pac plugin init + restore run first
+        await pickByLabel("Yes", 300000); // "create a plugin class?" — yes (a user needs a plugin type to deploy)
+        await answerText("AcceptancePluginClass"); // class name
+      });
+      const cs = path.join(workspace, projectName, "AcceptancePluginClass.cs");
+      expect(await waitForFile(cs, 120000), "plugin class scaffolded").to.equal(true);
+      return `wrote ${projectName}/AcceptancePluginClass.cs (scaffolded with a [CrmPluginRegistration] step)`;
+    });
+  });
+
+  it("builds the project — Local Build button", async () => {
+    await step(COMPONENT, "Build (Local Build button → dotnet build)", async () => {
+      await expandComponentCards();
+      await clickPanelButton("Local Build", { timeoutMs: 30000 });
+      const dll = await waitForMatchDeep(path.join(workspace, projectName), (f) => f === `${projectName}.dll`, 300000);
+      if (!dll) {
+        throw new Error("Local Build produced no compiled assembly");
+      }
+      return `compiled ${path.relative(workspace, dll)}`;
+    });
+  });
+
+  it("registers the step + publishes the package — Build & deploy button; verified in Dataverse", async () => {
+    await step(COMPONENT, "Register step + publish (Build & deploy package)", async () => {
+      await expandComponentCards();
+      await clickPanelButton("Build & deploy package", { timeoutMs: 30000, contains: true }); // primary button has a "▶ " prefix
+      // dotnet build + pack + upsert plugin package + register steps + publish — poll Dataverse for it.
+      let id: string | undefined;
+      const deadline = Date.now() + 420000;
+      do {
+        try {
+          id = await client.findPluginPackageId(pkgUnique());
+        } catch {
+          /* transient network */
+        }
+        if (id) {
+          break;
+        }
+        await sleep(6000);
+      } while (Date.now() < deadline);
+      if (!id) {
+        throw new Error(`plugin package ${pkgUnique()} not found in Dataverse after deploy`);
+      }
+      return `plugin package ${pkgUnique()} present in Dataverse (id ${id})`;
+    });
+  });
+
+  after(async function () {
+    try {
+      await client.deletePluginPackage(pkgUnique());
+    } catch {
+      /* best-effort cleanup */
+    }
+  });
+});

--- a/src/ui-test/e2e/solutionAcceptance.e2e.ts
+++ b/src/ui-test/e2e/solutionAcceptance.e2e.ts
@@ -1,0 +1,127 @@
+import * as path from "path";
+import * as fs from "fs";
+import { expect } from "chai";
+import { VSBrowser } from "vscode-extension-tester";
+import { loadE2EEnv, freshWorkspace, waitForFile, waitForOutput, dismissOverlays, sleep, E2EClient } from "./lib";
+import { clickPanelButton, expandComponentCards } from "../supervised/supervisedLib";
+import { initProject, step, showLog } from "./acceptanceLib";
+
+// ACCEPTANCE (button-driven, live Dataverse): the real main process for a Solution project —
+// EXTRACT the solution from Dataverse + unpack it (source-control ready), PACK it back to a zip
+// (the "build"), and DEPLOY (import) it. Solutions carry metadata, not code, so "write code" is
+// N/A; the round-trip Extract→Pack→Deploy is the workflow. All via the panel's own buttons.
+const COMPONENT = "Solution";
+
+describe("ACCEPTANCE: Solution — extract, pack, deploy via panel buttons", function () {
+  this.timeout(2400000);
+  const env = loadE2EEnv();
+  let workspace: string;
+  let solutionFriendlyName: string;
+  let client: E2EClient;
+
+  function config(): { zipPath?: string; packagePath?: string } {
+    const settings = JSON.parse(fs.readFileSync(path.join(workspace, "dataverse-powertools.json"), "utf8"));
+    return settings.solutionConfig ?? {};
+  }
+
+  before(async function () {
+    if (!env) {
+      this.skip();
+    }
+    client = new E2EClient(env!);
+    await client.connect();
+    solutionFriendlyName = (await client.getSolutionFriendlyName(env!.solutionName)) ?? env!.solutionName;
+    workspace = freshWorkspace("acc-solution");
+    await VSBrowser.instance.openResources(workspace);
+    await VSBrowser.instance.waitForWorkbench();
+    await sleep(3500);
+    await dismissOverlays();
+    await showLog();
+  });
+
+  it("starts a Solution project (Initialise button + wizard)", async () => {
+    await step(COMPONENT, "Start project (Initialise button)", async () => {
+      await initProject("Solution", env!, solutionFriendlyName, async () => {
+        /* solution needs no extra prompts beyond the connection + solution pick */
+      });
+      expect(await waitForFile(path.join(workspace, "dataverse-powertools.json"), 300000), "project scaffolded").to.equal(true);
+      return "Solution project scaffolded + connected (service principal)";
+    });
+  });
+
+  it("extracts + unpacks the solution — Extract button", async () => {
+    await step(COMPONENT, "Extract + unpack (Extract button)", async () => {
+      await expandComponentCards();
+      await clickPanelButton("Extract", { timeoutMs: 30000 });
+      const folder = config().packagePath ? path.resolve(workspace, config().packagePath!) : path.join(workspace, "src");
+      // pac solution export + unpack — the unpack folder fills with the customizations XML tree.
+      const deadline = Date.now() + 360000;
+      let has = false;
+      do {
+        try {
+          has = fs.existsSync(folder) && fs.readdirSync(folder).length > 0;
+        } catch {
+          has = false;
+        }
+        if (has) {
+          break;
+        }
+        await sleep(4000);
+      } while (Date.now() < deadline);
+      if (!has) {
+        throw new Error(`Extract produced no unpacked files under ${path.relative(workspace, folder)}`);
+      }
+      return `unpacked the solution into ${path.relative(workspace, folder)}/`;
+    });
+  });
+
+  it("packs the solution to a zip — Pack button", async () => {
+    await step(COMPONENT, "Pack (Pack button → .zip)", async () => {
+      await expandComponentCards();
+      await clickPanelButton("Pack", { timeoutMs: 30000 });
+      const zip = config().zipPath ? path.resolve(workspace, config().zipPath!) : "";
+      const deadline = Date.now() + 240000;
+      let found = "";
+      do {
+        if (zip && fs.existsSync(zip)) {
+          found = zip;
+          break;
+        }
+        // Fall back to any .zip produced under the workspace.
+        try {
+          const anyZip = fs.readdirSync(workspace).find((f) => f.toLowerCase().endsWith(".zip"));
+          if (anyZip) {
+            found = path.join(workspace, anyZip);
+            break;
+          }
+        } catch {
+          /* ignore */
+        }
+        await sleep(4000);
+      } while (Date.now() < deadline);
+      if (!found) {
+        throw new Error("Pack produced no solution .zip");
+      }
+      return `packed ${path.relative(workspace, found)}`;
+    });
+  });
+
+  it("deploys (imports) the solution — Deploy button", async () => {
+    await step(COMPONENT, "Deploy/import (Deploy button)", async () => {
+      await expandComponentCards();
+      await clickPanelButton("Deploy to", { timeoutMs: 30000, contains: true }); // primary "▶ Deploy to {environment}"
+      // Deploy re-packs (managed + unmanaged) THEN imports + publishes — slow, so allow a generous
+      // window before gating on the import-completion signal in the output channel.
+      const done = await waitForOutput(["Solution Imported successfully", "Published All Customizations", "imported successfully", "Import complete"], 900000);
+      if (!done) {
+        throw new Error("solution import did not report completion in the output channel");
+      }
+      // Confirm the target solution is still present/queryable after the round-trip import.
+      const friendly = await client.getSolutionFriendlyName(env!.solutionName);
+      if (!friendly) {
+        throw new Error(`solution ${env!.solutionName} not found in Dataverse after import`);
+      }
+      return `imported the solution round-trip; ${env!.solutionName} present in Dataverse`;
+    });
+  });
+});

--- a/src/ui-test/e2e/webresourceAcceptance.e2e.ts
+++ b/src/ui-test/e2e/webresourceAcceptance.e2e.ts
@@ -1,0 +1,114 @@
+import * as path from "path";
+import * as fs from "fs";
+import { expect } from "chai";
+import { VSBrowser } from "vscode-extension-tester";
+import { loadE2EEnv, freshWorkspace, answerText, pickByLabel, pickFirst, waitForFile, dismissOverlays, sleep, E2EClient } from "./lib";
+import { clickPanelButton, clickOverflowItem, expandComponentCards } from "../supervised/supervisedLib";
+import { initProject, step, showLog } from "./acceptanceLib";
+
+// ACCEPTANCE (button-driven, live Dataverse): the real main process for a Web Resources project —
+// start the project, write a TypeScript class bound to a form (the form-event registration),
+// build the bundle, then deploy it (which registers the form event + uploads), and verify the
+// web resource landed in Dataverse. All via the panel's own buttons + overflow menu.
+const COMPONENT = "Web Resource";
+
+describe("ACCEPTANCE: Web Resource — build, code, register, publish via panel buttons", function () {
+  this.timeout(2400000);
+  const env = loadE2EEnv();
+  let workspace: string;
+  let solutionFriendlyName: string;
+  let client: E2EClient;
+  const className = "AcceptanceWebResource";
+
+  function libraryName(): string {
+    const settings = JSON.parse(fs.readFileSync(path.join(workspace, "dataverse-powertools.json"), "utf8"));
+    return `${settings.prefix ?? env?.prefix}_library.js`;
+  }
+
+  before(async function () {
+    if (!env) {
+      this.skip();
+    }
+    client = new E2EClient(env!);
+    await client.connect();
+    solutionFriendlyName = (await client.getSolutionFriendlyName(env!.solutionName)) ?? env!.solutionName;
+    workspace = freshWorkspace("acc-webresource");
+    await VSBrowser.instance.openResources(workspace);
+    await VSBrowser.instance.waitForWorkbench();
+    await sleep(3500);
+    await dismissOverlays();
+    await showLog();
+  });
+
+  it("starts a Web Resources project (Initialise button + wizard)", async () => {
+    await step(COMPONENT, "Start project (Initialise button)", async () => {
+      await initProject("Web Resources", env!, solutionFriendlyName, async () => {
+        await pickByLabel("Single bundled library (recommended)", 600000); // output mode (restores run first)
+        await pickByLabel("No", 600000); // "create a new webresource?" — restores + typings run first
+      });
+      expect(await waitForFile(path.join(workspace, "dataverse-powertools.json"), 300000), "project scaffolded").to.equal(true);
+      return "Web Resources project scaffolded + connected (service principal)";
+    });
+  });
+
+  it("writes a class bound to a form (New class overflow) — code + form-event registration", async () => {
+    await step(COMPONENT, "Write code + register (New class bound to a form)", async () => {
+      await clickOverflowItem("New class", { timeoutMs: 45000 });
+      await answerText(className); // 1: class name
+      await pickFirst(60000); // 2: table (first available)
+      await pickFirst(60000); // 3: form (first available) — this is the form-event registration
+      await pickByLabel("Yes", 60000); // 4: create a test?
+      await sleep(3000);
+      await dismissOverlays();
+      const ts = path.join(workspace, "webresources_src", `${className}.ts`);
+      expect(await waitForFile(ts, 60000), "class file").to.equal(true);
+      return `wrote webresources_src/${className}.ts, bound to a form (RegisterEvent decoration)`;
+    });
+  });
+
+  it("builds the bundle — Local Build button", async () => {
+    await step(COMPONENT, "Build (Local Build button → webpack)", async () => {
+      await expandComponentCards();
+      await clickPanelButton("Local Build", { timeoutMs: 30000 });
+      expect(await waitForFile(path.join(workspace, "bin", libraryName()), 240000), `bin/${libraryName()}`).to.equal(true);
+      return `webpack bundled bin/${libraryName()}`;
+    });
+  });
+
+  it("registers the form event + publishes — Deploy button; verified in Dataverse", async () => {
+    await step(COMPONENT, "Register form event + publish (Deploy)", async () => {
+      await expandComponentCards();
+      await clickPanelButton("Deploy to", { timeoutMs: 30000, contains: true }); // "Deploy to {environment}"
+      // Deploy = build + upsert web resource + register form events + publish. Poll Dataverse.
+      let id: string | undefined;
+      const deadline = Date.now() + 300000;
+      do {
+        try {
+          id = await client.findWebresourceId(libraryName());
+        } catch {
+          /* transient */
+        }
+        if (id) {
+          break;
+        }
+        await sleep(5000);
+      } while (Date.now() < deadline);
+      if (!id) {
+        throw new Error(`web resource ${libraryName()} not found in Dataverse after deploy`);
+      }
+      const content = await client.getWebresourceContent(libraryName());
+      if (!content || content.length < 10) {
+        throw new Error(`web resource ${libraryName()} deployed but content is empty`);
+      }
+      return `web resource ${libraryName()} deployed (id ${id}, ${content.length} bytes of JS)`;
+    });
+  });
+
+  after(async function () {
+    try {
+      await client.deleteWebresource(libraryName());
+    } catch {
+      /* best-effort cleanup */
+    }
+  });
+});

--- a/src/ui-test/supervised/supervisedLib.ts
+++ b/src/ui-test/supervised/supervisedLib.ts
@@ -198,6 +198,54 @@ export async function expandComponentCards(): Promise<void> {
   await sleep(600);
 }
 
+/** Open a component card's ⋯ overflow menu and click the item with the given label — the real
+ * flow a user does for the rarer actions (New class, Add form registration, …). Tries each
+ * card's ⋯ (skipping the environment card) until the menu shows the item. Fires clicks via JS
+ * (the ⋯ and its popup rows are tiny + can be intercepted by a coordinate click). */
+export async function clickOverflowItem(itemLabel: string, opts: { timeoutMs?: number } = {}): Promise<void> {
+  const timeoutMs = opts.timeoutMs ?? 30000;
+  await narrate(`Overflow menu → "${itemLabel}"`);
+  const driver = VSBrowser.instance.driver;
+  const deadline = Date.now() + timeoutMs;
+  let lastError = "";
+  while (Date.now() < deadline) {
+    try {
+      const clicked = await withPanel(async (panel) => {
+        await expandCaretsInFrame(panel);
+        const overflows = await panel.findWebElements(By.css("button.iconbtn[aria-haspopup='menu']"));
+        for (const overflow of overflows) {
+          const owner = (await overflow.getAttribute("aria-label").catch(() => "")) ?? "";
+          if (/environment/i.test(owner)) {
+            continue; // the env-card ⋯ (Open environment / Admin Center / …), not a component action
+          }
+          await driver.executeScript("arguments[0].click();", overflow);
+          await sleep(500);
+          const items = await panel.findWebElements(By.css(".overflow-menu button.menu-item"));
+          for (const item of items) {
+            if ((await item.getText().catch(() => "")).trim() === itemLabel) {
+              await driver.executeScript("arguments[0].click();", item);
+              return true;
+            }
+          }
+          await driver.executeScript("arguments[0].click();", overflow); // close this menu, try the next ⋯
+          await sleep(300);
+        }
+        return false;
+      });
+      if (clicked) {
+        await sleep(1500);
+        return;
+      }
+      lastError = `overflow item "${itemLabel}" not found in any card menu`;
+    } catch (error) {
+      lastError = `${error}`;
+    }
+    await sleep(1500);
+  }
+  await screenshot(`FAILED-overflow-${itemLabel}`);
+  throw new Error(`clickOverflowItem timed out for "${itemLabel}" after ${timeoutMs}ms (${lastError})`);
+}
+
 /** True when the panel shows a live Dataverse connection (the green dot). */
 export async function isConnected(): Promise<boolean> {
   try {


### PR DESCRIPTION
**Button-driven acceptance e2e** covering the four deployable component types end-to-end, all through the **panel buttons + overflow menu** (no command palette), each verified in **live Dataverse**:

| Type | Steps (all via buttons) | Dataverse check |
|---|---|---|
| Plugin | Initialise + write plugin class → Local Build → Build & deploy package | plugin package present |
| Web Resource | Initialise → New class bound to a form → Local Build → Deploy | web resource + content present |
| Solution | Initialise → Extract → Pack → Deploy | `Solution Imported successfully` (round-trip) |
| PCF | Initialise (scaffold) → Restore + Local Build → Push | control bundle web resource present |

Ran on the VM: **13/14 automated steps pass**; the single miss was the Solution deploy assertion's timeout being too short (the import logged success) — widened. Also adds `clickOverflowItem` to the supervised lib, and declares **pngjs + gifenc** as devDependencies (the 0.14.35 `assembleGif.mjs` needed them; their absence also broke `npm list`). Suites self-skip without creds; test-only + tooling, no shipped-code change. **752/752** unit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)