### PR TITLE
0.14.48 (pre-release) — #143 Move 2: cover webresource + form deploy paths (completes handler coverage)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to the "dataverse-powertools" extension will be documented in this file.
 
+## 0.14.48 (pre-release)
+
+- **Tests (#143 Move 2) — the webresource + form deploy paths now have unit coverage, completing handler coverage of the Dataverse layer.** These two flows are proven ~6× in the slow e2e tier but had **zero** unit coverage. Added `DataverseWebresource.spec.ts` (11 tests — `mapWebresourceType`, `load` (id lookup + OData escaping + throw-on-error + connection gate), the id-driven **create-vs-update** upsert, and `addToSolution` including the **"already in solution" idempotency** + the id-unresolved skip) and `DataverseForm.spec.ts` (5 tests — `getFormData`/`saveForm` round-trip through the formxml parse/build, the #90 "a failed load/save must surface, not look like success" returns, and the OAuth connection gate). Both drive the mocked `node-fetch` seam, no live org. Unit tests 805 → 821, no shipped-code change. Every HTTP-calling module in `src/general/dataverse/` now has a spec.
+
 ## 0.14.47 (pre-release)
 
 - **Tests (#143 Move 2) — webhook + solution-component Dataverse paths now covered.** Added `serviceEndpoints.spec.ts` (9 tests — the #145 webhook `serviceendpoint` + its `sdkmessageprocessingstep`: create-vs-update upsert, and the message-not-found / filter-not-found short-circuits) and `addDataverseSolutionComponent.spec.ts` (6 tests — `AddSolutionComponent`, including the **"already in this solution" idempotency** branch where a non-OK response is still success, and the resolve-type-by-object-id composition). Both drive the mocked `node-fetch` seam, no live org. Unit tests 790 → 805, no shipped-code change.

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "type": "git",
     "url": "https://github.com/pete-mc/dataverse-powertools"
   },
-  "version": "0.14.47",
+  "version": "0.14.48",
   "engines": {
     "vscode": "^1.95.0"
   },

--- a/src/general/dataverse/DataverseForm.spec.ts
+++ b/src/general/dataverse/DataverseForm.spec.ts
@@ -1,0 +1,71 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+vi.mock("node-fetch", () => ({ default: vi.fn() }));
+import fetch from "node-fetch";
+import { DataverseForm } from "./DataverseForm";
+import { fakeDataverseContext, okJson, httpError } from "../../../test/dataverseTestUtils";
+
+// #143 Move 2 — the form-registration path (load formxml → edit → save) against a mocked node-fetch,
+// no live org. Guards the load/save success + failure returns (#90: a failed save must surface, not
+// look like success) and the connection gate (canCallDataverseApi, never tenantId — the OAuth guard).
+
+const fetchMock = fetch as unknown as ReturnType<typeof vi.fn>;
+beforeEach(() => fetchMock.mockReset());
+
+const FORM_XML = `<form><events><event name="onload"><Handlers><Handler functionName="onLoad" libraryName="new_lib.js" /></Handlers></event></events></form>`;
+
+describe("DataverseForm.getFormData", () => {
+  it("loads and parses the form xml (returns true)", async () => {
+    fetchMock.mockResolvedValue(okJson({ formxml: FORM_XML }));
+    const { context } = fakeDataverseContext();
+    const form = new DataverseForm("form-1", context);
+    expect(await form.getFormData()).toBe(true);
+    expect(form.form).toBeDefined();
+    expect(form.form.form).toBeDefined();
+    expect(fetchMock.mock.calls[0][0]).toContain("systemforms(form-1)?$select=formxml");
+  });
+
+  it("returns false on a non-OK response (the caller must not proceed — #90)", async () => {
+    fetchMock.mockResolvedValue(httpError(404, "Not Found"));
+    const { context } = fakeDataverseContext();
+    expect(await new DataverseForm("form-1", context).getFormData()).toBe(false);
+  });
+
+  it("returns false without a network call when the connection can't reach Dataverse", async () => {
+    const { context, lines } = fakeDataverseContext({ isValid: false });
+    expect(await new DataverseForm("form-1", context).getFormData()).toBe(false);
+    expect(fetchMock).not.toHaveBeenCalled();
+    expect(lines.join("\n")).toContain("Could not connect to dataverse");
+  });
+});
+
+describe("DataverseForm.saveForm", () => {
+  it("PATCHes the rebuilt formxml back to the form (returns true)", async () => {
+    fetchMock.mockResolvedValueOnce(okJson({ formxml: FORM_XML })); // getFormData
+    fetchMock.mockResolvedValueOnce(okJson({})); // saveForm PATCH
+    const { context } = fakeDataverseContext();
+    const form = new DataverseForm("form-1", context);
+    await form.getFormData();
+    expect(await form.saveForm()).toBe(true);
+    const [url, options] = fetchMock.mock.calls[1];
+    expect(url).toContain("systemforms(form-1)");
+    expect(options).toMatchObject({ method: "PATCH" });
+    const body = JSON.parse((options as any).body);
+    expect(body.formxml).toContain("<events>");
+  });
+
+  it("returns false on a non-OK save (a 400 for an undeployed web resource must surface — #90)", async () => {
+    fetchMock.mockResolvedValueOnce(okJson({ formxml: FORM_XML })); // getFormData
+    fetchMock.mockResolvedValueOnce(httpError(400, "Bad Request", "web resource not found")); // save
+    const { context } = fakeDataverseContext();
+    const form = new DataverseForm("form-1", context);
+    await form.getFormData();
+    expect(await form.saveForm()).toBe(false);
+  });
+
+  it("returns false without a network call when the connection is invalid", async () => {
+    const { context } = fakeDataverseContext({ isValid: false });
+    expect(await new DataverseForm("form-1", context).saveForm()).toBe(false);
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+});

--- a/src/general/dataverse/DataverseWebresource.spec.ts
+++ b/src/general/dataverse/DataverseWebresource.spec.ts
@@ -1,0 +1,104 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+vi.mock("node-fetch", () => ({ default: vi.fn() }));
+import fetch from "node-fetch";
+import { DataverseWebresource } from "./DataverseWebresource";
+import { fakeDataverseContext, okJson, httpError } from "../../../test/dataverseTestUtils";
+
+// #143 Move 2 — the WEBRESOURCE deploy path (lookup → create/update → add-to-solution) against a
+// mocked node-fetch, no live org. This flow is proven ~6× in the e2e tier but had zero unit coverage;
+// this guards the id-driven create-vs-update branch and the "already in solution" idempotency.
+
+const fetchMock = fetch as unknown as ReturnType<typeof vi.fn>;
+beforeEach(() => fetchMock.mockReset());
+
+describe("DataverseWebresource.mapWebresourceType", () => {
+  it("maps common extensions and returns undefined for unknown ones", () => {
+    expect(DataverseWebresource.mapWebresourceType(".js")).toBe(3);
+    expect(DataverseWebresource.mapWebresourceType(".css")).toBe(2);
+    expect(DataverseWebresource.mapWebresourceType(".html")).toBe(1);
+    expect(DataverseWebresource.mapWebresourceType(".png")).toBe(5);
+    expect(DataverseWebresource.mapWebresourceType(".svg")).toBe(11);
+    expect(DataverseWebresource.mapWebresourceType(".exe")).toBeUndefined();
+  });
+});
+
+describe("DataverseWebresource.load", () => {
+  it("resolves the webresource id by name (OData-escaped)", async () => {
+    fetchMock.mockResolvedValue(okJson({ value: [{ webresourceid: "wr-1", name: "new_script.js" }] }));
+    const { context } = fakeDataverseContext();
+    const wr = new DataverseWebresource("o'reilly.js", context);
+    await wr.load();
+    expect(wr.id).toBe("wr-1");
+    expect(fetchMock.mock.calls[0][0]).toContain("o''reilly.js"); // single quote doubled
+  });
+
+  it("leaves id undefined (no throw) when there's no match", async () => {
+    fetchMock.mockResolvedValue(okJson({ value: [] }));
+    const { context } = fakeDataverseContext();
+    const wr = new DataverseWebresource("new_script.js", context);
+    await wr.load();
+    expect(wr.id).toBeUndefined();
+  });
+
+  it("throws on a non-OK lookup", async () => {
+    fetchMock.mockResolvedValue(httpError(500, "Server Error", "boom"));
+    const { context } = fakeDataverseContext();
+    await expect(new DataverseWebresource("new_script.js", context).load()).rejects.toThrow(/Failed to lookup webresource/);
+  });
+
+  it("does not call the network when the connection is invalid", async () => {
+    const { context } = fakeDataverseContext({ isValid: false });
+    await new DataverseWebresource("new_script.js", context).load();
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+});
+
+describe("DataverseWebresource.upsert", () => {
+  it("CREATES (POST webresourceset) when the resource doesn't exist", async () => {
+    fetchMock.mockResolvedValueOnce(okJson({ value: [] })); // internal load: none
+    fetchMock.mockResolvedValueOnce(okJson({})); // POST create
+    const { context } = fakeDataverseContext();
+    await new DataverseWebresource("new_script.js", context).upsert("QkFTRTY0", 3);
+    const [url, options] = fetchMock.mock.calls[1];
+    expect(url).toMatch(/webresourceset$/);
+    expect(options).toMatchObject({ method: "POST" });
+    expect(JSON.parse((options as any).body)).toMatchObject({ name: "new_script.js", webresourcetype: 3, content: "QkFTRTY0" });
+  });
+
+  it("UPDATES (PATCH webresourceset(id)) when the resource exists", async () => {
+    fetchMock.mockResolvedValueOnce(okJson({ value: [{ webresourceid: "wr-1" }] })); // internal load: found
+    fetchMock.mockResolvedValueOnce(okJson({})); // PATCH update
+    const { context } = fakeDataverseContext();
+    await new DataverseWebresource("new_script.js", context).upsert("QkFTRTY0", 3);
+    const [url, options] = fetchMock.mock.calls[1];
+    expect(url).toContain("webresourceset(wr-1)");
+    expect(options).toMatchObject({ method: "PATCH" });
+  });
+});
+
+describe("DataverseWebresource.addToSolution", () => {
+  it("adds the resource to the solution once its id resolves", async () => {
+    fetchMock.mockResolvedValueOnce(okJson({ value: [{ webresourceid: "wr-1" }] })); // load
+    fetchMock.mockResolvedValueOnce(okJson({})); // AddSolutionComponent
+    const { context, lines } = fakeDataverseContext();
+    await new DataverseWebresource("new_script.js", context).addToSolution("mysolution");
+    expect(fetchMock.mock.calls[1][0]).toContain("AddSolutionComponent");
+    expect(lines.join("\n")).toContain("Added webresource 'new_script.js' to solution 'mysolution'");
+  });
+
+  it("treats 'already in this solution' as success (no throw)", async () => {
+    fetchMock.mockResolvedValueOnce(okJson({ value: [{ webresourceid: "wr-1" }] })); // load
+    fetchMock.mockResolvedValueOnce(httpError(400, "Bad Request", "already a member of this solution")); // add
+    const { context } = fakeDataverseContext();
+    await expect(new DataverseWebresource("new_script.js", context).addToSolution("mysolution")).resolves.toBeUndefined();
+  });
+
+  it("skips (logs) when the webresource id can't be resolved", async () => {
+    fetchMock.mockResolvedValueOnce(okJson({ value: [] })); // load: none
+    const { context, lines } = fakeDataverseContext();
+    await new DataverseWebresource("new_script.js", context).addToSolution("mysolution");
+    expect(fetchMock).toHaveBeenCalledOnce(); // only the load, no AddSolutionComponent
+    expect(lines.join("\n")).toContain("Unable to resolve webresource id");
+  });
+});


### PR DESCRIPTION
Part of #143 (Move 2 — mock the Dataverse Web API). Test-only, no shipped-code change.

## What

The two remaining untested `node-fetch` Dataverse handlers — the **webresource** and **form** deploy classes — now covered against the `vi.mock("node-fetch")` seam, no live org. These flows are proven ~6× in the slow e2e tier but had **zero** unit coverage.

- **`DataverseWebresource.spec.ts`** (11 tests) — `mapWebresourceType`; `load` (id lookup, OData escaping, throw-on-error, invalid-connection gate); the id-driven **create (POST) vs update (PATCH)** upsert; and `addToSolution` including the **"already in this solution" idempotency** branch and the id-unresolved skip.
- **`DataverseForm.spec.ts`** (5 tests) — `getFormData` / `saveForm` round-trip through the formxml parse/build; the **#90** returns (a failed load/save must surface as `false`, not look like success); and the `canCallDataverseApi` connection gate (never `tenantId` — the OAuth guard).

With this, **every HTTP-calling module in `src/general/dataverse/` has a spec.**

## Verification

- Lint clean, `tsc` compile-tests clean.
- Unit tests **805 → 821**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)