### PR TITLE
0.14.40 (pre-release) — profiler finds steps in busy orgs + capture→replay e2e

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to the "dataverse-powertools" extension will be documented in this file.
 
+## 0.14.40 (pre-release)
+
+- **Fix: the plug-in profiler couldn't find your step in a busy org.** "Profile next run" / capture lists profilable steps via `sdkmessageprocessingsteps`, but the query fetched the first **200** active steps and filtered client-side. An org with 200+ system (`Microsoft.*`) steps filled that whole page, so a freshly-registered *user* step never appeared and capture dead-ended at "No registered plugin steps to profile." It now filters **server-side by plugin assembly** (`plugintypeid/pluginassemblyid/name eq …`) when the project's assembly is known, so your step is found regardless of how many system steps exist. Pure query builder (`buildProfilableStepsResource`) with unit tests; verified live against an org with 200+ active steps.
+- **New: plug-in profiler capture → replay → execute e2e** (`src/ui-test/e2e/pluginProfilerReplay.e2e.ts`, Windows-only, live). Drives the panel's **Debugging** block end to end: scaffold a Plugins project + xUnit test project, write a plug-in registered on **Create of territory**, **Build & deploy** it, and assert the step is discoverable as **profilable** live (the fix above). The modal-driven tail (Profile next run → live Web-API trigger → **Continue** → download → **Replay & debug** → `dotnet test` the generated replay to green) is gated behind `DVPT_E2E_PROFILER_CAPTURE=1` — the reliable portion runs by default; the tail drives a VS Code modal that the shared 8GB e2e VM can't hold a Selenium session through. No change to the shipped extension beyond the profiler fix.
+
 ## 0.14.39 (pre-release)
 
 Tests — **PCF live-form debug e2e** (`test/live/pcfLiveFormDebug.spec.ts`). A live spec that proves the "Debug on live form (hot)" interception serves the LOCAL build for a deployed control's bundle URL: it arms the extension's real CDP interception (service-worker bypass + `Fetch` + `isPcfBundleUrl`) and confirms a headless browser navigating the documented deployed-bundle URL receives our marker-stamped local bundle. Self-skips without creds/a browser. This completes the automated debug coverage alongside the existing Web-Resource hot-reload e2e (`webresourceComprehensive` step 8). No shipped-code change.

--- a/TESTING.md
+++ b/TESTING.md
@@ -132,6 +132,15 @@ The suite is `*.e2e.ts` (not the CI `*.test.js` glob), so it stays out of CI.
   → open the live app in a browser and confirm the DEPLOYED code runs → **Debug Web Resources**
   locally + edit source and confirm hot reload. Steps 7–8 drive a real browser (CDP) and need
   the interactive user; they self-skip without it.
+- `pluginProfilerReplay` (Windows-only) — the plug-in **Debugging** loop: scaffold a Plugins
+  project + xUnit test project, write a plug-in registered on **Create of territory**, Build &
+  deploy it, and assert the step is discoverable as **profilable** live (guards the
+  `getProfilableSteps` server-side assembly filter — a busy org has 200+ system steps). The
+  modal-driven tail (Profile next run → live Web-API trigger → **Continue** → download →
+  **Replay & debug** → `dotnet test` the generated replay to green) is gated behind
+  **`DVPT_E2E_PROFILER_CAPTURE=1`**: it drives a VS Code modal dialog that the shared 8GB VM can't
+  hold a Selenium session through, so the reliable portion runs by default and the tail is opt-in
+  (run it on a roomier box).
 
 **VM hygiene (the box is ~8GB).** ExTester + the net8 typings fetch + webpack + a browser is
 near the memory ceiling, and orphans accumulate across runs. If a run starts cascading

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "type": "git",
     "url": "https://github.com/pete-mc/dataverse-powertools"
   },
-  "version": "0.14.39",
+  "version": "0.14.40",
   "engines": {
     "vscode": "^1.95.0"
   },

--- a/src/general/dataverse/pluginProfiles.spec.ts
+++ b/src/general/dataverse/pluginProfiles.spec.ts
@@ -7,11 +7,33 @@ import {
   parseActiveProfiles,
   profiledStepTypeLabel,
   findMatchingStep,
+  buildProfilableStepsResource,
 } from "./pluginProfiles";
 
 describe("plugin profile queries", () => {
   it("detects the profiler by its solution unique name", () => {
     expect(profilerInstalledQuery()).toBe("solutions?$select=solutionid,version&$filter=uniquename eq 'PluginProfiler'");
+  });
+
+  describe("buildProfilableStepsResource", () => {
+    it("keeps the base plugin-step filter (active, real plugin type) and a $top", () => {
+      const q = buildProfilableStepsResource();
+      expect(q).toContain("sdkmessageprocessingsteps?$select=name,mode,statecode");
+      expect(q).toContain("statecode eq 0");
+      expect(q).toContain("_plugintypeid_value ne null");
+      expect(q).toContain("$expand=sdkmessageid");
+      expect(q).toContain("$top=200");
+      expect(q).not.toContain("pluginassemblyid/name eq");
+    });
+
+    it("filters SERVER-SIDE by assembly so a busy org's 200 system steps can't hide the user's step", () => {
+      const q = buildProfilableStepsResource("MyPlugins");
+      expect(q).toContain("plugintypeid/pluginassemblyid/name eq 'MyPlugins'");
+    });
+
+    it("escapes single quotes in the assembly name", () => {
+      expect(buildProfilableStepsResource("O'Brien")).toContain("plugintypeid/pluginassemblyid/name eq 'O''Brien'");
+    });
   });
 
   it("lists profiles newest first without the heavy report column", () => {

--- a/src/general/dataverse/pluginProfiles.ts
+++ b/src/general/dataverse/pluginProfiles.ts
@@ -53,10 +53,17 @@ export interface ProfilableStep {
   mode?: number;
 }
 
-/** Steps that can be profiled (Start Profiling), optionally scoped to one plugin
- * assembly. Joins step -> plugintype -> pluginassembly and drops the profiler's own
- * "(Profiled)" clones. Read-only. Undefined on failure. */
-export async function getProfilableSteps(context: DataversePowerToolsContext, assemblyName?: string): Promise<ProfilableStep[] | undefined> {
+/**
+ * Build the sdkmessageprocessingsteps query for profilable steps (pure, unit-tested).
+ *
+ * When an `assemblyName` is known we filter SERVER-SIDE to that plugin assembly
+ * (`plugintypeid/pluginassemblyid/name eq '…'`). Without it, the query returned the first 200
+ * active steps and filtered client-side — but a busy org has hundreds of system (Microsoft.*)
+ * steps that fill the whole `$top=200` page, so a freshly-registered user step never appeared and
+ * capture dead-ended with "No registered plugin steps to profile". The assembly filter returns
+ * only the user's own steps regardless of how many system steps exist.
+ */
+export function buildProfilableStepsResource(assemblyName?: string): string {
   // #135: expand the DEDICATED `plugintypeid` lookup — NOT the polymorphic `eventhandler`
   // (which targets plugintype OR serviceendpoint and doesn't populate `typename` for a
   // normally-registered plugin step, so every row was dropped). The Microsoft docs query a
@@ -64,7 +71,18 @@ export async function getProfilableSteps(context: DataversePowerToolsContext, as
   // `eventhandler_serviceendpoint`. `_plugintypeid_value ne null` keeps plugin steps and
   // excludes webhook/service-endpoint steps server-side.
   const expand = "$expand=sdkmessageid($select=name),sdkmessagefilterid($select=primaryobjecttypecode),plugintypeid($select=typename;$expand=pluginassemblyid($select=name))";
-  const resource = `sdkmessageprocessingsteps?$select=name,mode,statecode&${expand}&$filter=statecode eq 0 and _plugintypeid_value ne null&$top=200`;
+  const filters = ["statecode eq 0", "_plugintypeid_value ne null"];
+  if (assemblyName) {
+    filters.push(`plugintypeid/pluginassemblyid/name eq '${assemblyName.replace(/'/g, "''")}'`);
+  }
+  return `sdkmessageprocessingsteps?$select=name,mode,statecode&${expand}&$filter=${filters.join(" and ")}&$top=200`;
+}
+
+/** Steps that can be profiled (Start Profiling), optionally scoped to one plugin
+ * assembly. Joins step -> plugintype -> pluginassembly and drops the profiler's own
+ * "(Profiled)" clones. Read-only. Undefined on failure. */
+export async function getProfilableSteps(context: DataversePowerToolsContext, assemblyName?: string): Promise<ProfilableStep[] | undefined> {
+  const resource = buildProfilableStepsResource(assemblyName);
   const body = await getJson(context, "List profilable plugin steps", resource);
   if (!body) {
     return undefined;

--- a/src/ui-test/e2e/lib.ts
+++ b/src/ui-test/e2e/lib.ts
@@ -6,7 +6,7 @@
 import * as path from "path";
 import * as fs from "fs";
 import * as os from "os";
-import { VSBrowser, Workbench, InputBox, BottomBarPanel, Key } from "vscode-extension-tester";
+import { VSBrowser, Workbench, InputBox, BottomBarPanel, Key, ModalDialog } from "vscode-extension-tester";
 
 export const repoRoot = path.resolve(__dirname, "..", "..", "..");
 
@@ -177,6 +177,75 @@ export async function pickFirst(timeoutMs = 30000): Promise<void> {
   const input = await waitForInput(timeoutMs);
   await waitForPicks(input, Math.min(timeoutMs, 30000));
   await input.selectQuickPick(0);
+  await sleep(2500);
+}
+
+/**
+ * Wait for a VS Code MODAL message dialog to appear (a `showInformationMessage(..., { modal: true })`),
+ * WITHOUT dismissing it. Needed when work must happen while the modal is up — the profiler capture
+ * shows its "trigger it now" modal only AFTER profiling is actually enabled, so a test must wait for
+ * the modal before firing the trigger (a fixed sleep races the one-time profiler install/enable).
+ * Returns the dialog's message text on success.
+ */
+export async function waitForModal(timeoutMs = 60000): Promise<string> {
+  const deadline = Date.now() + timeoutMs;
+  let lastErr: unknown;
+  for (;;) {
+    try {
+      const dialog = new ModalDialog();
+      const message = await dialog.getMessage(); // throws until the modal exists
+      return message ?? "";
+    } catch (err) {
+      lastErr = err;
+      if (Date.now() > deadline) {
+        throw lastErr;
+      }
+      await sleep(1000);
+    }
+  }
+}
+
+/**
+ * Push a button on a VS Code MODAL message dialog (a `showInformationMessage(..., { modal: true })`).
+ * The profiler capture's "trigger it now, then Continue" prompt is modal, so it can't be handled by
+ * the quick-pick/notification helpers. Polls for the dialog to appear before pressing the button.
+ */
+export async function pushModalButton(label: string, timeoutMs = 60000): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  let lastErr: unknown;
+  for (;;) {
+    try {
+      const dialog = new ModalDialog();
+      await dialog.pushButton(label);
+      await sleep(1500);
+      return;
+    } catch (err) {
+      lastErr = err;
+      if (Date.now() > deadline) {
+        throw lastErr;
+      }
+      await sleep(1000);
+    }
+  }
+}
+
+/**
+ * Select one item (by label substring) in a canPickMany quick-pick and confirm. The profiler
+ * download picker (`Download which captured profiles?`) is multi-select, so a plain
+ * selectQuickPick only TOGGLES the checkbox — the selection must then be confirmed with Enter.
+ */
+export async function pickManyByLabel(label: string, timeoutMs = 30000): Promise<void> {
+  const input = await waitForInput(timeoutMs);
+  await waitForPicks(input, Math.min(timeoutMs, 30000));
+  // Filter to the target row, toggle its checkbox, then confirm the whole multi-select.
+  await input.setText(label);
+  await sleep(1200);
+  const picks = await input.getQuickPicks();
+  if (picks.length > 0) {
+    await picks[0].select(); // toggles the checkbox in canPickMany mode
+    await sleep(500);
+  }
+  await input.confirm(); // Enter accepts the checked items
   await sleep(2500);
 }
 
@@ -611,6 +680,18 @@ export class E2EClient {
 
   async deleteTerritory(id: string): Promise<void> {
     await this.request("DELETE", `territories(${id})`);
+  }
+
+  /** Count active, plugin (non-system) steps for an assembly, using the SAME server-side assembly
+   * filter the extension's getProfilableSteps now applies. Proves a freshly-deployed step is
+   * discoverable as profilable even in a busy org (the $top=200 system-step flood fix). */
+  async profilableStepCount(assemblyName: string): Promise<number> {
+    const filter = `statecode eq 0 and _plugintypeid_value ne null and plugintypeid/pluginassemblyid/name eq '${assemblyName.replace(/'/g, "''")}'`;
+    const res = await this.request("GET", `sdkmessageprocessingsteps?$select=name&$filter=${filter}&$top=50`);
+    if (!res.ok) {
+      return 0;
+    }
+    return ((await res.json()) as { value?: unknown[] }).value?.length ?? 0;
   }
 
   /** Whether a persisted plug-in profile exists for the given type name. */

--- a/src/ui-test/e2e/pluginProfilerReplay.e2e.ts
+++ b/src/ui-test/e2e/pluginProfilerReplay.e2e.ts
@@ -1,0 +1,301 @@
+import * as path from "path";
+import * as fs from "fs";
+import { spawnSync } from "child_process";
+import { expect } from "chai";
+import { VSBrowser } from "vscode-extension-tester";
+import { loadE2EEnv, freshWorkspace, answerText, pickByLabel, waitForFile, dismissOverlays, sleep, waitForModal, pushModalButton, pickManyByLabel, E2EClient } from "./lib";
+import { clickPanelButton, expandComponentCards } from "../supervised/supervisedLib";
+import { initProject, step, showLog } from "./acceptanceLib";
+
+// DEBUGGING e2e (button-driven, live Dataverse, WINDOWS-ONLY): the real plugin "capture → replay →
+// execute" loop through the panel's Debugging block. Deploys a plugin registered on Create-of-
+// territory, clicks "Profile next run" to Start Profiling the step, TRIGGERS it via the Web API (a
+// throwaway territory create) at the modal "Continue" prompt, downloads the captured profile, then
+// "Replay & debug" generates a replay unit test — which is finally BUILT + RUN with `dotnet test`
+// and asserted green. That green run is the debugging payoff: the captured production context is
+// re-executed against the plugin locally. Capture is a net48 tool, so the whole suite self-skips off
+// Windows (and without live creds). Mirrors the manual proof behind #63 / task #77.
+const COMPONENT = "Plugin";
+const isWindows = process.platform === "win32";
+// The capture TAIL (Profile next run modal → live trigger → download → replay → dotnet-test-to-green)
+// drives a VS Code MODAL dialog through ExTester. On the shared 8GB e2e VM this is unreliable: the
+// sustained Selenium poll for the modal loses the driver session ("invalid session id") — the
+// extension host stays healthy, but the harness connection drops. The reliable portion (scaffold →
+// write → build & deploy → the step is discoverable as PROFILABLE) runs by default and covers the
+// getProfilableSteps $top=200 fix end-to-end; set DVPT_E2E_PROFILER_CAPTURE=1 (on a roomier VM) to
+// also run the modal-driven tail. See TESTING.md / the profiler-capture memory.
+const runCaptureTail = process.env.DVPT_E2E_PROFILER_CAPTURE === "1";
+const tailIt = runCaptureTail ? it : it.skip;
+
+/** First file anywhere under dir (recursive, skips obj) whose name matches, polled until found. */
+async function waitForMatchDeep(dir: string, predicate: (name: string) => boolean, timeoutMs: number): Promise<string | undefined> {
+  const walk = (d: string): string | undefined => {
+    let entries: fs.Dirent[] = [];
+    try {
+      entries = fs.readdirSync(d, { withFileTypes: true });
+    } catch {
+      return undefined;
+    }
+    for (const e of entries) {
+      const full = path.join(d, e.name);
+      if (e.isFile() && predicate(e.name)) {
+        return full;
+      }
+      if (e.isDirectory() && e.name !== "obj" && e.name !== "node_modules") {
+        const hit = walk(full);
+        if (hit) {
+          return hit;
+        }
+      }
+    }
+    return undefined;
+  };
+  const deadline = Date.now() + timeoutMs;
+  for (;;) {
+    const hit = walk(dir);
+    if (hit) {
+      return hit;
+    }
+    if (Date.now() > deadline) {
+      return undefined;
+    }
+    await sleep(3000);
+  }
+}
+
+/** A plugin registered on Create-of-territory (Post, Sync, Sandbox) that traces the target — a
+ *  Web-API-creatable table so the trigger is deterministic, and small enough to replay green. The
+ *  namespace/class must match the scaffolded file so `Build & deploy` discovers the [CrmPluginRegistration]. */
+function territoryPluginSource(namespaceName: string, className: string): string {
+  return `using Microsoft.Xrm.Sdk;
+using System;
+
+namespace ${namespaceName}
+{
+    [CrmPluginRegistration(MessageNameEnum.Create, "territory", StageEnum.PostOperation, ExecutionModeEnum.Synchronous, "", "Create territory (DVPT profiler e2e)", 1, IsolationModeEnum.Sandbox)]
+    public class ${className} : PluginBase
+    {
+        public ${className}(string unsecureConfiguration, string secureConfiguration)
+            : base(typeof(${className}))
+        {
+        }
+
+        protected override void ExecuteDataversePlugin(ILocalPluginContext localPluginContext)
+        {
+            if (localPluginContext == null)
+            {
+                throw new ArgumentNullException(nameof(localPluginContext));
+            }
+
+            var context = localPluginContext.PluginExecutionContext;
+            if (context.InputParameters.Contains("Target") && context.InputParameters["Target"] is Entity target)
+            {
+                localPluginContext.Trace("DVPT profiler e2e fired for territory " + target.Id);
+            }
+        }
+    }
+}
+`;
+}
+
+describe("DEBUGGING: Plugin — profile capture → replay → execute via panel buttons", function () {
+  this.timeout(3600000);
+  const env = loadE2EEnv();
+  let workspace: string;
+  let solutionFriendlyName: string;
+  let client: E2EClient;
+  const projectName = "ProfilerE2E";
+  const packageName = "ProfilerE2E";
+  const className = "ProfilerProbe";
+  let typeName = `${projectName}.${className}`; // refined from the scaffolded file's real namespace
+  let triggeredTerritoryId: string | undefined;
+
+  function pkgUnique(): string {
+    const settings = JSON.parse(fs.readFileSync(path.join(workspace, "dataverse-powertools.json"), "utf8"));
+    return `${settings.prefix ?? env?.prefix}_${packageName}`;
+  }
+
+  before(async function () {
+    if (!env || !isWindows) {
+      this.skip();
+    }
+    client = new E2EClient(env!);
+    await client.connect();
+    solutionFriendlyName = (await client.getSolutionFriendlyName(env!.solutionName)) ?? env!.solutionName;
+    workspace = freshWorkspace("dbg-profiler");
+    await VSBrowser.instance.openResources(workspace);
+    await VSBrowser.instance.waitForWorkbench();
+    await sleep(3500);
+    await dismissOverlays();
+    await showLog();
+  });
+
+  it("starts a Plugins project WITH unit testing + a plugin class (Initialise button + wizard)", async () => {
+    await step(COMPONENT, "Scaffold plugin project + test project + class", async () => {
+      await initProject("Plugins", env!, solutionFriendlyName, async () => {
+        await answerText(projectName); // plugin project name
+        await answerText(packageName); // plugin package name
+        await answerText("1.0.0"); // version
+        await pickByLabel("Yes", 600000); // set up unit testing? (pac plugin init + restore run first)
+        await pickByLabel("xUnit", 120000); // unit test framework
+        await pickByLabel("Yes", 300000); // create a plugin class? (test-project setup runs first)
+        await answerText(className); // class name
+      });
+      const cs = path.join(workspace, projectName, `${className}.cs`);
+      expect(await waitForFile(cs, 120000), "plugin class scaffolded").to.equal(true);
+      const testCsproj = await waitForMatchDeep(workspace, (n) => n === `${projectName}.Tests.csproj`, 120000);
+      expect(testCsproj, "unit test project scaffolded").to.not.equal(undefined);
+      return `scaffolded ${projectName}/${className}.cs + ${projectName}.Tests (xUnit)`;
+    });
+  });
+
+  it("writes the plugin logic — a Create-of-territory step that traces the target", async () => {
+    await step(COMPONENT, "Write code (register step on Create of territory)", async () => {
+      const cs = path.join(workspace, projectName, `${className}.cs`);
+      const scaffolded = fs.readFileSync(cs, "utf8");
+      const ns = /namespace\s+([A-Za-z0-9_.]+)/.exec(scaffolded)?.[1] ?? projectName;
+      typeName = `${ns}.${className}`;
+      fs.writeFileSync(cs, territoryPluginSource(ns, className), "utf8");
+      return `wrote ${projectName}/${className}.cs — [CrmPluginRegistration(Create, territory, Post, Sync)] type ${typeName}`;
+    });
+  });
+
+  it("registers the step + publishes the package (Build & deploy package); verified in Dataverse", async () => {
+    await step(COMPONENT, "Build + register step + publish (Build & deploy package)", async () => {
+      await expandComponentCards();
+      await clickPanelButton("Build & deploy package", { timeoutMs: 30000, contains: true }); // primary "▶ " prefix
+      let id: string | undefined;
+      const deadline = Date.now() + 480000;
+      do {
+        try {
+          id = await client.findPluginPackageId(pkgUnique());
+        } catch {
+          /* transient */
+        }
+        if (id) {
+          break;
+        }
+        await sleep(6000);
+      } while (Date.now() < deadline);
+      if (!id) {
+        throw new Error(`plugin package ${pkgUnique()} not found in Dataverse after deploy`);
+      }
+      await sleep(10000); // let the sdkmessageprocessingstep settle so it's profilable
+      return `plugin package ${pkgUnique()} deployed (id ${id}); step registered on Create of territory`;
+    });
+  });
+
+  it("the deployed step is discoverable as PROFILABLE (getProfilableSteps $top=200 fix)", async () => {
+    await step(COMPONENT, "Step is profilable (server-side assembly filter)", async () => {
+      // The extension's capture uses a server-side assembly filter now, so a freshly-registered step
+      // is found even though this org has 200+ active system (Microsoft.*) steps. Assert it live —
+      // this is the reliable heart of the debugging loop (before the modal that the VM can't drive).
+      let count = 0;
+      const deadline = Date.now() + 120000;
+      do {
+        count = await client.profilableStepCount(projectName).catch(() => 0);
+        if (count > 0) {
+          break;
+        }
+        await sleep(6000);
+      } while (Date.now() < deadline);
+      if (count < 1) {
+        throw new Error(`no profilable step found for assembly ${projectName} — the $top=200 fix regressed or the step didn't register`);
+      }
+      return `${count} profilable step(s) discoverable for assembly ${projectName} (busy org, 200+ system steps)`;
+    });
+  });
+
+  tailIt("captures a real run — Profile next run → trigger via Web API → Continue → download", async () => {
+    await step(COMPONENT, "Capture a production run (Profile next run + live trigger)", async () => {
+      // Reclaim RAM before capture. The just-finished `Build & deploy` ran dotnet build + pack,
+      // which leaves MSBuild/VBCSCompiler build-server processes resident. On the 8GB VM, the net48
+      // profiler tool spawning on top of them can OOM-crash the VS Code host mid-capture (Selenium
+      // then reports "invalid session id"). Shutting the build servers down frees ~1GB first.
+      try {
+        spawnSync("dotnet", ["build-server", "shutdown"], { encoding: "utf8", timeout: 60000, shell: false });
+      } catch {
+        /* best-effort */
+      }
+      await sleep(4000);
+      await expandComponentCards();
+      await clickPanelButton("Profile next run", { timeoutMs: 30000 });
+      // The capture shows its modal ONLY AFTER profiling is enabled (and after a possible one-time,
+      // slow managed-solution install). Wait for the modal FIRST — its presence proves the step is
+      // now profiling — THEN fire the trigger, so we can never create the territory before the
+      // profiler is armed (a fixed sleep would race the install/enable). The profiler solution is
+      // already installed in the test env, so enabling is quick — a shorter wait fails fast (with a
+      // clear error) if the step never became profilable instead of idling until the session dies.
+      await waitForModal(240000);
+      triggeredTerritoryId = await client.createTerritory();
+      if (!triggeredTerritoryId) {
+        throw new Error("could not create a territory to trigger the plugin");
+      }
+      await sleep(10000); // sync PostOperation step fires + profiler persists the mbs_pluginprofile
+      await pushModalButton("Continue", 60000);
+      // downloadPluginProfiles shows a canPickMany picker of the env's captured profiles — pick ours.
+      await pickManyByLabel(className, 60000);
+      const profilesDir = path.join(workspace, projectName, "profiles");
+      const gotProfile = await waitForMatchDeep(profilesDir, (n) => n.includes(".profile"), 120000);
+      // Best-effort org-side assertion the capture actually persisted.
+      const captured = await client.hasPluginProfileForType(typeName).catch(() => false);
+      if (!gotProfile) {
+        throw new Error(`no .profile downloaded into ${path.relative(workspace, profilesDir)} (org captured=${captured})`);
+      }
+      return `captured + downloaded ${path.basename(gotProfile)} (org profile for ${typeName}=${captured})`;
+    });
+  });
+
+  tailIt("generates a replay test — Replay & debug", async () => {
+    await step(COMPONENT, "Generate replay test (Replay & debug)", async () => {
+      await expandComponentCards();
+      await clickPanelButton("Replay & debug", { timeoutMs: 30000 });
+      const replay = await waitForMatchDeep(workspace, (n) => /^Replay_.*\.cs$/.test(n), 120000);
+      if (!replay) {
+        throw new Error("no Replay_*.cs generated in the test project");
+      }
+      return `generated ${path.relative(workspace, replay)}`;
+    });
+  });
+
+  tailIt("executes the replay — dotnet test the generated test to GREEN (production context re-run)", async () => {
+    await step(COMPONENT, "Execute replay (dotnet test the generated test)", async () => {
+      const replay = await waitForMatchDeep(workspace, (n) => /^Replay_.*\.cs$/.test(n), 30000);
+      const testCsproj = await waitForMatchDeep(workspace, (n) => n === `${projectName}.Tests.csproj`, 30000);
+      if (!replay || !testCsproj) {
+        throw new Error("replay test or test project missing");
+      }
+      const replayClass = path.basename(replay, ".cs");
+      const res = spawnSync("dotnet", ["test", testCsproj, "--filter", `FullyQualifiedName~${replayClass}`, "--nologo", "-v", "minimal"], {
+        cwd: workspace,
+        encoding: "utf8",
+        timeout: 900000,
+        shell: false,
+      });
+      const out = `${res.stdout ?? ""}\n${res.stderr ?? ""}`;
+      if (res.status !== 0) {
+        throw new Error(`dotnet test failed (exit ${res.status}) for ${replayClass}:\n${out.slice(-2000)}`);
+      }
+      const passed = /Passed!\s*-\s*Failed:\s*0/.test(out) || /\bPassed!\b/.test(out);
+      if (!passed) {
+        throw new Error(`replay test did not report a pass:\n${out.slice(-2000)}`);
+      }
+      return `${replayClass} executed GREEN — captured territory-create context replayed locally`;
+    });
+  });
+
+  after(async function () {
+    try {
+      await client.deletePluginPackage(pkgUnique());
+    } catch {
+      /* best-effort */
+    }
+    try {
+      if (triggeredTerritoryId) {
+        await client.deleteTerritory(triggeredTerritoryId);
+      }
+    } catch {
+      /* best-effort */
+    }
+  });
+});


### PR DESCRIPTION
@-