### PR TITLE
0.14.46 (pre-release) — #143 Move 2: unit-cover the plugin-deploy Dataverse path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to the "dataverse-powertools" extension will be documented in this file.
 
+## 0.14.46 (pre-release)
+
+- **Tests (#143 Move 2) — the plugin-deploy Dataverse path now has unit coverage.** The `pluginpackage` and classic `pluginassembly` create/update handlers (`getDataversePluginPackage.ts`, `getDataversePluginAssembly.ts`) were untested. Added `getDataversePluginPackage.spec.ts` and `getDataversePluginAssembly.spec.ts` (16 tests) driving them against the mocked `node-fetch` seam (no live org): the **create-vs-update upsert branching**, the create-returns-204 **`OData-EntityId` header id-parse**, OData single-quote escaping, the **strong-name (`0x8004416c`) guidance** an unsigned `--skip-signing` assembly triggers, and the package→assembly materialisation poll. No shipped-code change. Unit tests 774 → 790.
+
 ## 0.14.45 (pre-release)
 
 - **Tests (#143 Move 2) — the Plugin Profiler's whole Web API path now runs in CI against the mocked Dataverse API, with no live org.** This was the single largest untested `fetch` surface in the Dataverse layer: only the profiler's pure query builders/parsers were unit-tested, while the async calls that actually issue requests (`getPluginAssemblyProfilingInfo`, `setPluginAssemblyContent`, `getProfilableSteps`, `deleteProfilerStep`, `isProfilerInstalled`, `getPluginProfiles`, `getPluginProfileContent`) had no coverage. Extended the in-memory Web API mock (`test/dataverseFetchMock.ts`) to model `pluginassemblies` (filter-by-name + content PATCH), `sdkmessageprocessingsteps` (profilable-step list + clone DELETE), `solutions`, `mbs_pluginprofiles` (list + report-by-id) and `ImportSolution`, and added `pluginProfiles.mock.spec.ts` (11 tests) that drives the capture-prep → discover → cleanup flow end to end. It asserts the request is **shaped** correctly (the #135/#140 server-side assembly filter; keyed PATCH/DELETE; the 0.14.43 package-content prep), that behaviour is **identical under service-principal and interactive (OAuth) auth** — the recurring `tenantId`-gating bug class (#128/#129/#135) — and that an invalid connection short-circuits before any network call. No shipped-code change.

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "type": "git",
     "url": "https://github.com/pete-mc/dataverse-powertools"
   },
-  "version": "0.14.45",
+  "version": "0.14.46",
   "engines": {
     "vscode": "^1.95.0"
   },

--- a/src/general/dataverse/getDataversePluginAssembly.spec.ts
+++ b/src/general/dataverse/getDataversePluginAssembly.spec.ts
@@ -1,0 +1,93 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+vi.mock("node-fetch", () => ({ default: vi.fn() }));
+import fetch from "node-fetch";
+import * as fs from "fs";
+import {
+  getDataversePluginAssemblyId,
+  createDataversePluginAssembly,
+  ensureDataversePluginAssemblyId,
+  updateDataversePluginAssemblyContent,
+  upsertDataversePluginAssembly,
+} from "./getDataversePluginAssembly";
+import { fakeDataverseContext, okJson, httpError } from "../../../test/dataverseTestUtils";
+
+// #143 Move 2 — the classic (non-package) plugin-ASSEMBLY deploy path against a mocked node-fetch,
+// no live org. Guards the create-vs-update upsert branching and the strong-name (0x8004416c)
+// guidance that a --skip-signing assembly triggers.
+
+const fetchMock = fetch as unknown as ReturnType<typeof vi.fn>;
+
+beforeEach(() => {
+  fetchMock.mockReset();
+  vi.spyOn(fs.promises, "readFile").mockResolvedValue(Buffer.from("DLLBYTES"));
+});
+
+describe("getDataversePluginAssemblyId", () => {
+  it("looks up an assembly by name and returns its id", async () => {
+    fetchMock.mockResolvedValue(okJson({ value: [{ pluginassemblyid: "asm-1", name: "Contoso.Plugins" }] }));
+    const { context } = fakeDataverseContext();
+    expect(await getDataversePluginAssemblyId(context, "Contoso.Plugins")).toBe("asm-1");
+    expect(fetchMock.mock.calls[0][0]).toContain("pluginassemblies?");
+  });
+
+  it("returns undefined on an empty result", async () => {
+    fetchMock.mockResolvedValue(okJson({ value: [] }));
+    const { context } = fakeDataverseContext();
+    expect(await getDataversePluginAssemblyId(context, "Contoso.Plugins")).toBeUndefined();
+  });
+
+  it("logs strong-name guidance when the API rejects an unsigned assembly (0x8004416c)", async () => {
+    fetchMock.mockResolvedValue(httpError(400, "Bad Request", "error 0x8004416c: public assembly must have public key token"));
+    const { context, lines } = fakeDataverseContext();
+    expect(await getDataversePluginAssemblyId(context, "Contoso.Plugins")).toBeUndefined();
+    expect(lines.join("\n")).toContain("strong-named assembly");
+  });
+});
+
+describe("createDataversePluginAssembly", () => {
+  it("POSTs the base64 assembly content and returns the new id", async () => {
+    fetchMock.mockResolvedValue(okJson({ pluginassemblyid: "asm-new" }));
+    const { context } = fakeDataverseContext();
+    expect(await createDataversePluginAssembly(context, "Contoso.Plugins", "/tmp/a.dll")).toBe("asm-new");
+    const [url, options] = fetchMock.mock.calls[0];
+    expect(url).toContain("pluginassemblies");
+    expect(options).toMatchObject({ method: "POST" });
+    expect(JSON.parse((options as any).body)).toMatchObject({ name: "Contoso.Plugins", content: Buffer.from("DLLBYTES").toString("base64"), isolationmode: 2 });
+  });
+});
+
+describe("ensure / upsert branching", () => {
+  it("ensure returns the existing id without creating", async () => {
+    fetchMock.mockResolvedValue(okJson({ value: [{ pluginassemblyid: "asm-existing" }] }));
+    const { context } = fakeDataverseContext();
+    expect(await ensureDataversePluginAssemblyId(context, "Contoso.Plugins", "/tmp/a.dll")).toEqual({ assemblyId: "asm-existing", created: false });
+    expect(fetchMock).toHaveBeenCalledOnce(); // lookup only, no create
+  });
+
+  it("ensure creates when the assembly is missing", async () => {
+    fetchMock.mockResolvedValueOnce(okJson({ value: [] })); // lookup: none
+    fetchMock.mockResolvedValueOnce(okJson({ pluginassemblyid: "asm-created" })); // POST
+    const { context } = fakeDataverseContext();
+    expect(await ensureDataversePluginAssemblyId(context, "Contoso.Plugins", "/tmp/a.dll")).toEqual({ assemblyId: "asm-created", created: true });
+  });
+
+  it("upsert PATCHes content when the assembly already exists", async () => {
+    fetchMock.mockResolvedValueOnce(okJson({ value: [{ pluginassemblyid: "asm-existing" }] })); // lookup
+    fetchMock.mockResolvedValueOnce(okJson({})); // PATCH
+    const { context } = fakeDataverseContext();
+    expect(await upsertDataversePluginAssembly(context, "Contoso.Plugins", "/tmp/a.dll")).toEqual({ assemblyId: "asm-existing", created: false, updated: true });
+    const patch = fetchMock.mock.calls[1];
+    expect(patch[0]).toContain("pluginassemblies(asm-existing)");
+    expect(patch[1]).toMatchObject({ method: "PATCH" });
+  });
+});
+
+describe("updateDataversePluginAssemblyContent", () => {
+  it("returns false and logs guidance on a strong-name rejection", async () => {
+    fetchMock.mockResolvedValue(httpError(400, "Bad Request", "0x8004416c public key token"));
+    const { context, lines } = fakeDataverseContext();
+    expect(await updateDataversePluginAssemblyContent(context, "asm-1", "/tmp/a.dll")).toBe(false);
+    expect(lines.join("\n")).toContain("strong-named assembly");
+  });
+});

--- a/src/general/dataverse/getDataversePluginPackage.spec.ts
+++ b/src/general/dataverse/getDataversePluginPackage.spec.ts
@@ -1,0 +1,105 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+vi.mock("node-fetch", () => ({ default: vi.fn() }));
+import fetch from "node-fetch";
+import * as fs from "fs";
+import { getDataversePluginPackageId, upsertDataversePluginPackage, waitForDataversePluginAssemblyFromPackage } from "./getDataversePluginPackage";
+import { fakeDataverseContext, okJson, httpError } from "../../../test/dataverseTestUtils";
+
+// #143 Move 2 — the plugin-PACKAGE deploy path (create/update the pluginpackage + wait for its
+// assembly to materialise) against a mocked node-fetch, no live org. Guards the create-vs-update
+// upsert branching and the OData-EntityId header id-parse (create returns 204, no JSON body).
+
+const fetchMock = fetch as unknown as ReturnType<typeof vi.fn>;
+
+/** A create response: 204 No Content with the new id in the OData-EntityId header. */
+function createdViaHeader(id: string) {
+  return {
+    ok: true,
+    status: 204,
+    statusText: "No Content",
+    headers: { get: (k: string) => (k === "OData-EntityId" ? `https://org.crm.dynamics.com/api/data/v9.2/pluginpackages(${id})` : null) },
+    json: async () => ({}),
+    text: async () => "",
+  };
+}
+
+const META = { name: "Contoso Plugins", uniqueName: "contoso_plugins", version: "1.0.0.0" };
+
+beforeEach(() => {
+  fetchMock.mockReset();
+  vi.spyOn(fs.promises, "readFile").mockResolvedValue(Buffer.from("DLLBYTES"));
+});
+
+describe("getDataversePluginPackageId", () => {
+  it("looks up a package by unique name and returns its id", async () => {
+    fetchMock.mockResolvedValue(okJson({ value: [{ pluginpackageid: "pkg-1", uniquename: META.uniqueName }] }));
+    const { context } = fakeDataverseContext();
+    expect(await getDataversePluginPackageId(context, META.uniqueName)).toBe("pkg-1");
+    const url = fetchMock.mock.calls[0][0] as string;
+    expect(url).toContain("pluginpackages?");
+    expect(url).toContain("uniquename");
+  });
+
+  it("escapes a single quote in the unique name (OData injection guard)", async () => {
+    fetchMock.mockResolvedValue(okJson({ value: [] }));
+    const { context } = fakeDataverseContext();
+    await getDataversePluginPackageId(context, "o'brien");
+    const url = fetchMock.mock.calls[0][0] as string;
+    expect(url).toContain("o''brien"); // the single quote is doubled (OData escaping)
+  });
+
+  it("returns undefined on an empty result or a non-OK response", async () => {
+    const { context } = fakeDataverseContext();
+    fetchMock.mockResolvedValue(okJson({ value: [] }));
+    expect(await getDataversePluginPackageId(context, META.uniqueName)).toBeUndefined();
+    fetchMock.mockResolvedValue(httpError(404, "Not Found"));
+    expect(await getDataversePluginPackageId(context, META.uniqueName)).toBeUndefined();
+  });
+});
+
+describe("upsertDataversePluginPackage", () => {
+  it("CREATES when the package doesn't exist, reading the new id from the OData-EntityId header", async () => {
+    fetchMock.mockResolvedValueOnce(okJson({ value: [] })); // lookup: none
+    fetchMock.mockResolvedValueOnce(createdViaHeader("pkg-new")); // POST create
+    const { context } = fakeDataverseContext();
+    const result = await upsertDataversePluginPackage(context, META, "/tmp/pkg.nupkg");
+    expect(result).toEqual({ pluginPackageId: "pkg-new", created: true, updated: false });
+    expect(fetchMock.mock.calls[1][1]).toMatchObject({ method: "POST" });
+  });
+
+  it("UPDATES (PATCH) when the package already exists", async () => {
+    fetchMock.mockResolvedValueOnce(okJson({ value: [{ pluginpackageid: "pkg-existing" }] })); // lookup: found
+    fetchMock.mockResolvedValueOnce({ ok: true, status: 204, statusText: "No Content", json: async () => ({}), text: async () => "" }); // PATCH
+    const { context } = fakeDataverseContext();
+    const result = await upsertDataversePluginPackage(context, META, "/tmp/pkg.nupkg");
+    expect(result).toEqual({ pluginPackageId: "pkg-existing", created: false, updated: true });
+    const patch = fetchMock.mock.calls[1];
+    expect(patch[0]).toContain("pluginpackages(pkg-existing)");
+    expect(patch[1]).toMatchObject({ method: "PATCH" });
+  });
+});
+
+describe("waitForDataversePluginAssemblyFromPackage", () => {
+  it("returns the assembly id once it appears, filtered by package + name", async () => {
+    fetchMock.mockResolvedValue(okJson({ value: [{ pluginassemblyid: "asm-1", name: "Contoso.Plugins" }] }));
+    const { context } = fakeDataverseContext();
+    const id = await waitForDataversePluginAssemblyFromPackage(context, "pkg-1", "Contoso.Plugins");
+    expect(id).toBe("asm-1");
+    const url = fetchMock.mock.calls[0][0] as string;
+    expect(url).toContain("_packageid_value eq pkg-1");
+  });
+
+  it("returns undefined when the assembly never appears within the window", async () => {
+    fetchMock.mockResolvedValue(okJson({ value: [] }));
+    const { context } = fakeDataverseContext();
+    // maxWait 0 + pollInterval 0 → one poll, empty, then the window is exhausted.
+    expect(await waitForDataversePluginAssemblyFromPackage(context, "pkg-1", "Contoso.Plugins", 0, 0)).toBeUndefined();
+  });
+
+  it("returns undefined on a non-OK response", async () => {
+    fetchMock.mockResolvedValue(httpError(500, "Server Error"));
+    const { context } = fakeDataverseContext();
+    expect(await waitForDataversePluginAssemblyFromPackage(context, "pkg-1", "Contoso.Plugins")).toBeUndefined();
+  });
+});


### PR DESCRIPTION
Part of #143 (Move 2 — mock the Dataverse Web API). Test-only, no shipped-code change.

## What

`getDataversePluginPackage.ts` and `getDataversePluginAssembly.ts` — the plugin-deploy handlers (create/update a `pluginpackage`; create/update a classic `pluginassembly`) — were untested. Added two spec files (16 tests) driving them against the existing `vi.mock("node-fetch")` seam (`test/dataverseTestUtils.ts`), no live org.

## What it guards

- **Upsert branching** — lookup-then-create vs lookup-then-PATCH, for both packages and assemblies.
- **`OData-EntityId` header id-parse** — create returns `204 No Content`, so the new id is read from the header, not a JSON body (a real quirk that had no coverage).
- **OData escaping** — a single quote in a unique name is doubled (`o''brien`).
- **Strong-name guidance** — an unsigned (`--skip-signing`) assembly hits `0x8004416c`; the handler logs actionable guidance and returns undefined/false.
- **Package→assembly poll** — `waitForDataversePluginAssemblyFromPackage` returns the id once it materialises, filtered by package + name, and gives up cleanly when the window expires.

## Verification

- Lint clean, `tsc` compile-tests clean.
- Unit tests **774 → 790**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)