### PR TITLE
0.14.47 (pre-release) — #143 Move 2: cover webhook + solution-component Dataverse paths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to the "dataverse-powertools" extension will be documented in this file.
 
+## 0.14.47 (pre-release)
+
+- **Tests (#143 Move 2) — webhook + solution-component Dataverse paths now covered.** Added `serviceEndpoints.spec.ts` (9 tests — the #145 webhook `serviceendpoint` + its `sdkmessageprocessingstep`: create-vs-update upsert, and the message-not-found / filter-not-found short-circuits) and `addDataverseSolutionComponent.spec.ts` (6 tests — `AddSolutionComponent`, including the **"already in this solution" idempotency** branch where a non-OK response is still success, and the resolve-type-by-object-id composition). Both drive the mocked `node-fetch` seam, no live org. Unit tests 790 → 805, no shipped-code change.
+
 ## 0.14.46 (pre-release)
 
 - **Tests (#143 Move 2) — the plugin-deploy Dataverse path now has unit coverage.** The `pluginpackage` and classic `pluginassembly` create/update handlers (`getDataversePluginPackage.ts`, `getDataversePluginAssembly.ts`) were untested. Added `getDataversePluginPackage.spec.ts` and `getDataversePluginAssembly.spec.ts` (16 tests) driving them against the mocked `node-fetch` seam (no live org): the **create-vs-update upsert branching**, the create-returns-204 **`OData-EntityId` header id-parse**, OData single-quote escaping, the **strong-name (`0x8004416c`) guidance** an unsigned `--skip-signing` assembly triggers, and the package→assembly materialisation poll. No shipped-code change. Unit tests 774 → 790.

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "type": "git",
     "url": "https://github.com/pete-mc/dataverse-powertools"
   },
-  "version": "0.14.46",
+  "version": "0.14.47",
   "engines": {
     "vscode": "^1.95.0"
   },

--- a/src/general/dataverse/addDataverseSolutionComponent.spec.ts
+++ b/src/general/dataverse/addDataverseSolutionComponent.spec.ts
@@ -1,0 +1,63 @@
+/* eslint-disable @typescript-eslint/naming-convention -- AddSolutionComponent action params are PascalCase */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+vi.mock("node-fetch", () => ({ default: vi.fn() }));
+import fetch from "node-fetch";
+import { addDataverseSolutionComponent, addDataverseSolutionComponentByObjectId } from "./addDataverseSolutionComponent";
+import { fakeDataverseContext, okJson, httpError } from "../../../test/dataverseTestUtils";
+
+// #143 Move 2 — AddSolutionComponent path against a mocked node-fetch, no live org. Guards the
+// success + the "already in this solution" idempotency branch (a non-OK response that must still
+// be treated as success), and the resolve-type-then-add composition.
+
+const fetchMock = fetch as unknown as ReturnType<typeof vi.fn>;
+beforeEach(() => fetchMock.mockReset());
+
+describe("addDataverseSolutionComponent", () => {
+  it("POSTs AddSolutionComponent and returns true on success", async () => {
+    fetchMock.mockResolvedValue(okJson({}));
+    const { context } = fakeDataverseContext();
+    expect(await addDataverseSolutionComponent(context, "mysolution", 61, "comp-1")).toBe(true);
+    const [url, options] = fetchMock.mock.calls[0];
+    expect(url).toContain("AddSolutionComponent");
+    expect(JSON.parse((options as any).body)).toMatchObject({ ComponentId: "comp-1", ComponentType: 61, SolutionUniqueName: "mysolution" });
+  });
+
+  it("treats an 'already in this solution' error as success (idempotent re-run)", async () => {
+    fetchMock.mockResolvedValue(httpError(400, "Bad Request", "Component is already in this solution."));
+    const { context } = fakeDataverseContext();
+    expect(await addDataverseSolutionComponent(context, "mysolution", 61, "comp-1")).toBe(true);
+  });
+
+  it("returns false and logs on a genuine failure", async () => {
+    fetchMock.mockResolvedValue(httpError(403, "Forbidden", "privilege missing"));
+    const { context, lines } = fakeDataverseContext();
+    expect(await addDataverseSolutionComponent(context, "mysolution", 61, "comp-1")).toBe(false);
+    expect(lines.join("\n")).toContain("Failed to add component to solution 'mysolution'");
+  });
+
+  it("returns false without a network call when the solution name is empty", async () => {
+    const { context } = fakeDataverseContext();
+    expect(await addDataverseSolutionComponent(context, "", 61, "comp-1")).toBe(false);
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+});
+
+describe("addDataverseSolutionComponentByObjectId", () => {
+  it("resolves the component type by object id, then adds it", async () => {
+    fetchMock.mockResolvedValueOnce(okJson({ value: [{ componenttype: 80, objectid: "obj-1" }] })); // resolve type
+    fetchMock.mockResolvedValueOnce(okJson({})); // AddSolutionComponent
+    const { context } = fakeDataverseContext();
+    expect(await addDataverseSolutionComponentByObjectId(context, "mysolution", "obj-1")).toBe(true);
+    expect(fetchMock.mock.calls[0][0]).toContain("solutioncomponents?");
+    expect(JSON.parse((fetchMock.mock.calls[1][1] as any).body)).toMatchObject({ ComponentType: 80, ComponentId: "obj-1" });
+  });
+
+  it("returns false (no add) when the component type can't be resolved", async () => {
+    fetchMock.mockResolvedValueOnce(okJson({ value: [] })); // resolve type → none
+    const { context, lines } = fakeDataverseContext();
+    expect(await addDataverseSolutionComponentByObjectId(context, "mysolution", "obj-1")).toBe(false);
+    expect(lines.join("\n")).toContain("Could not resolve solution component type");
+    expect(fetchMock).toHaveBeenCalledOnce(); // only the resolve, no add
+  });
+});

--- a/src/general/dataverse/serviceEndpoints.spec.ts
+++ b/src/general/dataverse/serviceEndpoints.spec.ts
@@ -1,0 +1,114 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+vi.mock("node-fetch", () => ({ default: vi.fn() }));
+import fetch from "node-fetch";
+import { findWebhookServiceEndpointId, upsertWebhookServiceEndpoint, registerWebhookStep } from "./serviceEndpoints";
+import { WebhookAuthType, StepStage, StepMode, WebhookEndpointDefinition, WebhookStepDefinition } from "../../azurefunction/webhookPayloads";
+import { fakeDataverseContext, okJson } from "../../../test/dataverseTestUtils";
+
+// #143 Move 2 — the WEBHOOK registration path (#145: serviceendpoint + its sdkmessageprocessingstep)
+// against a mocked node-fetch, no live org. Guards the create-vs-update upsert branching and the
+// message/filter resolution short-circuits. Auth gates on the live connection (canCallDataverseApi),
+// never tenantId — so this works under interactive (OAuth) auth too (#90/#91).
+
+const fetchMock = fetch as unknown as ReturnType<typeof vi.fn>;
+beforeEach(() => fetchMock.mockReset());
+
+const ENDPOINT: WebhookEndpointDefinition = {
+  name: "MyFunctionHook",
+  url: "https://fn.azurewebsites.net/api/hook",
+  authType: WebhookAuthType.httpHeader,
+  authValue: "x-functions-key=secret",
+};
+
+const STEP: WebhookStepDefinition = {
+  stepName: "MyFunctionHook: Create of account",
+  messageName: "Create",
+  entityLogicalName: "account",
+  stage: StepStage.postOperation,
+  mode: StepMode.asynchronous,
+};
+
+describe("findWebhookServiceEndpointId", () => {
+  it("returns the id of an existing endpoint by name (OData-escaped)", async () => {
+    fetchMock.mockResolvedValue(okJson({ value: [{ serviceendpointid: "sep-1", name: ENDPOINT.name }] }));
+    const { context } = fakeDataverseContext();
+    expect(await findWebhookServiceEndpointId(context, "O'Hook")).toBe("sep-1");
+    const url = fetchMock.mock.calls[0][0] as string;
+    expect(url).toContain("serviceendpoints?");
+    expect(url).toContain("O''Hook"); // single quote doubled
+  });
+
+  it("returns undefined when none exists", async () => {
+    fetchMock.mockResolvedValue(okJson({ value: [] }));
+    const { context } = fakeDataverseContext();
+    expect(await findWebhookServiceEndpointId(context, ENDPOINT.name)).toBeUndefined();
+  });
+});
+
+describe("upsertWebhookServiceEndpoint", () => {
+  it("CREATES the endpoint when none exists (lookup empty → POST)", async () => {
+    fetchMock.mockResolvedValueOnce(okJson({ value: [] })); // lookup
+    fetchMock.mockResolvedValueOnce(okJson({ serviceendpointid: "sep-new" })); // POST create
+    const { context } = fakeDataverseContext();
+    expect(await upsertWebhookServiceEndpoint(context, ENDPOINT)).toEqual({ serviceEndpointId: "sep-new", created: true, updated: false });
+    expect(fetchMock.mock.calls[1][1]).toMatchObject({ method: "POST" });
+  });
+
+  it("UPDATES the existing endpoint (lookup hit → PATCH)", async () => {
+    fetchMock.mockResolvedValueOnce(okJson({ value: [{ serviceendpointid: "sep-existing" }] })); // lookup
+    fetchMock.mockResolvedValueOnce({ ok: true, status: 204, statusText: "No Content", json: async () => ({}), text: async () => "" }); // PATCH (204)
+    const { context } = fakeDataverseContext();
+    expect(await upsertWebhookServiceEndpoint(context, ENDPOINT)).toEqual({ serviceEndpointId: "sep-existing", created: false, updated: true });
+    const patch = fetchMock.mock.calls[1];
+    expect(patch[0]).toContain("serviceendpoints(sep-existing)");
+    expect(patch[1]).toMatchObject({ method: "PATCH" });
+  });
+});
+
+describe("registerWebhookStep", () => {
+  it("errors when the SDK message isn't found (no write attempted)", async () => {
+    fetchMock.mockResolvedValueOnce(okJson({ value: [] })); // resolveSdkMessageId → none
+    const { context } = fakeDataverseContext();
+    const result = await registerWebhookStep(context, "sep-1", STEP);
+    expect(result.created).toBe(false);
+    expect(result.error).toContain("was not found");
+  });
+
+  it("errors when the message isn't available for the table (filter not found)", async () => {
+    fetchMock.mockResolvedValueOnce(okJson({ value: [{ sdkmessageid: "msg-1" }] })); // message resolved
+    fetchMock.mockResolvedValueOnce(okJson({ value: [] })); // filter → none
+    const { context } = fakeDataverseContext();
+    const result = await registerWebhookStep(context, "sep-1", STEP);
+    expect(result.error).toContain("not available for table 'account'");
+  });
+
+  it("CREATES the step when message + filter resolve and none exists", async () => {
+    fetchMock.mockResolvedValueOnce(okJson({ value: [{ sdkmessageid: "msg-1" }] })); // message
+    fetchMock.mockResolvedValueOnce(okJson({ value: [{ sdkmessagefilterid: "flt-1" }] })); // filter
+    fetchMock.mockResolvedValueOnce(okJson({ value: [] })); // existing step → none
+    fetchMock.mockResolvedValueOnce(okJson({ sdkmessageprocessingstepid: "step-new" })); // POST
+    const { context } = fakeDataverseContext();
+    expect(await registerWebhookStep(context, "sep-1", STEP)).toEqual({ stepId: "step-new", created: true, updated: false });
+    expect(fetchMock.mock.calls[3][1]).toMatchObject({ method: "POST" });
+  });
+
+  it("UPDATES the step when one already exists for this endpoint", async () => {
+    fetchMock.mockResolvedValueOnce(okJson({ value: [{ sdkmessageid: "msg-1" }] })); // message
+    fetchMock.mockResolvedValueOnce(okJson({ value: [{ sdkmessagefilterid: "flt-1" }] })); // filter
+    fetchMock.mockResolvedValueOnce(okJson({ value: [{ sdkmessageprocessingstepid: "step-existing" }] })); // existing step
+    fetchMock.mockResolvedValueOnce({ ok: true, status: 204, statusText: "No Content", json: async () => ({}), text: async () => "" }); // PATCH
+    const { context } = fakeDataverseContext();
+    expect(await registerWebhookStep(context, "sep-1", STEP)).toEqual({ stepId: "step-existing", created: false, updated: true });
+  });
+});
+
+describe("auth gating (the #90/#91 OAuth guard)", () => {
+  it("does not touch the network when the connection can't call the API", async () => {
+    // isValid:false with no organizationUrl override still initialises; force an unusable connection.
+    const { context } = fakeDataverseContext({ isValid: false, organizationUrl: "" });
+    // initialize() is a no-op stub that leaves isValid falsey → canCallDataverseApi is false.
+    expect(await findWebhookServiceEndpointId(context, ENDPOINT.name)).toBeUndefined();
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
Part of #143 (Move 2 — mock the Dataverse Web API). Test-only, no shipped-code change.

## What

Two more untested `node-fetch` Dataverse handlers now covered against the `vi.mock("node-fetch")` seam (`test/dataverseTestUtils.ts`), no live org:

- **`serviceEndpoints.spec.ts`** (9 tests) — the #145 **webhook** path: `findWebhookServiceEndpointId`, `upsertWebhookServiceEndpoint` (create-vs-update), and `registerWebhookStep` (create-vs-update plus the **message-not-found** and **filter-not-available-for-table** short-circuits). Auth gates on the live connection, never `tenantId` (the #90/#91 OAuth guard).
- **`addDataverseSolutionComponent.spec.ts`** (6 tests) — `AddSolutionComponent`: success, the **"already in this solution" idempotency** branch (a non-OK response that must still count as success on a re-run), a genuine failure, the empty-name no-network guard, and `addDataverseSolutionComponentByObjectId` (resolve component type by object id, then add).

## Verification

- Lint clean, `tsc` compile-tests clean.
- Unit tests **790 → 805**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)