### PR TITLE
1.0.1 — FetchXML Generator (preview): detect FetchXML in code, edit it, run it (#238)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -103,6 +103,27 @@ Key behavior:
 
 Guideline: keep raw Dataverse HTTP calls in `src/general/dataverse/` helper classes instead of feature command files.
 
+## FetchXML query tools (`src/query`, #238)
+
+Finds FetchXML **inside the user's own C#/TypeScript string literals** — there is no query file
+type — then offers a CodeLens (Run / Edit in generator / issues), diagnostics with quick fixes, a
+generator webview, and a results grid.
+
+- Almost all of it is **pure and unit-tested**: `fetchXml.ts` (parse ⇄ serialize, faithful enough
+  to write back into source), `literals/` (per-language string + `+`-chain tokenizers), `holes.ts`
+  (interpolation ⇄ `@token` mapping), `consumers.ts`, `diagnostics.ts`, `parameters.ts`,
+  `edits.ts`, `generatorState.ts`, `results.ts`, `metadata/cache.ts`.
+- The model is **uniform** (`{ tag, attrs, children }`, nothing hoisted into typed fields) so an
+  attribute the generator doesn't know about still round-trips instead of vanishing from the user's file.
+- The generator webview is a **renderer only**: it posts edit INTENTS, the host applies them with
+  `edits.ts` and posts fresh state back, so generator behaviour is testable without a browser.
+- Write-back (`writeBack.ts`) re-reads the literal it is about to emit and **refuses** the write
+  unless it decodes back identically; a no-op save never touches the file.
+- Metadata is lazy and **session-scoped only** (`metadataService.ts`, keyed by organization URL) —
+  deliberately not persisted, because users change metadata while using this.
+- Commands + providers register ONCE in `extension.ts` (`registerQueryCommands`), never per
+  component. Gated by the `fetchXmlQueries` preview feature.
+
 ## Webresources flow (current)
 
 Main command path:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,57 @@ All notable changes to the "dataverse-powertools" extension will be documented i
 Pre-release builds get a per-version entry in [CHANGELOG-prerelease.md](CHANGELOG-prerelease.md);
 those entries are rolled up into one section here when a full release ships.
 
+## 1.0.1
+
+FetchXML query tools (preview): find the FetchXML in your code, edit it in a generator, run it against the environment.
+
+**FetchXML query tools ([#238](https://github.com/pete-mc/dataverse-powertools/issues/238)) —
+behind the `previewFeatures` flag, sign-off in [#239](https://github.com/pete-mc/dataverse-powertools/issues/239).**
+
+Find the FetchXML you already have in your code, edit it in a generator, and run it against the
+connected environment — without leaving VS Code and without a new file type to adopt.
+
+- **Detection in C# and TypeScript.** A CodeLens — **▶ Run · ✎ Edit in generator · ⚠ N issues** —
+  appears above FetchXML in your own source. All three shapes people actually write are
+  understood: a plain or verbatim string, an interpolated string / template literal, and a `+`
+  concatenation chain with variables in it. Bare `<filter>` fragments (a lookup's
+  `addCustomFilter`) are detected too. A query assembled with a `StringBuilder` is deliberately
+  not offered rather than half-parsed.
+- **Parameters, inferred.** Each interpolation becomes an `@name` parameter; its type comes from
+  the column the condition compares against, so a test run prompts and validates properly. A
+  GUID is checked, a date is normalised to UTC, and an `-x-days` operator is correctly treated as
+  a count rather than a date. Prompted values are remembered per workspace, never written to the file.
+- **Generator.** Tree of the query, per-element properties with table and column pickers from live
+  metadata, grouped operator picker, an editable XML pane, and the issues list. Attributes the
+  generator has no field for are preserved and shown, so an exotic query is never silently simplified.
+- **Run and results.** Rows in a grid with **formatted values**, so option sets and lookups read
+  as labels rather than ints and GUIDs; link-entity aliases and aggregate aliases get their own
+  columns. The header states which environment and identity the query ran as — that identity is
+  not who will run your plugin — and rows are capped for a test run. Copy as CSV/JSON.
+- **Diagnostics worth having even if you never open the generator.** An unescaped value interpolated
+  into an XML attribute (with a quick fix that wraps it in `SecurityElement.Escape` / `escapeXml`);
+  a local-time date compared against a UTC column; unknown table or column names; a query too long
+  for the `?fetchXml=` URL; `top` combined with paging; an aggregate attribute missing its alias;
+  and an aggregate query handed to a consumer that rejects one.
+- **Writing an edit back is guarded.** The edited literal is re-read with the same tokenizer that
+  parsed it and the write is REFUSED unless it decodes back identically; a no-op save never touches
+  the file; the change lands as a single undo step, preserving the literal's original form. **Save to
+  code** also saves the file, so the query that compiles and deploys is the one you just edited.
+- Snippets: `dvpt-fetch`, `dvpt-fetch-param`, `dvpt-fetch-filter`, `dvpt-escape-xml`.
+- Metadata is lazy and **session-scoped** with a **Clear Dataverse Metadata Cache** command — a
+  column you add in the maker portal shows up without reloading the window.
+
+**Also**
+
+- The unit-coverage floor is ratcheted up (statements 10 → 30, branches 11 → 34, functions
+  15 → 37, lines 10 → 30): `src/query` is almost entirely pure modules, and the floor should
+  follow.
+- Fixed a stale assertion in the live plugin-profiler suite, which still expected the pre-0.14.44
+  `ProfilerExecutionUtility.Replay(...)` generation instead of the in-process shape
+  ([#210](https://github.com/pete-mc/dataverse-powertools/issues/210)); `npm run test:live` is green again.
+- The FetchXML CodeLens and quick fixes also work in untitled buffers, so a query can be pasted
+  into a scratch file and run.
+
 ## 1.0.0
 
 The 1.0.0 GA — the first stable release since 0.7.0, folding in 68 pre-release builds (0.7.1 → 0.14.50).
@@ -75,7 +126,7 @@ Every pre-release entry is kept below.
 
 ### 0.14.40 (pre-release)
 
-- **Fix: the plug-in profiler couldn't find your step in a busy org.** "Profile next run" / capture lists profilable steps via `sdkmessageprocessingsteps`, but the query fetched the first **200** active steps and filtered client-side. An org with 200+ system (`Microsoft.*`) steps filled that whole page, so a freshly-registered *user* step never appeared and capture dead-ended at "No registered plugin steps to profile." It now filters **server-side by plugin assembly** (`plugintypeid/pluginassemblyid/name eq …`) when the project's assembly is known, so your step is found regardless of how many system steps exist. Pure query builder (`buildProfilableStepsResource`) with unit tests; verified live against an org with 200+ active steps.
+- **Fix: the plug-in profiler couldn't find your step in a busy org.** "Profile next run" / capture lists profilable steps via `sdkmessageprocessingsteps`, but the query fetched the first **200** active steps and filtered client-side. An org with 200+ system (`Microsoft.*`) steps filled that whole page, so a freshly-registered *user* step never appeared and capture dead-ended at "No registered plugin steps to profile." It now filters **server-side by plugin assembly** (`plugintypeid/pluginassemblyid/name eq …`) when the project's assembly is known, so your step is found regardless of how many system steps exist. Pure query generator (`buildProfilableStepsResource`) with unit tests; verified live against an org with 200+ active steps.
 - **New: plug-in profiler capture → replay → execute e2e** (`src/ui-test/e2e/pluginProfilerReplay.e2e.ts`, Windows-only, live). Drives the panel's **Debugging** block end to end: scaffold a Plugins project + xUnit test project, write a plug-in registered on **Create of territory**, **Build & deploy** it, and assert the step is discoverable as **profilable** live (the fix above). The modal-driven tail (Profile next run → live Web-API trigger → **Continue** → download → **Replay & debug** → `dotnet test` the generated replay to green) is gated behind `DVPT_E2E_PROFILER_CAPTURE=1` — the reliable portion runs by default; the tail drives a VS Code modal that the shared 8GB e2e VM can't hold a Selenium session through. No change to the shipped extension beyond the profiler fix.
 
 ### 0.14.39 (pre-release)
@@ -125,7 +176,7 @@ Testing (#143 Move 2) — **mock the Dataverse Web API.** A reusable in-memory W
 
 ### 0.14.29 (pre-release)
 
-PCF (#141) — **choose the control template + framework when scaffolding.** Adding a PCF component previously always ran `pac pcf init --template field --framework none`. It now asks two quick-picks up front — **template** (Field vs Dataset) and **framework** (Standard vs React) — and scaffolds accordingly. Dismissing either pick falls back to the previous field/none default, so nothing breaks. The choice values come from fixed enums (no free-text reaches the command line). Pure choice lists + argv builder unit-tested. +4 tests (726).
+PCF (#141) — **choose the control template + framework when scaffolding.** Adding a PCF component previously always ran `pac pcf init --template field --framework none`. It now asks two quick-picks up front — **template** (Field vs Dataset) and **framework** (Standard vs React) — and scaffolds accordingly. Dismissing either pick falls back to the previous field/none default, so nothing breaks. The choice values come from fixed enums (no free-text reaches the command line). Pure choice lists + argv generator unit-tested. +4 tests (726).
 
 ### 0.14.28 (pre-release)
 
@@ -184,7 +235,7 @@ Power Pages / Portals (#150) — **typed portal Web API client** (issue #4, seco
 
 Azure Functions (#145) — **Send test context** (issue #7), the local inner loop for webhook functions.
 
-- **Send test RemoteExecutionContext to local function** builds a sample Dataverse webhook payload — a `RemoteExecutionContext` in the platform's **exact documented DataContractJson wire format** (typed `InputParameters["Target"]` entity with the `__type` discriminator, `/Date(ms)/` timestamps, all top-level fields) — and POSTs it to your locally-running function (`func start`), so you can exercise the typed handler without a live Dataverse trigger. Prompts for the function name, message, and primary entity. The payload builder is pure + unit-tested against the documented shape (5 tests), so `ReadRemoteExecutionContextAsync` deserializes it correctly.
+- **Send test RemoteExecutionContext to local function** builds a sample Dataverse webhook payload — a `RemoteExecutionContext` in the platform's **exact documented DataContractJson wire format** (typed `InputParameters["Target"]` entity with the `__type` discriminator, `/Date(ms)/` timestamps, all top-level fields) — and POSTs it to your locally-running function (`func start`), so you can exercise the typed handler without a live Dataverse trigger. Prompts for the function name, message, and primary entity. The payload generator is pure + unit-tested against the documented shape (5 tests), so `ReadRemoteExecutionContextAsync` deserializes it correctly.
 
 > This closes the last v1-core-adjacent gap in #145 — earlier deferred because I wouldn't hand-generate the payload blind; the shape is now taken verbatim from the [official webhook docs](https://learn.microsoft.com/power-apps/developer/data-platform/use-webhooks). Requires the local host running (`Run locally (func start)`).
 
@@ -314,7 +365,7 @@ PCF (#141) — ship the service-layer pattern as **VS Code snippets** (the 80/20
 
 Testing epic (#143), Move 3 — extract trapped pure logic into `vscode`-free modules and unit-test it, so the network/registration payload shapes and the panel/test-scaffold logic are guarded in CI instead of only by the manual e2e. No behaviour change; 62 new unit tests (478 → 540).
 
-- **Plugin-step & workflow-activity registration payloads** — extracted into `src/general/dataverse/stepPayloads.ts`: the `@odata.bind` step body (`buildStepPayload`), the "does the live step differ" diff (`stepNeedsUpdate` / `normalizeFilteringAttributes`), and the sparse workflow-activity PATCH builder (`getWorkflowPatchPayload`). These build the exact bodies Dataverse receives during Deploy — now covered by 22 tests.
+- **Plugin-step & workflow-activity registration payloads** — extracted into `src/general/dataverse/stepPayloads.ts`: the `@odata.bind` step body (`buildStepPayload`), the "does the live step differ" diff (`stepNeedsUpdate` / `normalizeFilteringAttributes`), and the sparse workflow-activity PATCH generator (`getWorkflowPatchPayload`). These build the exact bodies Dataverse receives during Deploy — now covered by 22 tests.
 - **Panel project-card view-model** — `src/panel/panelCards.ts`: the settings→card field mapping (name fallback chain, `.csproj` detail, trigger passthrough) and the time formatter, split from the fs/vscode reads in `panelState.ts`.
 - **Plugin unit-test scaffolding logic** — `src/plugins/unitTestingLogic.ts`: target-framework compatibility resolution (`net462`→`net472`, netstandard→`net8.0`), C# language-version parsing, class-name sanitising, and the per-framework boilerplate.
 
@@ -393,7 +444,7 @@ Plugins — early-bound authoring quality-of-life.
 
 Foundation & Quality (cont.) — test-layer depth, no user-facing change.
 
-- **Plugin-component integration coverage (#147).** A new integration test opens a plugin-component fixture, drives *Configure Earlybound*, and asserts the **full** set of registry commands is registered — closing the gap the no-workspace test couldn't reach (the model-builder tree's `editModelBuilderSetting` registers lazily on first use). A renamed or dropped command in any of the three registration paths now fails in CI instead of only in the manual e2e.
+- **Plugin-component integration coverage (#147).** A new integration test opens a plugin-component fixture, drives *Configure Earlybound*, and asserts the **full** set of registry commands is registered — closing the gap the no-workspace test couldn't reach (the model-generator tree's `editModelBuilderSetting` registers lazily on first use). A renamed or dropped command in any of the three registration paths now fails in CI instead of only in the manual e2e.
 - **Consolidated the duplicated OData string-escaper (#143).** `escapeODataString` — copy-pasted into four Dataverse Web API modules (plugin/workflow registration, assembly, package) — is now one shared, unit-tested pure module, with tests covering the `$filter` injection shape it exists to prevent. Behaviour is byte-identical.
 - **e2e:** the wizard project-type quick-pick now falls back to keyboard selection when a coordinate click is intercepted by the empty-editor watermark — fixes four plugin-lifecycle e2e steps that broke after the project-type picker was reordered.
 
@@ -404,15 +455,15 @@ Foundation & Quality — multi-component polish, safer onboarding, and a real in
 - **Panel: minimise & organise component cards (#156).** **Ungroup** a group (its members return to the list in order); **minimise/expand individual component cards**; a **multi-component workspace opens with cards minimised** by default (your manual expand/collapse persists and wins next time). A single-type project is now **capped at one component** — to hold more, convert it to a **multi-component project**, which is also renamed and **floated to the top** of the new-project picker ("Multi-component project (two or more types)").
 - **Every component initialises on load (#146).** In a workspace with two components of the same type, the second one's Test Explorer tests + watchers now appear immediately instead of only after re-adding it.
 - **Web Resources onboarding on Add Component (#126).** Adding a Web Resources component now generates typings and offers to create a class — the same first-create experience a standalone project gets.
-- **Removed two broken Command Palette entries (#147)** — *Edit Plugin Message Filter* and *Toggle Emit Entity Type Code* were contributed but never wired up, so they failed "command not found"; both were superseded by the model-builder settings tree.
+- **Removed two broken Command Palette entries (#147)** — *Edit Plugin Message Filter* and *Toggle Emit Entity Type Code* were contributed but never wired up, so they failed "command not found"; both were superseded by the model-generator settings tree.
 - **Under the hood:** a new CI-runnable **integration test layer** (asserts command registration and guards the multi-component Test Explorer wiring), a guard against dead command declarations, and more internal logic extracted to pure, unit-tested modules. Unit coverage 358 → 394.
 
 ### 0.8.6 (pre-release)
 
 Test hardening + safer form-event registration.
 
-- **Form-event registration fails fast on the schema-bug shape.** The form-XML builder now refuses to write a web-resource `<Library>` without a resolved name — the exact shape that once broke a form with `0x80048425` — turning a would-be corrupt form into a clear error. Behaviour is otherwise unchanged.
-- **Under the hood (no functional change):** a new CI-runnable **integration test layer** (asserts command registration and guards the multi-component duplicate-`TestController` crash that shipped in 0.8.4), and the highest-risk internal logic extracted into pure, unit-tested modules — the form-XML builder, the model-builder (earlybound) settings helpers, and the plugin profilable-steps filter (the code path behind "No registered plugin steps to profile"). Unit coverage 358 → 386. See the testing-strategy epic (#143).
+- **Form-event registration fails fast on the schema-bug shape.** The form-XML generator now refuses to write a web-resource `<Library>` without a resolved name — the exact shape that once broke a form with `0x80048425` — turning a would-be corrupt form into a clear error. Behaviour is otherwise unchanged.
+- **Under the hood (no functional change):** a new CI-runnable **integration test layer** (asserts command registration and guards the multi-component duplicate-`TestController` crash that shipped in 0.8.4), and the highest-risk internal logic extracted into pure, unit-tested modules — the form-XML generator, the model-generator (earlybound) settings helpers, and the plugin profilable-steps filter (the code path behind "No registered plugin steps to profile"). Unit coverage 358 → 386. See the testing-strategy epic (#143).
 
 ### 0.8.5 (pre-release)
 
@@ -561,12 +612,12 @@ Manual-testing feedback wave across web resources, plugins, solutions and the pa
 
 ## 0.5.2
 
-- Fixed early-bound generation failing with `spawn EINVAL`: on Windows `pac` is a `.cmd` shim that recent Node versions refuse to spawn directly, so all `pac` calls (early-bound/model builder, portals, solutions) now run through `cmd.exe /c pac …`.
+- Fixed early-bound generation failing with `spawn EINVAL`: on Windows `pac` is a `.cmd` shim that recent Node versions refuse to spawn directly, so all `pac` calls (early-bound/model generator, portals, solutions) now run through `cmd.exe /c pac …`.
 - Fixed plugin deploy failing with `spawn pwsh ENOENT`: the plugin package is now sanitized (forbidden SDK assemblies stripped) with an in-process zip library instead of shelling out to PowerShell, so it no longer requires PowerShell Core and works cross-platform.
 - Fixed new Web Resources projects failing to create with an `npm ERESOLVE` error — TypeScript is now pinned to v5 (a bare install resolved to TypeScript 7, which conflicts with the ESLint TypeScript plugin's peer range).
 - Fixed the early-bound side panel showing "error loading" until VS Code was reloaded after creating a project — the tree view provider is now registered immediately on project creation.
 - Fixed typings generation failing with `XrmDefinitelyTyped.exe ENOENT`: new Web Resources projects now restore the `Delegate.XrmDefinitelyTyped` tool via paket (the restore step had been missing from the template), and the command now reports a clear, actionable error if the tool still isn't present.
-- Fixed service-principal projects failing to reconnect on load ("Dataverse Not Connected", "Error refreshing authorization token", and broken typings): when reassembling the connection string from the stored settings and the secret-storage credentials, the client id was glued onto the URL with no separator (`Url=<url>ClientId=…`). The parts are now merged through the shared connection-string builder so the separators are always correct.
+- Fixed service-principal projects failing to reconnect on load ("Dataverse Not Connected", "Error refreshing authorization token", and broken typings): when reassembling the connection string from the stored settings and the secret-storage credentials, the client id was glued onto the URL with no separator (`Url=<url>ClientId=…`). The parts are now merged through the shared connection-string generator so the separators are always correct.
 - Fixed a new Web Resources project not building cleanly out of the box: the scaffolded `webresources_src/library.ts` re-exported a non-existent `./account` module. It is now an empty stub that `Create Web Resource Class` appends each new class to.
 - Fixed the webpack build of a fresh Web Resources project failing on the scaffolded sample files: `class.ts` and `sample.test.ts` were copied in with unreplaced placeholders (`Form.TableName.Main.FormName`, `import '../ClassName'`), which ts-loader type-checked and rejected. They are templates for the Create Class/Test commands, not scaffold files, so a new project no longer ships them.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -21,6 +21,12 @@ npm run test:coverage     # Vitest + a coverage floor CI enforces (see vitest.co
 npm run test:integration  # real VS Code extension host (downloads VS Code once)
 ```
 
+**`test:integration` does NOT rebuild the bundle.** It runs `compile-tests` (tsc → `out/`) and the
+extension host loads `main` = `dist/extension.js`. So after changing anything under `src/` that the
+*extension* runs (a provider, a registration, a command), run `npm run compile` first or the host
+under test is your PREVIOUS build — a fix appears not to work, or a bug appears already fixed. Only
+the test files themselves come from `out/`.
+
 `npm test` = unit + integration. CI ([.github/workflows/ci.yml](.github/workflows/ci.yml))
 runs lint + compile + `test:coverage` + integration on every PR, plus the UI tests.
 **Publishing to the Marketplace is gated on these passing**

--- a/README.md
+++ b/README.md
@@ -73,6 +73,9 @@ to show them:
 - **Plug-in debugging** — Profile next run, Download a run, Replay & debug, and the per-step
   `Profile` CodeLens.
 - **Custom APIs** — define, generate handlers and typed clients, deploy, and invoke.
+- **FetchXML query tools** — a CodeLens on the FetchXML already in your C#/TypeScript to run it,
+  edit it in a generator, or see what's wrong with it (unescaped values, local-time dates compared
+  against UTC columns, unknown columns).
 
 Everything else is on by default.
 

--- a/media/queryGenerator.css
+++ b/media/queryGenerator.css
@@ -1,0 +1,276 @@
+/* FetchXML Generator webview (#238). Theme variables only — no hard-coded colours, so it follows
+   whatever theme the user has. */
+
+body {
+  margin: 0;
+  padding: 0;
+  font-family: var(--vscode-font-family);
+  font-size: var(--vscode-font-size);
+  color: var(--vscode-foreground);
+  background: var(--vscode-editor-background);
+  display: flex;
+  flex-direction: column;
+  height: 100vh;
+  box-sizing: border-box;
+}
+
+header {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 8px 12px;
+  border-bottom: 1px solid var(--vscode-panel-border);
+  flex: 0 0 auto;
+}
+
+#title {
+  font-weight: 600;
+  flex: 1 1 auto;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+#title .consumer {
+  font-weight: 400;
+  opacity: 0.75;
+  margin-left: 8px;
+}
+
+#title .dirty {
+  color: var(--vscode-gitDecoration-modifiedResourceForeground, var(--vscode-foreground));
+  margin-left: 6px;
+}
+
+#actions {
+  display: flex;
+  gap: 6px;
+  flex: 0 0 auto;
+}
+
+button {
+  font-family: inherit;
+  font-size: inherit;
+  color: var(--vscode-button-secondaryForeground, var(--vscode-button-foreground));
+  background: var(--vscode-button-secondaryBackground, var(--vscode-button-background));
+  border: none;
+  padding: 4px 10px;
+  border-radius: 2px;
+  cursor: pointer;
+}
+
+button:hover {
+  background: var(--vscode-button-secondaryHoverBackground, var(--vscode-button-hoverBackground));
+}
+
+button#run,
+button#save {
+  color: var(--vscode-button-foreground);
+  background: var(--vscode-button-background);
+}
+
+button#run:hover,
+button#save:hover {
+  background: var(--vscode-button-hoverBackground);
+}
+
+button:disabled {
+  opacity: 0.5;
+  cursor: default;
+}
+
+#notice {
+  padding: 6px 12px;
+  background: var(--vscode-inputValidation-warningBackground);
+  border-bottom: 1px solid var(--vscode-inputValidation-warningBorder);
+}
+
+main {
+  display: flex;
+  flex: 1 1 auto;
+  min-height: 0;
+}
+
+#treePane {
+  flex: 1 1 45%;
+  min-width: 240px;
+  display: flex;
+  flex-direction: column;
+  border-right: 1px solid var(--vscode-panel-border);
+  min-height: 0;
+}
+
+#tree {
+  flex: 1 1 auto;
+  overflow: auto;
+  padding: 6px 0;
+}
+
+#treeActions {
+  flex: 0 0 auto;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+  padding: 8px;
+  border-top: 1px solid var(--vscode-panel-border);
+}
+
+.row {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding: 2px 8px;
+  cursor: pointer;
+  white-space: nowrap;
+}
+
+.row:hover {
+  background: var(--vscode-list-hoverBackground);
+}
+
+.row.selected {
+  background: var(--vscode-list-activeSelectionBackground);
+  color: var(--vscode-list-activeSelectionForeground);
+}
+
+.row .tag {
+  opacity: 0.7;
+  font-size: 0.9em;
+}
+
+.row .label {
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.row.readonly .label {
+  font-style: italic;
+  opacity: 0.8;
+}
+
+#propertiesPane {
+  flex: 1 1 55%;
+  overflow: auto;
+  padding: 10px 12px;
+  min-width: 260px;
+}
+
+.field {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin-bottom: 6px;
+}
+
+.field label {
+  flex: 0 0 110px;
+  opacity: 0.85;
+}
+
+.field input[type="text"],
+.field input[type="number"],
+.field select {
+  flex: 1 1 auto;
+  min-width: 0;
+  font-family: inherit;
+  font-size: inherit;
+  color: var(--vscode-input-foreground);
+  background: var(--vscode-input-background);
+  border: 1px solid var(--vscode-input-border, transparent);
+  padding: 3px 5px;
+}
+
+.field input[type="checkbox"] {
+  margin: 0;
+}
+
+.hint {
+  opacity: 0.7;
+  font-size: 0.9em;
+  margin: -2px 0 8px 118px;
+}
+
+h3 {
+  font-size: 0.95em;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  opacity: 0.7;
+  margin: 16px 0 6px;
+}
+
+.pill {
+  display: inline-block;
+  padding: 1px 6px;
+  border-radius: 8px;
+  background: var(--vscode-badge-background);
+  color: var(--vscode-badge-foreground);
+  font-size: 0.85em;
+  margin-left: 6px;
+}
+
+.diagnostic {
+  display: flex;
+  gap: 8px;
+  padding: 4px 0;
+  border-top: 1px solid var(--vscode-panel-border);
+}
+
+.diagnostic .severity {
+  flex: 0 0 auto;
+}
+
+.diagnostic.error .severity {
+  color: var(--vscode-editorError-foreground);
+}
+
+.diagnostic.warning .severity {
+  color: var(--vscode-editorWarning-foreground);
+}
+
+.diagnostic.info .severity {
+  color: var(--vscode-editorInfo-foreground);
+}
+
+.other {
+  opacity: 0.75;
+  font-size: 0.9em;
+  padding: 2px 0;
+}
+
+#xmlPane {
+  flex: 0 0 auto;
+  display: flex;
+  flex-direction: column;
+  border-top: 1px solid var(--vscode-panel-border);
+  padding: 6px 12px 10px;
+}
+
+#xmlPane label {
+  font-size: 0.95em;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  opacity: 0.7;
+  margin-bottom: 4px;
+}
+
+#xml {
+  font-family: var(--vscode-editor-font-family);
+  font-size: var(--vscode-editor-font-size);
+  color: var(--vscode-input-foreground);
+  background: var(--vscode-input-background);
+  border: 1px solid var(--vscode-input-border, transparent);
+  padding: 6px;
+  resize: vertical;
+  white-space: pre;
+  overflow: auto;
+}
+
+#xmlError {
+  color: var(--vscode-editorError-foreground);
+  padding-top: 4px;
+}
+
+.empty {
+  opacity: 0.7;
+  padding: 4px 0;
+}

--- a/media/queryGenerator.js
+++ b/media/queryGenerator.js
@@ -1,0 +1,339 @@
+// FetchXML Generator webview renderer (#238).
+//
+// Deliberately dumb: it renders the state the host sends and posts back INTENTS. It holds no query
+// model, does no XML parsing, and makes no decisions about what is valid — all of that lives in the
+// host's pure modules, where it is unit-tested.
+//
+// Everything user- or org-supplied is written with textContent, never innerHTML.
+
+(function () {
+  const vscode = acquireVsCodeApi();
+
+  const els = {
+    title: document.getElementById("title"),
+    notice: document.getElementById("notice"),
+    tree: document.getElementById("tree"),
+    treeActions: document.getElementById("treeActions"),
+    properties: document.getElementById("properties"),
+    otherAttributes: document.getElementById("otherAttributes"),
+    parameters: document.getElementById("parameters"),
+    diagnostics: document.getElementById("diagnostics"),
+    xml: document.getElementById("xml"),
+    xmlError: document.getElementById("xmlError"),
+    run: document.getElementById("run"),
+    save: document.getElementById("save"),
+    copy: document.getElementById("copy"),
+    refresh: document.getElementById("refresh"),
+  };
+
+  /** True while the user is typing in the XML box, so a re-render doesn't fight the caret. */
+  let editingXml = false;
+  let state;
+
+  function post(message) {
+    vscode.postMessage(message);
+  }
+
+  function el(tag, className, text) {
+    const node = document.createElement(tag);
+    if (className) {
+      node.className = className;
+    }
+    if (text !== undefined) {
+      node.textContent = text;
+    }
+    return node;
+  }
+
+  function heading(text, badge) {
+    const node = el("h3", undefined, text);
+    if (badge !== undefined) {
+      node.appendChild(el("span", "pill", String(badge)));
+    }
+    return node;
+  }
+
+  // --- tree ---------------------------------------------------------------------------------
+
+  function renderTree() {
+    els.tree.replaceChildren();
+    for (const row of state.tree) {
+      const node = el("div", `row${samePath(row.path, state.selection) ? " selected" : ""}${row.readOnly ? " readonly" : ""}`);
+      node.style.paddingLeft = `${8 + row.depth * 16}px`;
+      node.setAttribute("role", "treeitem");
+      node.appendChild(el("span", "tag", row.tag));
+      node.appendChild(el("span", "label", row.label));
+      node.addEventListener("click", () => post({ type: "select", path: row.path }));
+      els.tree.appendChild(node);
+    }
+  }
+
+  function renderTreeActions() {
+    els.treeActions.replaceChildren();
+    for (const tag of state.addable) {
+      const button = el("button", undefined, `+ ${tag}`);
+      button.disabled = state.readOnly;
+      button.addEventListener("click", () => post({ type: "add", path: state.selection, tag }));
+      els.treeActions.appendChild(button);
+    }
+    if (state.canRemove) {
+      const remove = el("button", undefined, "Remove");
+      remove.disabled = state.readOnly;
+      remove.addEventListener("click", () => post({ type: "edit", edit: { kind: "remove", path: state.selection } }));
+      els.treeActions.appendChild(remove);
+
+      for (const [label, offset] of [
+        ["Move up", -1],
+        ["Move down", 1],
+      ]) {
+        const move = el("button", undefined, label);
+        move.disabled = state.readOnly;
+        move.addEventListener("click", () => post({ type: "edit", edit: { kind: "move", path: state.selection, offset } }));
+        els.treeActions.appendChild(move);
+      }
+    }
+  }
+
+  function samePath(a, b) {
+    return a.length === b.length && a.every((value, index) => value === b[index]);
+  }
+
+  // --- properties ---------------------------------------------------------------------------
+
+  function optionList(select, values, current, placeholder) {
+    if (placeholder !== undefined) {
+      const blank = el("option", undefined, placeholder);
+      blank.value = "";
+      select.appendChild(blank);
+    }
+    for (const value of values) {
+      const option = el("option", undefined, value.label);
+      option.value = value.value;
+      if (value.value === current) {
+        option.selected = true;
+      }
+      select.appendChild(option);
+    }
+    // An existing value the picker doesn't offer (a column metadata hasn't loaded, a custom
+    // operator) must still be shown, or selecting anything else would silently change it.
+    if (current && !values.some((value) => value.value === current)) {
+      const extra = el("option", undefined, `${current} (current)`);
+      extra.value = current;
+      extra.selected = true;
+      select.appendChild(extra);
+    }
+  }
+
+  function fieldRow(field) {
+    const { descriptor, value } = field;
+    const wrapper = el("div", "field");
+    const id = `field-${descriptor.name}`;
+    const label = el("label", undefined, descriptor.label);
+    label.setAttribute("for", id);
+    wrapper.appendChild(label);
+
+    const send = (next) => post({ type: "edit", edit: { kind: "setAttr", path: state.selection, name: descriptor.name, value: next } });
+
+    let input;
+    if (descriptor.kind === "boolean") {
+      input = el("input");
+      input.type = "checkbox";
+      input.checked = value === "true" || value === "1";
+      input.addEventListener("change", () => send(input.checked ? "true" : ""));
+    } else if (descriptor.kind === "select" || descriptor.kind === "entity" || descriptor.kind === "attribute") {
+      input = el("select");
+      let options = [];
+      let placeholder = "(not set)";
+      if (descriptor.kind === "entity") {
+        options = (state.tables ?? []).map((table) => ({ value: table.logicalName, label: `${table.logicalName} — ${table.displayName}` }));
+        placeholder = state.tables ? "(not set)" : "loading tables…";
+      } else if (descriptor.kind === "attribute") {
+        options = (state.attributes ?? []).map((attribute) => ({ value: attribute.logicalName, label: `${attribute.logicalName} — ${attribute.displayName}` }));
+        placeholder = state.attributes ? "(not set)" : "loading columns…";
+      } else if (descriptor.name === "operator") {
+        // Grouped, so 60 operators stay navigable.
+        input.appendChild(Object.assign(document.createElement("option"), { value: "", textContent: "(not set)" }));
+        for (const group of state.operatorGroups) {
+          const optgroup = document.createElement("optgroup");
+          optgroup.label = group.label;
+          for (const operator of group.operators) {
+            const option = el("option", undefined, operator);
+            option.value = operator;
+            if (operator === value) {
+              option.selected = true;
+            }
+            optgroup.appendChild(option);
+          }
+          input.appendChild(optgroup);
+        }
+        if (value && !state.operatorGroups.some((group) => group.operators.includes(value))) {
+          const extra = el("option", undefined, `${value} (current)`);
+          extra.value = value;
+          extra.selected = true;
+          input.appendChild(extra);
+        }
+        placeholder = undefined;
+      } else {
+        options = descriptor.options.map((option) => ({ value: option, label: option }));
+      }
+      if (placeholder !== undefined) {
+        optionList(input, options, value, placeholder);
+      }
+      input.addEventListener("change", () => send(input.value));
+    } else {
+      input = el("input");
+      input.type = descriptor.kind === "number" ? "number" : "text";
+      input.value = value;
+      // Commit on blur/Enter rather than each keystroke, so the host isn't re-rendering mid-word.
+      input.addEventListener("change", () => send(input.value));
+      input.addEventListener("keydown", (event) => {
+        if (event.key === "Enter") {
+          send(input.value);
+        }
+      });
+    }
+    input.id = id;
+    input.disabled = state.readOnly;
+    wrapper.appendChild(input);
+    return wrapper;
+  }
+
+  function renderProperties() {
+    els.properties.replaceChildren();
+    els.properties.appendChild(heading(state.selectedTag ? `<${state.selectedTag}>` : "Properties"));
+
+    if (state.fields.length === 0) {
+      els.properties.appendChild(el("div", "empty", "This element has no editable properties."));
+    }
+    for (const field of state.fields) {
+      els.properties.appendChild(fieldRow(field));
+      if (field.descriptor.hint) {
+        els.properties.appendChild(el("div", "hint", field.descriptor.hint));
+      }
+    }
+
+    // A <value> node holds text rather than attributes.
+    if (state.selectedTag === "value") {
+      const wrapper = el("div", "field");
+      const label = el("label", undefined, "Value");
+      label.setAttribute("for", "value-text");
+      const input = el("input");
+      input.type = "text";
+      input.id = "value-text";
+      input.disabled = state.readOnly;
+      const row = state.tree.find((candidate) => samePath(candidate.path, state.selection));
+      input.value = row ? row.label : "";
+      input.addEventListener("change", () => post({ type: "edit", edit: { kind: "setText", path: state.selection, text: input.value } }));
+      wrapper.appendChild(label);
+      wrapper.appendChild(input);
+      els.properties.appendChild(wrapper);
+    }
+
+    els.otherAttributes.replaceChildren();
+    if (state.otherAttributes.length > 0) {
+      els.otherAttributes.appendChild(heading("Other attributes", state.otherAttributes.length));
+      els.otherAttributes.appendChild(el("div", "hint", "Kept exactly as written — edit them in the FetchXML box below."));
+      for (const attribute of state.otherAttributes) {
+        els.otherAttributes.appendChild(el("div", "other", `${attribute.name} = ${attribute.value}`));
+      }
+    }
+  }
+
+  function renderParameters() {
+    els.parameters.replaceChildren();
+    if (state.parameters.length === 0) {
+      return;
+    }
+    els.parameters.appendChild(heading("Parameters", state.parameters.length));
+    for (const parameter of state.parameters) {
+      const wrapper = el("div", "field");
+      const id = `param-${parameter.name}`;
+      const label = el("label", undefined, `@${parameter.name}`);
+      label.setAttribute("for", id);
+      label.title = parameter.expression ? `Bound to ${parameter.expression}` : "Typed in the generator";
+      const input = el("input");
+      input.type = "text";
+      input.id = id;
+      input.value = parameter.value;
+      input.placeholder = parameter.type;
+      input.addEventListener("change", () => post({ type: "setParameter", name: parameter.name, value: input.value }));
+      wrapper.appendChild(label);
+      wrapper.appendChild(input);
+      els.parameters.appendChild(wrapper);
+      if (parameter.expression) {
+        els.parameters.appendChild(el("div", "hint", `Bound to \`${parameter.expression}\` in the code — a test run uses the value above.`));
+      }
+    }
+  }
+
+  function renderDiagnostics() {
+    els.diagnostics.replaceChildren();
+    if (state.diagnostics.length === 0) {
+      return;
+    }
+    els.diagnostics.appendChild(heading("Issues", state.diagnostics.length));
+    for (const diagnostic of state.diagnostics) {
+      const row = el("div", `diagnostic ${diagnostic.severity}`);
+      row.appendChild(el("span", "severity", diagnostic.severity === "error" ? "✖" : diagnostic.severity === "warning" ? "⚠" : "ℹ"));
+      row.appendChild(el("span", "message", diagnostic.message));
+      els.diagnostics.appendChild(row);
+    }
+  }
+
+  function render() {
+    els.title.replaceChildren();
+    els.title.appendChild(el("span", undefined, state.title));
+    els.title.appendChild(el("span", "consumer", state.consumerLabel));
+    if (state.dirty) {
+      els.title.appendChild(el("span", "dirty", "● unsaved"));
+    }
+
+    if (state.readOnly) {
+      els.notice.textContent = "This string can't be rewritten safely (a raw string literal), so the generator is read-only. Run and Copy still work.";
+      els.notice.hidden = false;
+    } else {
+      els.notice.hidden = true;
+    }
+
+    els.save.disabled = state.readOnly || !state.dirty;
+
+    renderTree();
+    renderTreeActions();
+    renderProperties();
+    renderParameters();
+    renderDiagnostics();
+
+    if (!editingXml && els.xml.value !== state.xml) {
+      els.xml.value = state.xml;
+      els.xmlError.hidden = true;
+    }
+  }
+
+  // --- wiring -------------------------------------------------------------------------------
+
+  els.run.addEventListener("click", () => post({ type: "run" }));
+  els.save.addEventListener("click", () => post({ type: "save" }));
+  els.copy.addEventListener("click", () => post({ type: "copyXml" }));
+  els.refresh.addEventListener("click", () => post({ type: "refreshMetadata" }));
+
+  els.xml.addEventListener("focus", () => {
+    editingXml = true;
+  });
+  els.xml.addEventListener("blur", () => {
+    editingXml = false;
+    post({ type: "setXml", xml: els.xml.value });
+  });
+
+  window.addEventListener("message", (event) => {
+    const message = event.data;
+    if (message.type === "state") {
+      state = message.state;
+      render();
+    } else if (message.type === "xmlError") {
+      els.xmlError.textContent = message.error;
+      els.xmlError.hidden = false;
+    }
+  });
+
+  post({ type: "ready" });
+})();

--- a/media/queryResults.css
+++ b/media/queryResults.css
@@ -1,0 +1,106 @@
+/* FetchXML results webview (#238). Theme variables only. */
+
+body {
+  margin: 0;
+  font-family: var(--vscode-font-family);
+  font-size: var(--vscode-font-size);
+  color: var(--vscode-foreground);
+  background: var(--vscode-editor-background);
+  display: flex;
+  flex-direction: column;
+  height: 100vh;
+  box-sizing: border-box;
+}
+
+#summary {
+  flex: 0 0 auto;
+  padding: 8px 12px;
+  border-bottom: 1px solid var(--vscode-panel-border);
+  line-height: 1.5;
+}
+
+#summary .count {
+  font-weight: 600;
+}
+
+#summary .ran-as {
+  opacity: 0.8;
+}
+
+#summary .capped {
+  color: var(--vscode-editorWarning-foreground);
+}
+
+#error {
+  margin: 12px;
+  padding: 10px;
+  background: var(--vscode-inputValidation-errorBackground);
+  border: 1px solid var(--vscode-inputValidation-errorBorder);
+  white-space: pre-wrap;
+}
+
+#grid {
+  flex: 1 1 auto;
+  overflow: auto;
+}
+
+table {
+  border-collapse: collapse;
+  width: max-content;
+  min-width: 100%;
+}
+
+th,
+td {
+  text-align: left;
+  padding: 4px 10px;
+  border-bottom: 1px solid var(--vscode-panel-border);
+  white-space: nowrap;
+  max-width: 420px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+th {
+  position: sticky;
+  top: 0;
+  background: var(--vscode-editor-background);
+  border-bottom: 2px solid var(--vscode-panel-border);
+  font-weight: 600;
+}
+
+tbody tr:nth-child(even) {
+  background: var(--vscode-list-hoverBackground);
+}
+
+td.empty-value {
+  opacity: 0.5;
+}
+
+footer {
+  flex: 0 0 auto;
+  display: flex;
+  gap: 6px;
+  padding: 8px 12px;
+  border-top: 1px solid var(--vscode-panel-border);
+}
+
+button {
+  font-family: inherit;
+  font-size: inherit;
+  color: var(--vscode-button-secondaryForeground, var(--vscode-button-foreground));
+  background: var(--vscode-button-secondaryBackground, var(--vscode-button-background));
+  border: none;
+  padding: 4px 10px;
+  border-radius: 2px;
+  cursor: pointer;
+}
+
+button:hover {
+  background: var(--vscode-button-secondaryHoverBackground, var(--vscode-button-hoverBackground));
+}
+
+.no-rows {
+  padding: 16px 12px;
+  opacity: 0.8;
+}

--- a/media/queryResults.js
+++ b/media/queryResults.js
@@ -1,0 +1,113 @@
+// FetchXML results webview renderer (#238).
+//
+// Every cell here is data from the environment, i.e. untrusted input. The grid is therefore built
+// with createElement/textContent throughout — there is no innerHTML in this file, and none should be
+// added.
+
+(function () {
+  const vscode = acquireVsCodeApi();
+
+  const els = {
+    summary: document.getElementById("summary"),
+    error: document.getElementById("error"),
+    grid: document.getElementById("grid"),
+    copyCsv: document.getElementById("copyCsv"),
+    copyJson: document.getElementById("copyJson"),
+    copyXml: document.getElementById("copyXml"),
+  };
+
+  function el(tag, className, text) {
+    const node = document.createElement(tag);
+    if (className) {
+      node.className = className;
+    }
+    if (text !== undefined) {
+      node.textContent = text;
+    }
+    return node;
+  }
+
+  function renderSummary(payload) {
+    els.summary.replaceChildren();
+
+    const rows = payload.rows.length;
+    const total = payload.totalRecordCount;
+    const count = el("div");
+    count.appendChild(el("span", "count", `${rows} ${rows === 1 ? "row" : "rows"}`));
+    if (typeof total === "number" && total !== rows) {
+      count.appendChild(el("span", undefined, ` of ${total} matching`));
+    }
+    if (payload.moreRecords) {
+      count.appendChild(el("span", undefined, " · more available"));
+    }
+    if (payload.context && payload.context.rowCap !== undefined && payload.context.rowCap !== null) {
+      count.appendChild(el("span", "capped", ` · capped at ${payload.context.rowCap} for this test run`));
+    }
+    els.summary.appendChild(count);
+
+    // Stating the identity matters: the query ran as the CONNECTED user, not as whoever will run the
+    // plugin, so row-level security and eq-userid resolve differently at runtime.
+    const context = payload.context || {};
+    const parts = [];
+    if (context.organizationUrl) {
+      parts.push(context.organizationUrl);
+    }
+    if (context.identity) {
+      parts.push(`as ${context.identity}`);
+    }
+    if (parts.length > 0) {
+      els.summary.appendChild(el("div", "ran-as", `Ran against ${parts.join(" ")}`));
+    }
+  }
+
+  function renderGrid(payload) {
+    els.grid.replaceChildren();
+    if (payload.rows.length === 0) {
+      els.grid.appendChild(el("div", "no-rows", "No rows matched."));
+      return;
+    }
+
+    const table = el("table");
+    const thead = el("thead");
+    const headerRow = el("tr");
+    for (const column of payload.columns) {
+      const th = el("th", undefined, column.label);
+      th.title = column.key;
+      headerRow.appendChild(th);
+    }
+    thead.appendChild(headerRow);
+    table.appendChild(thead);
+
+    const tbody = el("tbody");
+    for (const row of payload.rows) {
+      const tr = el("tr");
+      for (const column of payload.columns) {
+        const value = row[column.key];
+        const td = el("td", value === undefined || value === "" ? "empty-value" : undefined, value === undefined ? "" : value);
+        td.title = value === undefined ? "" : value;
+        tr.appendChild(td);
+      }
+      tbody.appendChild(tr);
+    }
+    table.appendChild(tbody);
+    els.grid.appendChild(table);
+  }
+
+  els.copyCsv.addEventListener("click", () => vscode.postMessage({ type: "copyCsv" }));
+  els.copyJson.addEventListener("click", () => vscode.postMessage({ type: "copyJson" }));
+  els.copyXml.addEventListener("click", () => vscode.postMessage({ type: "copyXml" }));
+
+  window.addEventListener("message", (event) => {
+    const message = event.data;
+    if (message.type === "results") {
+      els.error.hidden = true;
+      renderSummary(message.payload);
+      renderGrid(message.payload);
+    } else if (message.type === "error") {
+      els.summary.replaceChildren(el("div", undefined, message.title));
+      els.grid.replaceChildren();
+      els.error.textContent = message.error;
+      els.error.hidden = false;
+    }
+  });
+})();

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "type": "git",
     "url": "https://github.com/pete-mc/dataverse-powertools"
   },
-  "version": "1.0.0",
+  "version": "1.0.1",
   "engines": {
     "vscode": "^1.95.0"
   },
@@ -31,6 +31,26 @@
       {
         "language": "typescriptreact",
         "path": "./snippets/dvpt-pcf.code-snippets"
+      },
+      {
+        "language": "csharp",
+        "path": "./snippets/dvpt-fetchxml-csharp.code-snippets"
+      },
+      {
+        "language": "typescript",
+        "path": "./snippets/dvpt-fetchxml-typescript.code-snippets"
+      },
+      {
+        "language": "typescriptreact",
+        "path": "./snippets/dvpt-fetchxml-typescript.code-snippets"
+      },
+      {
+        "language": "javascript",
+        "path": "./snippets/dvpt-fetchxml-typescript.code-snippets"
+      },
+      {
+        "language": "javascriptreact",
+        "path": "./snippets/dvpt-fetchxml-typescript.code-snippets"
       }
     ],
     "languageModelTools": [
@@ -833,6 +853,21 @@
       {
         "command": "dataverse-powertools.recheckRequirements",
         "title": "Dataverse PowerTools: Recheck Requirements"
+      },
+      {
+        "command": "dataverse-powertools.openFetchXmlGenerator",
+        "title": "Dataverse PowerTools: FetchXML Generator",
+        "enablement": "dataverse-powertools.showLoaded && config.dataverse-powertools.previewFeatures"
+      },
+      {
+        "command": "dataverse-powertools.runFetchXml",
+        "title": "Dataverse PowerTools: Run FetchXML at Cursor",
+        "enablement": "dataverse-powertools.showLoaded && config.dataverse-powertools.previewFeatures"
+      },
+      {
+        "command": "dataverse-powertools.clearQueryMetadataCache",
+        "title": "Dataverse PowerTools: Clear Dataverse Metadata Cache",
+        "enablement": "dataverse-powertools.showLoaded && config.dataverse-powertools.previewFeatures"
       }
     ],
     "configuration": {

--- a/snippets/dvpt-fetchxml-csharp.code-snippets
+++ b/snippets/dvpt-fetchxml-csharp.code-snippets
@@ -1,0 +1,37 @@
+{
+  "Dataverse FetchXML query": {
+    "prefix": ["dvpt-fetch", "fetchxml"],
+    "body": [
+      "var fetchXml = $@\"<fetch top='50'>",
+      "  <entity name='${1:account}'>",
+      "    <attribute name='${2:name}' />",
+      "    <filter type='and'>",
+      "      <condition attribute='${3:statecode}' operator='eq' value='${4:0}' />",
+      "    </filter>",
+      "  </entity>",
+      "</fetch>\";",
+      "var ${5:results} = service.RetrieveMultiple(new FetchExpression(fetchXml));$0"
+    ],
+    "description": "FetchXML executed through FetchExpression. A CodeLens appears above it: run it, or open it in the builder."
+  },
+  "Dataverse FetchXML query with a parameter": {
+    "prefix": ["dvpt-fetch-param", "fetchxml-param"],
+    "body": [
+      "var fetchXml = $@\"<fetch top='50'>",
+      "  <entity name='${1:incident}'>",
+      "    <attribute name='${2:title}' />",
+      "    <filter type='and'>",
+      "      <condition attribute='${3:customerid}' operator='eq' value='{${4:accountId}}' />",
+      "    </filter>",
+      "  </entity>",
+      "</fetch>\";",
+      "var ${5:results} = service.RetrieveMultiple(new FetchExpression(fetchXml));$0"
+    ],
+    "description": "FetchXML with an interpolated value. The builder shows it as a parameter and a test run prompts for it."
+  },
+  "Escape a value for FetchXML": {
+    "prefix": ["dvpt-escape-xml", "EscapeXml"],
+    "body": ["System.Security.SecurityElement.Escape(${1:value})$0"],
+    "description": "Escape a string before interpolating it into a FetchXML attribute."
+  }
+}

--- a/snippets/dvpt-fetchxml-typescript.code-snippets
+++ b/snippets/dvpt-fetchxml-typescript.code-snippets
@@ -1,0 +1,52 @@
+{
+  "Dataverse FetchXML query (Xrm.WebApi)": {
+    "prefix": ["dvpt-fetch", "fetchxml"],
+    "body": [
+      "const fetchXml = `<fetch top='50'>",
+      "  <entity name='${1:account}'>",
+      "    <attribute name='${2:name}' />",
+      "    <filter type='and'>",
+      "      <condition attribute='${3:statecode}' operator='eq' value='${4:0}' />",
+      "    </filter>",
+      "  </entity>",
+      "</fetch>`;",
+      "const ${5:results} = await Xrm.WebApi.retrieveMultipleRecords(\"${1:account}\", \"?fetchXml=\" + encodeURIComponent(fetchXml));$0"
+    ],
+    "description": "FetchXML executed through Xrm.WebApi. A CodeLens appears above it: run it, or open it in the builder."
+  },
+  "Dataverse FetchXML query with a parameter": {
+    "prefix": ["dvpt-fetch-param", "fetchxml-param"],
+    "body": [
+      "const fetchXml = `<fetch top='50'>",
+      "  <entity name='${1:incident}'>",
+      "    <attribute name='${2:title}' />",
+      "    <filter type='and'>",
+      "      <condition attribute='${3:customerid}' operator='eq' value='${${4:accountId}}' />",
+      "    </filter>",
+      "  </entity>",
+      "</fetch>`;",
+      "const ${5:results} = await Xrm.WebApi.retrieveMultipleRecords(\"${1:incident}\", \"?fetchXml=\" + encodeURIComponent(fetchXml));$0"
+    ],
+    "description": "FetchXML with an interpolated value. The builder shows it as a parameter and a test run prompts for it."
+  },
+  "Dataverse FetchXML lookup filter": {
+    "prefix": ["dvpt-fetch-filter", "fetchxml-filter"],
+    "body": [
+      "const filterXml = `<filter type='and'>",
+      "  <condition attribute='${1:statecode}' operator='eq' value='${2:0}' />",
+      "</filter>`;",
+      "${3:control}.addCustomFilter(filterXml, \"${4:account}\");$0"
+    ],
+    "description": "A <filter> fragment for a lookup's custom filter — the shape addCustomFilter expects."
+  },
+  "Escape a value for FetchXML": {
+    "prefix": ["dvpt-escape-xml", "escapeXml"],
+    "body": [
+      "/** Escape a value for interpolation into a FetchXML attribute. */",
+      "function escapeXml(value: string): string {",
+      "  return value.replace(/[&<>\"']/g, (character) => ({ \"&\": \"&amp;\", \"<\": \"&lt;\", \">\": \"&gt;\", '\"': \"&quot;\", \"'\": \"&apos;\" })[character] as string);",
+      "}$0"
+    ],
+    "description": "The escapeXml helper the unescaped-value quick fix calls."
+  }
+}

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -19,6 +19,7 @@ import { registerMenuPanel } from "./panel/menuPanel";
 import { refreshPanelData } from "./panel/panelDataCache";
 import { registerSystemRequirementCommands } from "./general/systemRequirements";
 import { initInteractiveTokenCache } from "./general/dataverse/tokenAcquisition";
+import { registerQueryCommands } from "./query/queryCommands";
 
 export async function activate(vscodeContext: vscode.ExtensionContext) {
   const context = new DataversePowerToolsContext(vscodeContext);
@@ -51,6 +52,10 @@ export async function activate(vscodeContext: vscode.ExtensionContext) {
   // ONCE here (its commands + provider are global) — never per plugin component, or a
   // second plugin component's initialise throws "command … already exists" (#47).
   registerDecorationCodeLens(context);
+  // FetchXML query tools (#238): a CodeLens, diagnostics and quick fixes on FetchXML found in the
+  // user's own C#/TS, plus the builder and results views. Registered ONCE here for the same reason
+  // as the CodeLens above — the providers and commands are global, not per component.
+  registerQueryCommands(context);
   await vscode.commands.executeCommand("setContext", "dataverse-powertools.folderStateReady", false);
   await vscode.commands.executeCommand("setContext", "dataverse-powertools.detectingFolderSettings", true);
   await vscode.commands.executeCommand("setContext", "dataverse-powertools.hasSupportedProjectType", true);

--- a/src/general/previewFeatures.spec.ts
+++ b/src/general/previewFeatures.spec.ts
@@ -17,8 +17,8 @@ const packageJson = JSON.parse(fs.readFileSync(path.join(repoRoot, "package.json
 const contributedCommands: { command: string; enablement?: string }[] = packageJson.contributes.commands;
 
 describe("preview feature registry", () => {
-  it("declares the three release-gated features", () => {
-    expect(PREVIEW_FEATURES.map((f) => f.id)).toEqual(["azureFunctions", "pluginDebugging", "customApis"]);
+  it("declares the release-gated features", () => {
+    expect(PREVIEW_FEATURES.map((f) => f.id)).toEqual(["azureFunctions", "pluginDebugging", "customApis", "fetchXmlQueries"]);
     for (const feature of PREVIEW_FEATURES) {
       expect(feature.label.length, `${feature.id}: needs a label`).toBeGreaterThan(0);
       expect(feature.note.length, `${feature.id}: needs a note`).toBeGreaterThan(0);
@@ -88,10 +88,18 @@ describe("preview ↔ package.json parity", () => {
     expect(properties["dataverse-powertools.collapseCardsFrom"].default).toBe(3);
   });
 
-  it("owns only commands the project-type registry knows about (plus CodeLens-only ones)", () => {
+  it("owns only commands the project-type registry knows about (plus the cross-type ones)", () => {
     const registryCommands = new Set(projectTypeRegistry.flatMap((d) => [...d.commandIds]));
-    const codeLensOnly = new Set(["dataverse-powertools.toggleStepProfilingAtLine"]);
-    const unknown = PREVIEW_FEATURES.flatMap((f) => [...f.commands]).filter((id) => !registryCommands.has(id) && !codeLensOnly.has(id));
+    // Commands NO single project type owns, so the registry can't (its command ownership is unique
+    // per type): a CodeLens-only command, and the FetchXML tools, which act on any C#/TS file and are
+    // gated on `showLoaded` rather than on a type's context key.
+    const notTypeOwned = new Set([
+      "dataverse-powertools.toggleStepProfilingAtLine",
+      "dataverse-powertools.openFetchXmlGenerator",
+      "dataverse-powertools.runFetchXml",
+      "dataverse-powertools.clearQueryMetadataCache",
+    ]);
+    const unknown = PREVIEW_FEATURES.flatMap((f) => [...f.commands]).filter((id) => !registryCommands.has(id) && !notTypeOwned.has(id));
     expect(unknown, "preview commands that no project type owns").toEqual([]);
   });
 });

--- a/src/general/previewFeatures.ts
+++ b/src/general/previewFeatures.ts
@@ -66,6 +66,14 @@ export const PREVIEW_FEATURES: readonly PreviewFeature[] = [
     projectTypes: [],
     commands: [`${prefix}newCustomApi`, `${prefix}generateCustomApiHandlers`, `${prefix}generateCustomApiClients`, `${prefix}deployCustomApis`, `${prefix}invokeCustomApi`],
   },
+  {
+    id: "fetchXmlQueries",
+    label: "FetchXML query tools",
+    note: "Detecting FetchXML in code, the generator, running a query and writing an edit back are not manually verified yet.",
+    manualTestIssue: 239,
+    projectTypes: [],
+    commands: [`${prefix}openFetchXmlGenerator`, `${prefix}runFetchXml`, `${prefix}clearQueryMetadataCache`],
+  },
 ];
 
 const PREVIEW_COMMANDS = new Set(PREVIEW_FEATURES.flatMap((feature) => [...feature.commands]));

--- a/src/query/codeLens.ts
+++ b/src/query/codeLens.ts
@@ -1,0 +1,175 @@
+// CodeLens and diagnostics on FetchXML found in code (#238).
+//
+// This is the discovery surface: the lens appears on the query the developer already has, which is
+// why the feature needs no new file type and works on day one against an existing codebase. The
+// diagnostics are worth having even if nobody ever opens the generator.
+//
+// Registered ONCE globally (in extension.ts), never in a per-component `initialise*` — a second
+// component of the same type would throw on a duplicate registration (#47).
+
+import * as vscode from "vscode";
+import DataversePowerToolsContext from "../context";
+import { previewFeaturesEnabled } from "../general/extensionConfig";
+import { DetectedQuery, detectQueries } from "./detect";
+import { diagnoseQuery, QueryDiagnostic } from "./diagnostics";
+import { allTokenNames } from "./holes";
+import { languageFor } from "./literals";
+import { getMetadataCache } from "./metadataService";
+import { collectParameters } from "./parameters";
+import { serializeFetchXml, DEFAULT_FORMAT } from "./fetchXml";
+
+export const OPEN_GENERATOR_COMMAND = "dataverse-powertools.openFetchXmlGenerator";
+export const RUN_QUERY_COMMAND = "dataverse-powertools.runFetchXml";
+
+const DIAGNOSTIC_SOURCE = "Dataverse PowerTools";
+
+/** Languages we scan. Kept in step with `languageFor`. */
+const QUERY_LANGUAGES = ["csharp", "typescript", "typescriptreact", "javascript", "javascriptreact"];
+
+/**
+ * Documents we scan. `untitled` is included deliberately: pasting a query into a scratch buffer to
+ * run it is one of the main things this feature replaces a separate tool for. Other schemes (diff
+ * views, output channels) are left out so lenses don't appear where they can't be acted on.
+ */
+export const QUERY_DOCUMENT_SELECTOR: vscode.DocumentSelector = QUERY_LANGUAGES.flatMap((language) => [
+  { language, scheme: "file" },
+  { language, scheme: "untitled" },
+]);
+
+/** Find every query in a document, or nothing when the language isn't one we scan. */
+export function queriesIn(document: vscode.TextDocument): DetectedQuery[] {
+  const language = languageFor(document.languageId);
+  if (!language) {
+    return [];
+  }
+  return detectQueries(document.getText(), language);
+}
+
+function diagnosticsFor(context: DataversePowerToolsContext, query: DetectedQuery): QueryDiagnostic[] {
+  const expressions = Object.fromEntries(query.tokens.map((token) => [token.name, token.expression]));
+  const xml = serializeFetchXml(query.root, DEFAULT_FORMAT);
+  return diagnoseQuery({
+    root: query.root,
+    consumer: query.consumer,
+    language: query.language,
+    parameters: collectParameters(query.root, allTokenNames(xml), expressions),
+    // Whatever metadata happens to be loaded. Nothing is fetched here: a CodeLens pass must not
+    // make network calls, so name checks appear once the generator has warmed the cache.
+    metadata: getMetadataCache(context),
+  });
+}
+
+const SEVERITY: Record<QueryDiagnostic["severity"], vscode.DiagnosticSeverity> = {
+  error: vscode.DiagnosticSeverity.Error,
+  warning: vscode.DiagnosticSeverity.Warning,
+  info: vscode.DiagnosticSeverity.Information,
+};
+
+export class FetchXmlCodeLensProvider implements vscode.CodeLensProvider {
+  private readonly changed = new vscode.EventEmitter<void>();
+  readonly onDidChangeCodeLenses = this.changed.event;
+
+  constructor(private readonly context: DataversePowerToolsContext) {}
+
+  refresh(): void {
+    this.changed.fire();
+  }
+
+  provideCodeLenses(document: vscode.TextDocument): vscode.CodeLens[] {
+    // The whole feature is preview-gated, so with the flag off the lens simply never appears.
+    if (!previewFeaturesEnabled()) {
+      return [];
+    }
+
+    const lenses: vscode.CodeLens[] = [];
+    for (const query of queriesIn(document)) {
+      const range = new vscode.Range(document.positionAt(query.start), document.positionAt(query.start));
+      const problems = diagnosticsFor(this.context, query).filter((diagnostic) => diagnostic.severity !== "info");
+
+      lenses.push(
+        new vscode.CodeLens(range, {
+          title: "▶ Run",
+          tooltip: "Run this FetchXML against the connected environment",
+          command: RUN_QUERY_COMMAND,
+          arguments: [document.uri, query.start],
+        }),
+      );
+      lenses.push(
+        new vscode.CodeLens(range, {
+          title: query.writable ? "✎ Edit in generator" : "👁 View in generator",
+          tooltip: query.writable ? "Open the FetchXML Generator on this query" : "This string can't be rewritten safely, so the generator opens read-only",
+          command: OPEN_GENERATOR_COMMAND,
+          arguments: [document.uri, query.start],
+        }),
+      );
+      if (problems.length > 0) {
+        lenses.push(
+          new vscode.CodeLens(range, {
+            title: `⚠ ${problems.length} ${problems.length === 1 ? "issue" : "issues"}`,
+            tooltip: problems.map((problem) => problem.message).join("\n"),
+            command: "workbench.actions.view.problems",
+            arguments: [],
+          }),
+        );
+      }
+    }
+    return lenses;
+  }
+}
+
+/** Publish the diagnostics for one document. */
+export function refreshDiagnostics(context: DataversePowerToolsContext, collection: vscode.DiagnosticCollection, document: vscode.TextDocument): void {
+  if (!previewFeaturesEnabled()) {
+    collection.delete(document.uri);
+    return;
+  }
+  const diagnostics: vscode.Diagnostic[] = [];
+  for (const query of queriesIn(document)) {
+    const range = new vscode.Range(document.positionAt(query.start), document.positionAt(query.end));
+    for (const finding of diagnosticsFor(context, query)) {
+      // Point an expression-specific finding at the expression itself, so the squiggle lands on the
+      // interpolation rather than covering the whole query.
+      const target = finding.expression ? locate(document, query, finding.expression) : undefined;
+      const diagnostic = new vscode.Diagnostic(target ?? range, finding.message, SEVERITY[finding.severity]);
+      diagnostic.source = DIAGNOSTIC_SOURCE;
+      diagnostic.code = finding.code;
+      diagnostics.push(diagnostic);
+    }
+  }
+  collection.set(document.uri, diagnostics);
+}
+
+/** Find an expression inside the query's span so a diagnostic can point at it precisely. */
+function locate(document: vscode.TextDocument, query: Pick<DetectedQuery, "start" | "end">, expression: string): vscode.Range | undefined {
+  const span = document.getText().slice(query.start, query.end);
+  const index = span.indexOf(expression);
+  if (index === -1) {
+    return undefined;
+  }
+  return new vscode.Range(document.positionAt(query.start + index), document.positionAt(query.start + index + expression.length));
+}
+
+/** Quick fixes for the findings that have one — currently the unescaped-value warning. */
+export class FetchXmlCodeActionProvider implements vscode.CodeActionProvider {
+  static readonly providedCodeActionKinds = [vscode.CodeActionKind.QuickFix];
+
+  provideCodeActions(document: vscode.TextDocument, _range: vscode.Range | vscode.Selection, actionContext: vscode.CodeActionContext): vscode.CodeAction[] {
+    const actions: vscode.CodeAction[] = [];
+    for (const diagnostic of actionContext.diagnostics) {
+      if (diagnostic.source !== DIAGNOSTIC_SOURCE || diagnostic.code !== "unescapedValue") {
+        continue;
+      }
+      const expression = document.getText(diagnostic.range);
+      const wrapper = document.languageId === "csharp" ? `SecurityElement.Escape(${expression})` : `escapeXml(${expression})`;
+      const action = new vscode.CodeAction(`Escape with ${document.languageId === "csharp" ? "SecurityElement.Escape" : "escapeXml"}`, vscode.CodeActionKind.QuickFix);
+      action.edit = new vscode.WorkspaceEdit();
+      action.edit.replace(document.uri, diagnostic.range, wrapper);
+      action.diagnostics = [diagnostic];
+      actions.push(action);
+      if (document.languageId === "csharp") {
+        action.isPreferred = true;
+      }
+    }
+    return actions;
+  }
+}

--- a/src/query/consumers.ts
+++ b/src/query/consumers.ts
@@ -1,0 +1,150 @@
+// What the FetchXML is being handed to, and what that consumer will accept (#238).
+//
+// Restricting the feature to FetchXML removes the need to TRANSLATE between query languages, but it
+// does not remove the per-consumer differences — they just move from "can this be translated?" to
+// "does this consumer accept this FetchXML?". A saved view rejects `aggregate`; a lookup filter
+// takes a bare `<filter>` and silently ignores columns and joins; anything riding in a
+// `?fetchXml=` query string has a URL length ceiling.
+//
+// Detection is a deliberate heuristic — the nearest known callee before the literal — not a parse.
+// It degrades to `unknown` (generic checks only) rather than being wrong, and it costs nothing.
+//
+// Pure (no `vscode`) → unit-tested.
+
+import { Language } from "./literals";
+
+export interface Consumer {
+  id: string;
+  label: string;
+  /** The root element this consumer expects. */
+  expects: "fetch" | "filter";
+  /** The query travels in a URL query string, so its length is bounded. */
+  urlBound: boolean;
+  /** This consumer rejects `aggregate="true"` outright. */
+  rejectsAggregate: boolean;
+  /** Source text that identifies this consumer, matched against the code before the literal. */
+  markers: readonly string[];
+  /** Languages this consumer can appear in. */
+  languages: readonly Language[];
+}
+
+/** Practical ceiling for a FetchXML query riding in a GET query string, after URL encoding
+ * roughly triples its length. Well under the ~8 KB total that servers and proxies enforce. */
+export const URL_BOUND_XML_LIMIT = 2000;
+
+export const UNKNOWN_CONSUMER: Consumer = {
+  id: "unknown",
+  label: "FetchXML",
+  expects: "fetch",
+  urlBound: false,
+  rejectsAggregate: false,
+  markers: [],
+  languages: ["csharp", "typescript"],
+};
+
+export const CONSUMERS: readonly Consumer[] = [
+  {
+    id: "sdkFetchExpression",
+    label: "FetchExpression (SDK)",
+    expects: "fetch",
+    urlBound: false,
+    rejectsAggregate: false,
+    markers: ["new FetchExpression(", "FetchExpression(", "RetrieveMultiple("],
+    languages: ["csharp"],
+  },
+  {
+    id: "savedQuery",
+    label: "Saved view (savedquery / userquery)",
+    expects: "fetch",
+    urlBound: false,
+    // A view's fetchxml cannot aggregate — the grid has nothing to bind aliased aggregates to.
+    rejectsAggregate: true,
+    markers: ['["fetchxml"]', '"fetchxml",', "savedquery", "userquery"],
+    languages: ["csharp", "typescript"],
+  },
+  {
+    label: "Xrm.WebApi / context.webAPI",
+    id: "webApi",
+    expects: "fetch",
+    urlBound: true,
+    rejectsAggregate: false,
+    markers: ["retrieveMultipleRecords(", "?fetchXml=", "fetchXml="],
+    languages: ["typescript"],
+  },
+  {
+    id: "lookupFilter",
+    label: "Lookup filter (addCustomFilter / lookupObjects)",
+    expects: "filter",
+    urlBound: false,
+    // A `<filter>` fragment carries conditions only; an aggregate makes no sense there.
+    rejectsAggregate: true,
+    markers: ["addCustomFilter(", "lookupObjects(", "addPreSearch("],
+    languages: ["typescript"],
+  },
+];
+
+/** How far back to look for a callee. Generous enough for a wrapped argument list, small enough
+ * that an unrelated call earlier in the method can't claim the query. */
+const LOOKBEHIND = 300;
+
+/** How far forward to look when the query was assigned to a variable before being used. */
+const LOOKAHEAD = 600;
+
+function nearestMarkerBehind(before: string, language: Language): Consumer | undefined {
+  let best: Consumer | undefined;
+  let bestIndex = -1;
+  for (const consumer of CONSUMERS) {
+    if (!consumer.languages.includes(language)) {
+      continue;
+    }
+    for (const marker of consumer.markers) {
+      const index = before.lastIndexOf(marker);
+      if (index > bestIndex) {
+        bestIndex = index;
+        best = consumer;
+      }
+    }
+  }
+  return best;
+}
+
+function nearestMarkerAhead(after: string, language: Language): Consumer | undefined {
+  let best: Consumer | undefined;
+  let bestIndex = Number.MAX_SAFE_INTEGER;
+  for (const consumer of CONSUMERS) {
+    if (!consumer.languages.includes(language)) {
+      continue;
+    }
+    for (const marker of consumer.markers) {
+      const index = after.indexOf(marker);
+      if (index !== -1 && index < bestIndex) {
+        bestIndex = index;
+        best = consumer;
+      }
+    }
+  }
+  return best;
+}
+
+/**
+ * Identify the consumer from the code around the literal.
+ *
+ * Looking BEHIND handles the direct-argument case, `retrieveMultipleRecords(e, "?fetchXml=" + xml)`,
+ * and the nearest marker wins so an earlier unrelated call can't claim the query. Looking AHEAD is
+ * the fallback, because most real code assigns the query to a variable first and calls with it on
+ * the next line — that shape is the common one, not the exception.
+ *
+ * Misattribution only costs a label and a diagnostic, never a code edit, so a heuristic is the right
+ * trade here against parsing the file.
+ */
+export function detectConsumer(source: string, literalStart: number, literalEnd: number, language: Language): Consumer {
+  const behind = nearestMarkerBehind(source.slice(Math.max(0, literalStart - LOOKBEHIND), literalStart), language);
+  if (behind) {
+    return behind;
+  }
+  return nearestMarkerAhead(source.slice(literalEnd, literalEnd + LOOKAHEAD), language) ?? UNKNOWN_CONSUMER;
+}
+
+export function consumerById(id: string): Consumer {
+  return CONSUMERS.find((consumer) => consumer.id === id) ?? UNKNOWN_CONSUMER;
+}

--- a/src/query/detect.spec.ts
+++ b/src/query/detect.spec.ts
@@ -1,0 +1,336 @@
+import { describe, it, expect } from "vitest";
+import { detectQueries, queryAtOffset } from "./detect";
+import { computeWriteBack, buildInsertion } from "./writeBack";
+import { allTokenNames, detokenizeXml, identifierFrom, replaceTokens, tokenizeParts, tokensInXml } from "./holes";
+import { minifyFetchXml, serializeFetchXml } from "./fetchXml";
+import { detectConsumer } from "./consumers";
+
+/** A realistic plugin file: verbatim FetchXML, one interpolated id, handed to FetchExpression. */
+const CSHARP_PLUGIN = `using System;
+using Microsoft.Xrm.Sdk;
+using Microsoft.Xrm.Sdk.Query;
+
+public class OpenCases : IPlugin
+{
+    public void Execute(IServiceProvider serviceProvider)
+    {
+        var service = GetService(serviceProvider);
+        var accountId = Guid.NewGuid();
+        var result = service.RetrieveMultiple(new FetchExpression($@"<fetch top='50'>
+  <entity name='incident'>
+    <attribute name='title' />
+    <filter type='and'>
+      <condition attribute='customerid' operator='eq' value='{accountId}' />
+      <condition attribute='statecode' operator='eq' value='0' />
+    </filter>
+  </entity>
+</fetch>"));
+    }
+}`;
+
+/** A realistic web-resource file: template literal, two holes, handed to Xrm.WebApi. */
+const TYPESCRIPT_WEBRESOURCE = `export async function openCases(accountId: string, since: Date): Promise<void> {
+  const fetchXml = \`<fetch top='50'>
+  <entity name='incident'>
+    <attribute name='title' />
+    <filter type='and'>
+      <condition attribute='customerid' operator='eq' value='\${accountId}' />
+      <condition attribute='createdon' operator='on-or-after' value='\${since.toISOString()}' />
+    </filter>
+  </entity>
+</fetch>\`;
+  const result = await Xrm.WebApi.retrieveMultipleRecords("incident", "?fetchXml=" + encodeURIComponent(fetchXml));
+  console.log(result.entities.length);
+}`;
+
+describe("detection in C#", () => {
+  const queries = detectQueries(CSHARP_PLUGIN, "csharp");
+
+  it("finds exactly the one query", () => {
+    expect(queries).toHaveLength(1);
+    expect(queries[0].root.tag).toBe("fetch");
+    expect(queries[0].writable).toBe(true);
+  });
+
+  it("replaces the interpolation with a readable token named after the variable", () => {
+    expect(queries[0].tokens).toEqual([{ token: "@accountId", name: "accountId", expression: "accountId" }]);
+    expect(queries[0].xml).toContain("value='@accountId'");
+  });
+
+  it("spans exactly the literal, so the write-back replaces nothing else", () => {
+    const span = CSHARP_PLUGIN.slice(queries[0].start, queries[0].end);
+    expect(span.startsWith('$@"<fetch')).toBe(true);
+    expect(span.endsWith('</fetch>"')).toBe(true);
+  });
+
+  it("identifies the SDK consumer from the enclosing call", () => {
+    expect(queries[0].consumer.id).toBe("sdkFetchExpression");
+    expect(queries[0].consumer.urlBound).toBe(false);
+  });
+});
+
+describe("detection in TypeScript", () => {
+  const queries = detectQueries(TYPESCRIPT_WEBRESOURCE, "typescript");
+
+  it("finds the query and both parameters", () => {
+    expect(queries).toHaveLength(1);
+    expect(queries[0].tokens.map((token) => token.name)).toEqual(["accountId", "since"]);
+    expect(queries[0].tokens[1].expression).toBe("since.toISOString()");
+  });
+
+  it("identifies the Web API consumer, which is URL bound", () => {
+    expect(queries[0].consumer.id).toBe("webApi");
+    expect(queries[0].consumer.urlBound).toBe(true);
+  });
+});
+
+describe("what must NOT be detected", () => {
+  it("ignores FetchXML assembled with a StringBuilder", () => {
+    const source = `var sb = new StringBuilder();
+sb.Append("<fetch>");
+sb.Append("<entity name='account' />");
+sb.Append("</fetch>");`;
+    expect(detectQueries(source, "csharp")).toEqual([]);
+  });
+
+  it("ignores a mention of <fetch in a comment", () => {
+    expect(detectQueries(`// build a <fetch> here later\nvar x = "not xml";`, "csharp")).toEqual([]);
+  });
+
+  it("ignores XML that merely contains a fetch inside another root", () => {
+    expect(detectQueries(`var x = @"<soap><fetch><entity name='a' /></fetch></soap>";`, "csharp")).toEqual([]);
+  });
+
+  it("ignores a string with no query at all, cheaply", () => {
+    expect(detectQueries(`const a = "hello"; const b = 'world';`, "typescript")).toEqual([]);
+  });
+
+  it("ignores an incomplete query", () => {
+    expect(detectQueries(`var x = @"<fetch><entity name='account'>";`, "csharp")).toEqual([]);
+  });
+});
+
+describe("fragments and other consumers", () => {
+  it("detects a bare <filter> passed to addCustomFilter", () => {
+    const source = `lookup.addCustomFilter("<filter type='and'><condition attribute='statecode' operator='eq' value='0' /></filter>", "account");`;
+    const queries = detectQueries(source, "typescript");
+    expect(queries).toHaveLength(1);
+    expect(queries[0].root.tag).toBe("filter");
+    expect(queries[0].consumer.id).toBe("lookupFilter");
+    expect(queries[0].consumer.expects).toBe("filter");
+  });
+
+  it("picks the nearest callee when several appear", () => {
+    const source = `foo.addCustomFilter(x); bar.retrieveMultipleRecords("account", "?fetchXml=" + `;
+    expect(detectConsumer(source, source.length, source.length, "typescript").id).toBe("webApi");
+  });
+
+  it("looks ahead when the query is assigned to a variable before being used", () => {
+    const source = `const xml = @@LITERAL@@;\nawait Xrm.WebApi.retrieveMultipleRecords("account", "?fetchXml=" + xml);`;
+    const start = source.indexOf("@@LITERAL@@");
+    expect(detectConsumer(source, start, start + "@@LITERAL@@".length, "typescript").id).toBe("webApi");
+  });
+
+  it("prefers a callee behind over one ahead", () => {
+    const source = `lookup.addCustomFilter(@@L@@, "account");\nfoo.retrieveMultipleRecords("a", b);`;
+    const start = source.indexOf("@@L@@");
+    expect(detectConsumer(source, start, start + 5, "typescript").id).toBe("lookupFilter");
+  });
+
+  it("falls back to unknown with no recognisable callee", () => {
+    expect(detectConsumer("var xml = ", 10, 10, "csharp").id).toBe("unknown");
+  });
+});
+
+describe("cursor targeting", () => {
+  const queries = detectQueries(CSHARP_PLUGIN, "csharp");
+
+  it("finds the query the cursor sits inside", () => {
+    expect(queryAtOffset(queries, queries[0].start + 10)).toBe(queries[0]);
+  });
+
+  it("falls forward to the next query when the cursor is above it", () => {
+    expect(queryAtOffset(queries, 0)).toBe(queries[0]);
+  });
+
+  it("returns nothing when the cursor is past the last query", () => {
+    expect(queryAtOffset(queries, CSHARP_PLUGIN.length)).toBeUndefined();
+  });
+});
+
+describe("token mapping", () => {
+  it("names a parameter after the value, not the operation", () => {
+    expect(identifierFrom("accountId", 1)).toBe("accountId");
+    expect(identifierFrom("context.UserId", 1)).toBe("UserId");
+    expect(identifierFrom("since:yyyy-MM-dd", 1)).toBe("since");
+    expect(identifierFrom("since.toISOString()", 1)).toBe("since");
+    expect(identifierFrom("SecurityElement.Escape(name)", 1)).toBe("name");
+    expect(identifierFrom("DateTime.UtcNow", 1)).toBe("UtcNow");
+    expect(identifierFrom('dict["some key"] + 1', 3)).toBe("dict");
+  });
+
+  it("falls back to pN when nothing in the expression names a value", () => {
+    expect(identifierFrom("new Date()", 2)).toBe("p2");
+    expect(identifierFrom('"x" + 1', 4)).toBe("p4");
+  });
+
+  it("gives one token to a repeated expression so it is prompted for once", () => {
+    const { xml, tokens } = tokenizeParts([
+      { kind: "text", value: "a" },
+      { kind: "hole", expression: "id" },
+      { kind: "text", value: "b" },
+      { kind: "hole", expression: "id" },
+    ]);
+    expect(tokens).toHaveLength(1);
+    expect(xml).toBe("a@idb@id");
+  });
+
+  it("disambiguates two different expressions that want the same name", () => {
+    const { tokens } = tokenizeParts([
+      { kind: "hole", expression: "a.Id" },
+      { kind: "text", value: "-" },
+      { kind: "hole", expression: "b.Id" },
+    ]);
+    expect(tokens.map((token) => token.name)).toEqual(["Id", "Id2"]);
+  });
+
+  it("round-trips parts through tokenize and detokenize", () => {
+    const parts = [
+      { kind: "text" as const, value: "<condition value='" },
+      { kind: "hole" as const, expression: "accountId" },
+      { kind: "text" as const, value: "' />" },
+    ];
+    const { xml, tokens } = tokenizeParts(parts);
+    expect(detokenizeXml(xml, tokens)).toEqual(parts);
+  });
+
+  it("treats a token typed in the generator as a new parameter named after itself", () => {
+    expect(detokenizeXml("value='@newParam'", [])).toEqual([
+      { kind: "text", value: "value='" },
+      { kind: "hole", expression: "newParam" },
+      { kind: "text", value: "'" },
+    ]);
+  });
+
+  it("does NOT mistake an email address for a parameter", () => {
+    expect(detokenizeXml("value='peter@mcdonald.xyz'", [])).toEqual([{ kind: "text", value: "value='peter@mcdonald.xyz'" }]);
+    expect(allTokenNames("value='peter@mcdonald.xyz'")).toEqual([]);
+  });
+
+  it("does recognise a token after a wildcard, as a like filter needs", () => {
+    expect(allTokenNames("value='%@term%'")).toEqual(["term"]);
+  });
+
+  it("finds adjacent tokens", () => {
+    expect(allTokenNames("<a x='@one' y='@two' />")).toEqual(["one", "two"]);
+  });
+
+  it("reports only tokens still present in the XML", () => {
+    const tokens = [
+      { token: "@a", name: "a", expression: "a" },
+      { token: "@b", name: "b", expression: "b" },
+    ];
+    expect(tokensInXml("value='@a'", tokens).map((token) => token.name)).toEqual(["a"]);
+  });
+
+  it("leaves a token in place when resolve declines it", () => {
+    expect(replaceTokens("x='@a' y='@b'", (name) => (name === "a" ? "1" : undefined))).toBe("x='1' y='@b'");
+  });
+});
+
+describe("write-back", () => {
+  const csharp = detectQueries(CSHARP_PLUGIN, "csharp")[0];
+  const typescript = detectQueries(TYPESCRIPT_WEBRESOURCE, "typescript")[0];
+
+  it("reports no change when the XML is untouched, so the file is never dirtied", () => {
+    expect(computeWriteBack(csharp, csharp.xml)).toEqual({ ok: true, changed: false });
+    expect(computeWriteBack(typescript, typescript.xml)).toEqual({ ok: true, changed: false });
+  });
+
+  it("reports no change when only formatting differs", () => {
+    const reserialized = serializeFetchXml(csharp.root, { indent: "  ", newline: "\n", quote: "'" });
+    expect(computeWriteBack(csharp, reserialized)).toEqual({ ok: true, changed: false });
+  });
+
+  it("writes an edited C# query back as an interpolated verbatim string with the original expression", () => {
+    const edited = csharp.xml.replace("top='50'", "top='10'");
+    const result = computeWriteBack(csharp, edited);
+    expect(result.ok && result.changed).toBe(true);
+    const text = (result as { text: string }).text;
+    expect(text.startsWith('$@"')).toBe(true);
+    expect(text).toContain("top='10'");
+    expect(text).toContain("{accountId}");
+    expect(text).not.toContain("@accountId");
+  });
+
+  it("writes an edited TS query back as a template literal keeping the call expression", () => {
+    const edited = typescript.xml.replace("top='50'", "top='5'");
+    const result = computeWriteBack(typescript, edited);
+    const text = (result as { text: string }).text;
+    expect(text.startsWith("`")).toBe(true);
+    expect(text).toContain("${since.toISOString()}");
+    expect(text).toContain("top='5'");
+  });
+
+  it("substituting the written text back into the file yields code the scanner reads identically", () => {
+    const edited = csharp.xml.replace("top='50'", "top='25'");
+    const result = computeWriteBack(csharp, edited) as { text: string };
+    const updated = CSHARP_PLUGIN.slice(0, csharp.start) + result.text + CSHARP_PLUGIN.slice(csharp.end);
+    const requeried = detectQueries(updated, "csharp");
+    expect(requeried).toHaveLength(1);
+    expect(requeried[0].xml).toBe(edited);
+    expect(requeried[0].tokens).toEqual(csharp.tokens);
+  });
+
+  it("refuses malformed XML rather than writing it", () => {
+    const result = computeWriteBack(csharp, "<fetch><entity></fetch>");
+    expect(result.ok).toBe(false);
+  });
+
+  it("refuses to write a raw string literal", () => {
+    const raw = detectQueries('var x = """\n    <fetch><entity name=\'a\' /></fetch>\n    """;', "csharp")[0];
+    expect(raw.writable).toBe(false);
+    const result = computeWriteBack(raw, raw.xml.replace("'a'", "'b'"));
+    expect(result.ok).toBe(false);
+    expect(!result.ok && result.reason).toContain("read-only");
+  });
+
+  it("adds a new parameter as an interpolation, upgrading the literal form", () => {
+    const plain = detectQueries(`var x = @"<fetch><entity name='account'><filter><condition attribute='name' operator='eq' value='x' /></filter></entity></fetch>";`, "csharp")[0];
+    const result = computeWriteBack(plain, plain.xml.replace("value='x'", "value='@wanted'")) as { text: string };
+    expect(result.text.startsWith('$@"')).toBe(true);
+    expect(result.text).toContain("{wanted}");
+  });
+
+  it("escapes a quote that appears in an edited value", () => {
+    const plain = detectQueries(`var x = @"<fetch><entity name='account'><filter><condition attribute='name' operator='eq' value='x' /></filter></entity></fetch>";`, "csharp")[0];
+    const result = computeWriteBack(plain, plain.xml.replace(`value='x'`, `value="O&apos;Brien"`)) as { text: string };
+    // A verbatim string doubles its quotes; re-reading must give back exactly one.
+    expect(result.text).toContain(`value=""O&apos;Brien""`);
+    const reread = detectQueries(`var x = ${result.text};`, "csharp")[0];
+    expect(reread.root.children[0].children[0].children[0].attrs.value).toBe("O'Brien");
+  });
+});
+
+describe("insertion of a new query", () => {
+  it("emits a C# verbatim string indented to the cursor", () => {
+    const xml = "<fetch>\n  <entity name='account' />\n</fetch>";
+    expect(buildInsertion(xml, "csharp", "    ")).toBe(`@"<fetch>\n      <entity name='account' />\n    </fetch>"`);
+  });
+
+  it("emits a TS template literal", () => {
+    expect(buildInsertion("<fetch />", "typescript")).toBe("`<fetch />`");
+  });
+
+  it("round-trips through detection", () => {
+    const literal = buildInsertion("<fetch>\n  <entity name='account' />\n</fetch>", "csharp");
+    expect(detectQueries(`var q = ${literal};`, "csharp")).toHaveLength(1);
+  });
+});
+
+describe("minified length, as the URL check sees it", () => {
+  it("collapses whitespace so the estimate reflects what is sent", () => {
+    const query = detectQueries(CSHARP_PLUGIN, "csharp")[0];
+    expect(minifyFetchXml(query.root).length).toBeLessThan(query.xml.length);
+  });
+});

--- a/src/query/detect.ts
+++ b/src/query/detect.ts
@@ -1,0 +1,87 @@
+// Find the FetchXML in a source file (#238) — the entry point the CodeLens provider calls.
+//
+// Chains together the pure pieces: scan the file for string literals and `+` chains, keep the ones
+// that look like a query, swap interpolations for `@token` placeholders, and parse. A span is only
+// reported when the result parses with a `<fetch>` or `<filter>` root, which is what keeps
+// StringBuilder fragments, embedded XML payloads and passing mentions of "<fetch" out.
+//
+// Pure (no `vscode`) → unit-tested.
+
+import { Consumer, detectConsumer } from "./consumers";
+import { HoleToken, tokenizeParts } from "./holes";
+import { CodeString, Language, LiteralForm, StringPart, partsText, scanLanguage } from "./literals";
+import { ParseResult, parseFetchXml } from "./fetchXml";
+import { QueryNode } from "./queryModel";
+
+/** Cheap whole-file gate: no `<fetch`/`<filter` anywhere means no work to do. */
+const CANDIDATE_PATTERN = /<\s*(fetch|filter)[\s>/]/i;
+
+export interface DetectedQuery {
+  /** Offsets of the span to replace on write-back — the whole literal or concatenation chain. */
+  start: number;
+  end: number;
+  language: Language;
+  form: LiteralForm;
+  /** False when the span can't be faithfully re-emitted; the generator opens read-only. */
+  writable: boolean;
+  /** The query with interpolations replaced by `@token` placeholders. */
+  xml: string;
+  tokens: HoleToken[];
+  root: QueryNode;
+  consumer: Consumer;
+  /** The original code parts, kept so a no-op save can be recognised. */
+  parts: StringPart[];
+}
+
+function isCandidate(text: string): boolean {
+  return CANDIDATE_PATTERN.test(text);
+}
+
+/** Every FetchXML query in the source, in document order. */
+export function detectQueries(source: string, language: Language): DetectedQuery[] {
+  if (!isCandidate(source)) {
+    return [];
+  }
+
+  const detected: DetectedQuery[] = [];
+  for (const found of scanLanguage(source, language)) {
+    const query = toQuery(source, found, language);
+    if (query) {
+      detected.push(query);
+    }
+  }
+  return detected;
+}
+
+function toQuery(source: string, found: CodeString, language: Language): DetectedQuery | undefined {
+  if (!isCandidate(partsText(found.parts))) {
+    return undefined;
+  }
+  const { xml, tokens } = tokenizeParts(found.parts);
+  const parsed = parseFetchXml(xml);
+  if (!parsed.ok) {
+    return undefined;
+  }
+  return {
+    start: found.start,
+    end: found.end,
+    language,
+    form: found.form,
+    writable: found.writable,
+    xml,
+    tokens,
+    root: parsed.root,
+    consumer: detectConsumer(source, found.start, found.end, language),
+    parts: found.parts,
+  };
+}
+
+/** The query containing `offset`, or the first one after it — what "at the cursor" means. */
+export function queryAtOffset(queries: readonly DetectedQuery[], offset: number): DetectedQuery | undefined {
+  return queries.find((query) => offset >= query.start && offset <= query.end) ?? queries.find((query) => query.start >= offset);
+}
+
+/** Re-parse a candidate query string, exposed so callers can validate edited XML the same way. */
+export function reparse(xml: string): ParseResult {
+  return parseFetchXml(xml);
+}

--- a/src/query/diagnostics.ts
+++ b/src/query/diagnostics.ts
@@ -1,0 +1,178 @@
+// FetchXML diagnostics (#238).
+//
+// These pay off with no generator involved at all: they are checks on code the user already wrote.
+// The two that matter most are the ones nobody notices by reading:
+//
+//   * an unescaped value interpolated straight into an XML attribute — every codebase has these,
+//     and they break on an apostrophe long before anyone calls it an injection;
+//   * a local-time date compared against a Dataverse date column, which is always UTC, so the query
+//     silently returns the wrong rows by however many hours the user's offset is.
+//
+// Pure (no `vscode`) → unit-tested. The VS Code layer maps these onto Diagnostic objects and, for
+// the escaping one, a quick fix.
+
+import { Consumer, URL_BOUND_XML_LIMIT } from "./consumers";
+import { minifyFetchXml } from "./fetchXml";
+import { Language } from "./literals";
+import { MetadataLookup } from "./metadata/cache";
+import { ParameterType, QueryParameter, inferParameterType } from "./parameters";
+import { QueryNode, attrBool, walk } from "./queryModel";
+
+export type DiagnosticSeverity = "error" | "warning" | "info";
+
+export interface QueryDiagnostic {
+  code: string;
+  severity: DiagnosticSeverity;
+  message: string;
+  /** The code expression at fault, when the finding is about one — drives the quick fix. */
+  expression?: string;
+}
+
+export interface DiagnoseOptions {
+  root: QueryNode;
+  consumer: Consumer;
+  language: Language;
+  parameters: readonly QueryParameter[];
+  metadata?: MetadataLookup;
+}
+
+/** Helpers that make a value safe to interpolate. Wrapping in any of these clears the warning. */
+const ESCAPE_HELPERS: Record<Language, readonly string[]> = {
+  csharp: ["SecurityElement.Escape", "XmlConvert", "EscapeXml", "Escape(", "HtmlEncode", "XmlEscape"],
+  typescript: ["escapeXml", "escapeXmlValue", "xmlEscape", "escapeFetchXmlValue"],
+};
+
+/** Expressions that produce a LOCAL time. Compared against a UTC column, they are quietly wrong. */
+const LOCAL_TIME_PATTERNS = [/\bDateTime\.Now\b/, /\bDateTime\.Today\b/, /\bDateTimeOffset\.Now\b/];
+
+/** Types that cannot carry an injection or a broken quote, so they need no escaping. */
+const SAFE_TYPES: ReadonlySet<ParameterType> = new Set<ParameterType>(["guid", "number", "boolean", "datetime"]);
+
+function isEscaped(expression: string, language: Language): boolean {
+  return ESCAPE_HELPERS[language].some((helper) => expression.includes(helper));
+}
+
+export function diagnoseQuery(options: DiagnoseOptions): QueryDiagnostic[] {
+  const { root, consumer, language, parameters, metadata } = options;
+  const found: QueryDiagnostic[] = [];
+
+  // --- consumer capability ------------------------------------------------------------------
+  if (root.tag !== consumer.expects) {
+    found.push({
+      code: "wrongRoot",
+      severity: "error",
+      message:
+        consumer.expects === "filter"
+          ? `${consumer.label} takes a bare <filter> fragment, but this is a <${root.tag}>. Columns, orders, top and joins are ignored there.`
+          : `${consumer.label} expects a <fetch> query, but this is a <${root.tag}>.`,
+    });
+  }
+
+  const aggregate = attrBool(root, "aggregate");
+  if (aggregate && consumer.rejectsAggregate) {
+    found.push({ code: "aggregateRejected", severity: "error", message: `${consumer.label} does not accept an aggregate query.` });
+  }
+
+  if (consumer.urlBound && root.tag === "fetch") {
+    const length = minifyFetchXml(root).length;
+    if (length > URL_BOUND_XML_LIMIT) {
+      found.push({
+        code: "urlTooLong",
+        severity: "warning",
+        message: `This query is ${length} characters; ${consumer.label} sends it in a URL, where it will likely exceed the request-line limit once encoded. Trim columns or move the work server-side.`,
+      });
+    }
+  }
+
+  // --- parameters --------------------------------------------------------------------------
+  for (const parameter of parameters) {
+    if (parameter.expression === undefined) {
+      continue;
+    }
+    const type = inferParameterType(parameter, metadata);
+    if (!SAFE_TYPES.has(type) && !isEscaped(parameter.expression, language)) {
+      found.push({
+        code: "unescapedValue",
+        severity: "warning",
+        message: `\`${parameter.expression}\` is interpolated into an XML attribute without escaping. A value containing & or ' will break the query.`,
+        expression: parameter.expression,
+      });
+    }
+    if (type === "datetime" || parameter.usages.some((usage) => usage.operator && ["on", "on-or-before", "on-or-after"].includes(usage.operator))) {
+      const local =
+        language === "csharp"
+          ? LOCAL_TIME_PATTERNS.some((pattern) => pattern.test(parameter.expression as string))
+          : /new Date\(/.test(parameter.expression) && !/toISOString/.test(parameter.expression);
+      if (local) {
+        found.push({
+          code: "localTime",
+          severity: "warning",
+          message: `\`${parameter.expression}\` is local time, but Dataverse compares dates in UTC — this returns the wrong rows by your UTC offset. Use ${
+            language === "csharp" ? "DateTime.UtcNow" : ".toISOString()"
+          }.`,
+          expression: parameter.expression,
+        });
+      }
+    }
+  }
+
+  // --- shape ------------------------------------------------------------------------------
+  if (root.tag === "fetch") {
+    if (root.attrs.top !== undefined && (root.attrs.page !== undefined || root.attrs.count !== undefined)) {
+      found.push({ code: "topWithPaging", severity: "warning", message: "`top` cannot be combined with `page`/`count` — Dataverse rejects the query. Use one or the other." });
+    }
+
+    walk(root, (node, parents) => {
+      if (node.tag === "attribute") {
+        if (node.attrs.aggregate !== undefined && node.attrs.alias === undefined) {
+          found.push({
+            code: "aggregateNeedsAlias",
+            severity: "error",
+            message: `An aggregate attribute needs an alias (\`${node.attrs.aggregate}\` on \`${node.attrs.name ?? "?"}\`).`,
+          });
+        }
+        if (aggregate && node.attrs.aggregate === undefined && !attrBool(node, "groupby")) {
+          found.push({
+            code: "aggregateNeedsGroupBy",
+            severity: "warning",
+            message: `In an aggregate query every attribute must aggregate or group — \`${node.attrs.name ?? "?"}\` does neither.`,
+          });
+        }
+      }
+
+      if (node.tag === "all-attributes") {
+        found.push({ code: "allAttributes", severity: "info", message: "`<all-attributes />` returns every column on every row. Select only the columns you use." });
+      }
+
+      if (node.tag === "entity" || node.tag === "link-entity") {
+        const entity = node.attrs.name;
+        if (entity !== undefined && !entity.startsWith("@") && metadata?.knownEntity(entity) === false) {
+          found.push({ code: "unknownEntity", severity: "warning", message: `No table \`${entity}\` in this environment.` });
+        }
+        const selectsNothing = !node.children.some((child) => child.tag === "attribute" || child.tag === "all-attributes");
+        if (selectsNothing && node.tag === "entity" && !aggregate) {
+          found.push({ code: "noColumns", severity: "info", message: "No <attribute> elements, so this returns only the primary key." });
+        }
+      }
+
+      if (node.tag === "condition" || node.tag === "attribute" || node.tag === "order") {
+        const attribute = node.attrs.attribute ?? node.attrs.name;
+        const entity = node.attrs.entityname ?? nearestEntity(parents);
+        if (attribute !== undefined && entity !== undefined && !attribute.startsWith("@") && metadata?.knownAttribute(entity, attribute) === false) {
+          found.push({ code: "unknownAttribute", severity: "warning", message: `No column \`${attribute}\` on \`${entity}\`.` });
+        }
+      }
+    });
+  }
+
+  return found;
+}
+
+function nearestEntity(parents: readonly QueryNode[]): string | undefined {
+  for (let i = parents.length - 1; i >= 0; i--) {
+    if (parents[i].tag === "entity" || parents[i].tag === "link-entity") {
+      return parents[i].attrs.name;
+    }
+  }
+  return undefined;
+}

--- a/src/query/edits.spec.ts
+++ b/src/query/edits.spec.ts
@@ -1,0 +1,283 @@
+import { describe, it, expect } from "vitest";
+import { applyEdit, applyEdits, newFilterFragment, newQuery, nodeAt } from "./edits";
+import { ALL_OPERATORS, VALUELESS_OPERATORS, addableFor, buildState, fieldsFor, labelFor, scopeEntity } from "./generatorState";
+import { DEFAULT_FORMAT, parseFetchXml, serializeFetchXml } from "./fetchXml";
+import { QueryNode } from "./queryModel";
+
+function rootOf(xml: string): QueryNode {
+  const parsed = parseFetchXml(xml);
+  if (!parsed.ok) {
+    throw new Error(parsed.error);
+  }
+  return parsed.root;
+}
+
+const QUERY = rootOf(`<fetch top="50">
+  <entity name="account">
+    <attribute name="name" />
+    <filter type="and">
+      <condition attribute="statecode" operator="eq" value="0" />
+    </filter>
+  </entity>
+</fetch>`);
+
+describe("node paths", () => {
+  it("resolves the root and nested nodes", () => {
+    expect(nodeAt(QUERY, [])?.tag).toBe("fetch");
+    expect(nodeAt(QUERY, [0])?.tag).toBe("entity");
+    expect(nodeAt(QUERY, [0, 1, 0])?.tag).toBe("condition");
+    expect(nodeAt(QUERY, [0, 9])).toBeUndefined();
+  });
+});
+
+describe("applying edits", () => {
+  it("never mutates the input tree", () => {
+    const before = serializeFetchXml(QUERY, DEFAULT_FORMAT);
+    applyEdit(QUERY, { kind: "setAttr", path: [], name: "top", value: "5" });
+    expect(serializeFetchXml(QUERY, DEFAULT_FORMAT)).toBe(before);
+  });
+
+  it("sets an attribute and selects the edited node", () => {
+    const result = applyEdit(QUERY, { kind: "setAttr", path: [0, 1, 0], name: "value", value: "1" });
+    expect(nodeAt(result!.root, [0, 1, 0])?.attrs.value).toBe("1");
+    expect(result!.selection).toEqual([0, 1, 0]);
+  });
+
+  it("clearing a field removes the attribute rather than writing an empty one", () => {
+    const result = applyEdit(QUERY, { kind: "setAttr", path: [], name: "top", value: "" });
+    expect(nodeAt(result!.root, [])?.attrs.top).toBeUndefined();
+    expect(serializeFetchXml(result!.root, DEFAULT_FORMAT)).not.toContain("top");
+  });
+
+  it("adds a child and selects it", () => {
+    const result = applyEdit(QUERY, { kind: "addChild", path: [0, 1], tag: "condition", attrs: { operator: "eq" } });
+    expect(result!.selection).toEqual([0, 1, 1]);
+    expect(nodeAt(result!.root, [0, 1, 1])?.attrs.operator).toBe("eq");
+  });
+
+  it("adds a <value> with text, as an in condition needs", () => {
+    const result = applyEdit(QUERY, { kind: "addChild", path: [0, 1, 0], tag: "value", text: "2" });
+    expect(nodeAt(result!.root, [0, 1, 0, 0])?.text).toBe("2");
+    expect(serializeFetchXml(result!.root, DEFAULT_FORMAT)).toContain("<value>2</value>");
+  });
+
+  it("removes a node and selects its neighbour", () => {
+    const twoAttributes = applyEdit(QUERY, { kind: "addChild", path: [0], tag: "attribute", attrs: { name: "accountnumber" } })!.root;
+    const result = applyEdit(twoAttributes, { kind: "remove", path: [0, 0] });
+    expect(nodeAt(result!.root, [0, 0])?.tag).toBe("filter");
+    expect(result!.selection).toEqual([0, 0]);
+  });
+
+  it("selects the parent when the last child is removed", () => {
+    const result = applyEdit(QUERY, { kind: "remove", path: [0, 1, 0] });
+    expect(result!.selection).toEqual([0, 1]);
+  });
+
+  it("refuses to remove or move the root", () => {
+    expect(applyEdit(QUERY, { kind: "remove", path: [] })).toBeUndefined();
+    expect(applyEdit(QUERY, { kind: "move", path: [], offset: 1 })).toBeUndefined();
+  });
+
+  it("moves a node within its parent and refuses to move past the ends", () => {
+    const moved = applyEdit(QUERY, { kind: "move", path: [0, 0], offset: 1 });
+    expect(nodeAt(moved!.root, [0, 0])?.tag).toBe("filter");
+    expect(nodeAt(moved!.root, [0, 1])?.tag).toBe("attribute");
+    expect(moved!.selection).toEqual([0, 1]);
+    expect(applyEdit(QUERY, { kind: "move", path: [0, 0], offset: -1 })).toBeUndefined();
+  });
+
+  it("sets text on a value node", () => {
+    const withValue = applyEdit(QUERY, { kind: "addChild", path: [0, 1, 0], tag: "value", text: "1" })!.root;
+    const result = applyEdit(withValue, { kind: "setText", path: [0, 1, 0, 0], text: "9" });
+    expect(nodeAt(result!.root, [0, 1, 0, 0])?.text).toBe("9");
+  });
+
+  it("ignores an edit addressing a node that isn't there", () => {
+    expect(applyEdit(QUERY, { kind: "setAttr", path: [7], name: "x", value: "1" })).toBeUndefined();
+  });
+
+  it("applies a run of edits and stops at the first that fails", () => {
+    const result = applyEdits(QUERY, [
+      { kind: "setAttr", path: [], name: "top", value: "3" },
+      { kind: "setAttr", path: [99], name: "x", value: "1" },
+      { kind: "setAttr", path: [], name: "distinct", value: "true" },
+    ]);
+    expect(result.root.attrs.top).toBe("3");
+    expect(result.root.attrs.distinct).toBeUndefined();
+  });
+});
+
+describe("starting points", () => {
+  it("builds a valid new query", () => {
+    const xml = serializeFetchXml(newQuery(), DEFAULT_FORMAT);
+    expect(parseFetchXml(xml).ok).toBe(true);
+    expect(xml).toContain('<entity name="account">');
+  });
+
+  it("builds a valid filter fragment for the lookup consumers", () => {
+    const root = newFilterFragment();
+    expect(root.tag).toBe("filter");
+    expect(parseFetchXml(serializeFetchXml(root, DEFAULT_FORMAT)).ok).toBe(true);
+  });
+});
+
+describe("tree labels", () => {
+  it("reads like the query, not like XML", () => {
+    expect(labelFor(rootOf(`<fetch top="50" distinct="true" />`))).toBe("top 50 · distinct");
+    expect(labelFor(nodeAt(QUERY, [0])!)).toBe("account");
+    expect(labelFor(nodeAt(QUERY, [0, 0])!)).toBe("name");
+    expect(labelFor(nodeAt(QUERY, [0, 1])!)).toBe("AND");
+    expect(labelFor(nodeAt(QUERY, [0, 1, 0])!)).toBe("statecode eq 0");
+  });
+
+  it("shows an aggregate with its alias", () => {
+    expect(labelFor(rootOf(`<fetch><entity name="a"><attribute name="accountid" aggregate="count" alias="n" /></entity></fetch>`).children[0].children[0])).toBe(
+      "count(accountid) as n",
+    );
+  });
+
+  it("omits the value for an operator that takes none", () => {
+    expect(labelFor(rootOf(`<fetch><entity name="a"><filter><condition attribute="name" operator="null" /></filter></entity></fetch>`).children[0].children[0].children[0])).toBe(
+      "name null",
+    );
+  });
+
+  it("lists the values of an in condition", () => {
+    const condition = rootOf(
+      `<fetch><entity name="a"><filter><condition attribute="statecode" operator="in"><value>0</value><value>1</value></condition></filter></entity></fetch>`,
+    ).children[0].children[0].children[0];
+    expect(labelFor(condition)).toBe("statecode in 0, 1");
+  });
+
+  it("shows a join with its direction and alias", () => {
+    const link = rootOf(`<fetch><entity name="account"><link-entity name="contact" from="parentcustomerid" to="accountid" alias="c" link-type="outer" /></entity></fetch>`)
+      .children[0].children[0];
+    expect(labelFor(link)).toBe("contact as c (outer: parentcustomerid → accountid)");
+  });
+
+  it("labels a condition qualified by a link-entity alias", () => {
+    const condition = rootOf(`<fetch><entity name="a"><filter><condition entityname="c" attribute="fullname" operator="eq" value="x" /></filter></entity></fetch>`).children[0]
+      .children[0].children[0];
+    expect(labelFor(condition)).toBe("c.fullname eq x");
+  });
+});
+
+describe("field and child descriptors", () => {
+  it("offers the operators a condition needs, grouped", () => {
+    expect(ALL_OPERATORS).toContain("eq");
+    expect(ALL_OPERATORS).toContain("last-x-days");
+    expect(ALL_OPERATORS).toContain("under");
+    expect(new Set(ALL_OPERATORS).size).toBe(ALL_OPERATORS.length);
+  });
+
+  it("knows which operators take no value", () => {
+    expect(VALUELESS_OPERATORS.has("null")).toBe(true);
+    expect(VALUELESS_OPERATORS.has("eq-userid")).toBe(true);
+    expect(VALUELESS_OPERATORS.has("eq")).toBe(false);
+  });
+
+  it("offers children appropriate to each element", () => {
+    expect(addableFor("entity")).toContain("link-entity");
+    expect(addableFor("filter")).toEqual(["condition", "filter"]);
+    expect(addableFor("attribute")).toEqual([]);
+    expect(addableFor("nonsense")).toEqual([]);
+  });
+
+  it("describes a condition's fields with a parameter hint", () => {
+    const value = fieldsFor("condition").find((field) => field.name === "value");
+    expect(value?.hint).toContain("@name");
+  });
+});
+
+describe("scope resolution for the column picker", () => {
+  it("uses the nearest enclosing table", () => {
+    const withLink = rootOf(
+      `<fetch><entity name="account"><link-entity name="contact" from="parentcustomerid" to="accountid"><attribute name="fullname" /></link-entity></entity></fetch>`,
+    );
+    expect(scopeEntity(withLink, [0, 0, 0])).toBe("contact");
+    expect(scopeEntity(withLink, [0])).toBe("account");
+    expect(scopeEntity(withLink, [])).toBeUndefined();
+  });
+});
+
+describe("assembling generator state", () => {
+  const state = buildState({
+    root: QUERY,
+    format: DEFAULT_FORMAT,
+    selection: [0, 1, 0],
+    diagnostics: [],
+    parameters: [],
+    readOnly: false,
+    consumerLabel: "FetchExpression (SDK)",
+    title: "Plugin.cs",
+    dirty: false,
+  });
+
+  it("flattens the tree with depth and paths", () => {
+    expect(state.tree.map((row) => [row.depth, row.tag])).toEqual([
+      [0, "fetch"],
+      [1, "entity"],
+      [2, "attribute"],
+      [2, "filter"],
+      [3, "condition"],
+    ]);
+  });
+
+  it("exposes the selected node's fields with current values", () => {
+    expect(state.selectedTag).toBe("condition");
+    expect(state.fields.find((field) => field.descriptor.name === "operator")?.value).toBe("eq");
+    expect(state.canRemove).toBe(true);
+  });
+
+  it("serializes the XML for the preview", () => {
+    expect(state.xml).toContain('<condition attribute="statecode" operator="eq" value="0" />');
+  });
+
+  it("falls back to the root when the selection no longer resolves", () => {
+    const orphaned = buildState({
+      root: QUERY,
+      format: DEFAULT_FORMAT,
+      selection: [5, 5],
+      diagnostics: [],
+      parameters: [],
+      readOnly: false,
+      consumerLabel: "x",
+      title: "y",
+      dirty: false,
+    });
+    expect(orphaned.selection).toEqual([]);
+    expect(orphaned.selectedTag).toBe("fetch");
+    expect(orphaned.canRemove).toBe(false);
+  });
+
+  it("surfaces attributes the generator has no field for, so nothing looks lost", () => {
+    const exotic = buildState({
+      root: rootOf(`<fetch latematerialize="true"><entity name="account" /></fetch>`),
+      format: DEFAULT_FORMAT,
+      selection: [],
+      diagnostics: [],
+      parameters: [],
+      readOnly: false,
+      consumerLabel: "x",
+      title: "y",
+      dirty: false,
+    });
+    expect(exotic.otherAttributes).toEqual([{ name: "latematerialize", value: "true" }]);
+  });
+
+  it("marks a comment node read-only so the generator won't try to edit it", () => {
+    const withComment = buildState({
+      root: rootOf(`<fetch><!-- note --><entity name="account" /></fetch>`),
+      format: DEFAULT_FORMAT,
+      selection: [0],
+      diagnostics: [],
+      parameters: [],
+      readOnly: false,
+      consumerLabel: "x",
+      title: "y",
+      dirty: false,
+    });
+    expect(withComment.tree[1].readOnly).toBe(true);
+    expect(withComment.tree[1].label).toBe("comment: note");
+  });
+});

--- a/src/query/edits.ts
+++ b/src/query/edits.ts
@@ -1,0 +1,114 @@
+// Structural edits to a query, addressed by node path (#238).
+//
+// The generator webview never owns the model: it sends an INTENT ("set this attribute", "add a
+// condition here") and the host applies it and sends fresh state back. That keeps one source of
+// truth, keeps the webview dumb, and — the reason it is worth doing — makes every edit a pure
+// function over the model, so the whole generator's behaviour is unit-testable without a webview.
+//
+// A path is the list of child indices from the root: [] is the root, [0] its first child.
+//
+// Pure (no `vscode`) → unit-tested.
+
+import { Attrs, QueryNode, cloneNode, makeNode } from "./queryModel";
+
+export type QueryEdit =
+  | { kind: "setAttr"; path: number[]; name: string; value?: string }
+  | { kind: "addChild"; path: number[]; tag: string; attrs?: Attrs; text?: string }
+  | { kind: "remove"; path: number[] }
+  | { kind: "setText"; path: number[]; text: string }
+  | { kind: "move"; path: number[]; offset: number };
+
+export interface EditResult {
+  root: QueryNode;
+  /** Where the selection should land afterwards — the added node, or the removed node's neighbour. */
+  selection: number[];
+}
+
+/** Resolve a path against a tree, or undefined when it doesn't address a node. */
+export function nodeAt(root: QueryNode, path: readonly number[]): QueryNode | undefined {
+  let node: QueryNode | undefined = root;
+  for (const index of path) {
+    node = node?.children[index];
+  }
+  return node;
+}
+
+/** Apply an edit to a COPY of the tree; returns undefined when the edit doesn't apply. */
+export function applyEdit(root: QueryNode, edit: QueryEdit): EditResult | undefined {
+  const next = cloneNode(root);
+
+  if (edit.kind === "remove" || edit.kind === "move") {
+    if (edit.path.length === 0) {
+      return undefined; // the root is not removable or movable
+    }
+    const parent = nodeAt(next, edit.path.slice(0, -1));
+    const index = edit.path[edit.path.length - 1];
+    if (!parent || parent.children[index] === undefined) {
+      return undefined;
+    }
+    if (edit.kind === "remove") {
+      parent.children.splice(index, 1);
+      const neighbour = Math.min(index, parent.children.length - 1);
+      return { root: next, selection: neighbour < 0 ? edit.path.slice(0, -1) : [...edit.path.slice(0, -1), neighbour] };
+    }
+    const target = index + edit.offset;
+    if (target < 0 || target >= parent.children.length) {
+      return undefined;
+    }
+    const [moved] = parent.children.splice(index, 1);
+    parent.children.splice(target, 0, moved);
+    return { root: next, selection: [...edit.path.slice(0, -1), target] };
+  }
+
+  const node = nodeAt(next, edit.path);
+  if (!node) {
+    return undefined;
+  }
+
+  switch (edit.kind) {
+    case "setAttr": {
+      // An empty value removes the attribute rather than writing `name=""` — the generator's text
+      // boxes are cleared to mean "not set", and a stray empty attribute changes query semantics.
+      if (edit.value === undefined || edit.value === "") {
+        delete node.attrs[edit.name];
+      } else {
+        node.attrs[edit.name] = edit.value;
+      }
+      return { root: next, selection: [...edit.path] };
+    }
+    case "addChild": {
+      node.children.push(makeNode(edit.tag, { ...(edit.attrs ?? {}) }, []));
+      if (edit.text !== undefined) {
+        node.children[node.children.length - 1].text = edit.text;
+      }
+      return { root: next, selection: [...edit.path, node.children.length - 1] };
+    }
+    case "setText": {
+      node.text = edit.text;
+      return { root: next, selection: [...edit.path] };
+    }
+  }
+}
+
+/** Apply a run of edits, stopping at the first that doesn't apply. */
+export function applyEdits(root: QueryNode, edits: readonly QueryEdit[]): EditResult {
+  let current: EditResult = { root, selection: [] };
+  for (const edit of edits) {
+    const applied = applyEdit(current.root, edit);
+    if (!applied) {
+      break;
+    }
+    current = applied;
+  }
+  return current;
+}
+
+/** A minimal, valid starting query for "new FetchXML query". */
+export function newQuery(entity = "account", primaryName = "name"): QueryNode {
+  return makeNode("fetch", { top: "50" }, [makeNode("entity", { name: entity }, [makeNode("attribute", { name: primaryName })])]);
+}
+
+/** A minimal `<filter>` fragment, for the lookup-filter consumers. */
+export function newFilterFragment(): QueryNode {
+  return makeNode("filter", { type: "and" }, [makeNode("condition", { attribute: "statecode", operator: "eq", value: "0" })]);
+}

--- a/src/query/fetchXml.spec.ts
+++ b/src/query/fetchXml.spec.ts
@@ -1,0 +1,162 @@
+import { describe, it, expect } from "vitest";
+import { parseFetchXml, serializeFetchXml, minifyFetchXml, detectFormat, escapeXmlAttribute, DEFAULT_FORMAT } from "./fetchXml";
+import { attrBool, entityScopes, isAggregate, nodesEqual, queryEntity, cloneNode } from "./queryModel";
+
+/** Parse and re-serialize with the source's own detected formatting. */
+function roundTrip(xml: string): string {
+  const parsed = parseFetchXml(xml);
+  if (!parsed.ok) {
+    throw new Error(parsed.error);
+  }
+  return serializeFetchXml(parsed.root, parsed.format);
+}
+
+const FULL = `<fetch top="50" distinct="true">
+  <entity name="account">
+    <attribute name="name" alias="n" />
+    <order attribute="name" descending="true" />
+    <filter type="and">
+      <condition attribute="statecode" operator="eq" value="0" />
+      <filter type="or">
+        <condition attribute="name" operator="like" value="%a&amp;b%" />
+        <condition attribute="accountid" operator="in">
+          <value>1</value>
+          <value>2</value>
+        </condition>
+      </filter>
+    </filter>
+    <link-entity name="contact" from="parentcustomerid" to="accountid" alias="c" link-type="outer">
+      <attribute name="fullname" />
+    </link-entity>
+  </entity>
+</fetch>`;
+
+describe("parse / serialize round trip", () => {
+  it("reproduces a full query byte-for-byte", () => {
+    expect(roundTrip(FULL)).toBe(FULL);
+  });
+
+  it("reproduces a single-line query on one line", () => {
+    const xml = `<fetch><entity name="account"><attribute name="name" /></entity></fetch>`;
+    expect(roundTrip(xml)).toBe(xml);
+  });
+
+  it("preserves single-quoted attributes, the style used inside code literals", () => {
+    const xml = `<fetch><entity name='account'><attribute name='name' /></entity></fetch>`;
+    expect(roundTrip(xml)).toBe(xml);
+  });
+
+  it("preserves a bare <filter> fragment root", () => {
+    const xml = `<filter type="and">\n  <condition attribute="statecode" operator="eq" value="0" />\n</filter>`;
+    const parsed = parseFetchXml(xml);
+    expect(parsed.ok && parsed.root.tag).toBe("filter");
+    expect(roundTrip(xml)).toBe(xml);
+  });
+
+  it("preserves comments rather than silently deleting them", () => {
+    const xml = `<fetch>\n  <!-- only active -->\n  <entity name="account" />\n</fetch>`;
+    expect(roundTrip(xml)).toContain("<!-- only active -->");
+  });
+
+  it("preserves attributes the generator knows nothing about", () => {
+    const xml = `<fetch no-lock="true" latematerialize="true" useraworderby="1"><entity name="account" mystery="keep" /></fetch>`;
+    expect(roundTrip(xml)).toBe(xml);
+  });
+
+  it("preserves a boolean attribute written without a value", () => {
+    const parsed = parseFetchXml(`<fetch distinct><entity name="account" /></fetch>`);
+    expect(parsed.ok && serializeFetchXml(parsed.root, parsed.format)).toBe(`<fetch distinct><entity name="account" /></fetch>`);
+  });
+
+  it("round-trips escaped values without double-escaping", () => {
+    const xml = `<fetch><entity name="account"><filter><condition attribute="name" operator="eq" value="a &amp; b &lt; c" /></filter></entity></fetch>`;
+    expect(roundTrip(xml)).toBe(xml);
+    expect(roundTrip(roundTrip(xml))).toBe(xml);
+  });
+
+  it("keeps @token placeholders untouched — they must survive to be substituted back", () => {
+    const xml = `<fetch><entity name="account"><filter><condition attribute="accountid" operator="eq" value="@accountId" /></filter></entity></fetch>`;
+    expect(roundTrip(xml)).toBe(xml);
+  });
+});
+
+describe("parse failures", () => {
+  it("rejects empty input", () => {
+    expect(parseFetchXml("   ")).toEqual({ ok: false, error: "The query is empty." });
+  });
+
+  it("rejects a root that is not fetch or filter", () => {
+    const result = parseFetchXml(`<entity name="account" />`);
+    expect(result.ok).toBe(false);
+    expect(!result.ok && result.error).toContain("<entity>");
+  });
+
+  it("rejects mismatched tags", () => {
+    expect(parseFetchXml(`<fetch><entity name="account"></fetch>`).ok).toBe(false);
+  });
+});
+
+describe("format detection", () => {
+  it("detects tab indentation and CRLF", () => {
+    expect(detectFormat("<fetch>\r\n\t<entity name='a' />\r\n</fetch>")).toEqual({ indent: "\t", newline: "\r\n", quote: "'" });
+  });
+
+  it("defaults to double quotes when neither style dominates", () => {
+    expect(detectFormat("<fetch />").quote).toBe('"');
+  });
+});
+
+describe("accessors", () => {
+  const root = (parseFetchXml(FULL) as { root: import("./queryModel").QueryNode }).root;
+
+  it("finds the entity and its joins", () => {
+    expect(queryEntity(root)?.attrs.name).toBe("account");
+    expect(entityScopes(root).map((n) => n.attrs.name)).toEqual(["account", "contact"]);
+  });
+
+  it("reads booleans written either way", () => {
+    expect(attrBool(root, "distinct")).toBe(true);
+    expect(isAggregate(root)).toBe(false);
+    expect(attrBool((parseFetchXml(`<fetch aggregate="1" />`) as { root: import("./queryModel").QueryNode }).root, "aggregate")).toBe(true);
+  });
+});
+
+describe("structural comparison", () => {
+  const root = (parseFetchXml(FULL) as { root: import("./queryModel").QueryNode }).root;
+
+  it("treats a clone as equal and a changed value as different", () => {
+    const clone = cloneNode(root);
+    expect(nodesEqual(root, clone)).toBe(true);
+    clone.attrs.top = "51";
+    expect(nodesEqual(root, clone)).toBe(false);
+  });
+
+  it("ignores attribute order but not child order", () => {
+    const a = parseFetchXml(`<fetch top="1" distinct="true" />`);
+    const b = parseFetchXml(`<fetch distinct="true" top="1" />`);
+    expect(a.ok && b.ok && nodesEqual(a.root, b.root)).toBe(true);
+
+    const c = parseFetchXml(`<fetch><entity name="a" /><entity name="b" /></fetch>`);
+    const d = parseFetchXml(`<fetch><entity name="b" /><entity name="a" /></fetch>`);
+    expect(c.ok && d.ok && nodesEqual(c.root, d.root)).toBe(false);
+  });
+});
+
+describe("minify", () => {
+  it("collapses to one line for the ?fetchXml= URL path", () => {
+    expect(minifyFetchXml((parseFetchXml(FULL) as { root: import("./queryModel").QueryNode }).root)).toBe(
+      `<fetch top="50" distinct="true"><entity name="account"><attribute name="name" alias="n" /><order attribute="name" descending="true" /><filter type="and"><condition attribute="statecode" operator="eq" value="0" /><filter type="or"><condition attribute="name" operator="like" value="%a&amp;b%" /><condition attribute="accountid" operator="in"><value>1</value><value>2</value></condition></filter></filter><link-entity name="contact" from="parentcustomerid" to="accountid" alias="c" link-type="outer"><attribute name="fullname" /></link-entity></entity></fetch>`,
+    );
+  });
+});
+
+describe("attribute escaping", () => {
+  it("escapes only the delimiting quote", () => {
+    expect(escapeXmlAttribute(`he said "hi" & 'bye'`, '"')).toBe("he said &quot;hi&quot; &amp; 'bye'");
+    expect(escapeXmlAttribute(`he said "hi" & 'bye'`, "'")).toBe('he said "hi" &amp; &apos;bye&apos;');
+  });
+
+  it("uses the default format when none is given", () => {
+    expect(serializeFetchXml({ tag: "fetch", attrs: {}, children: [] }, DEFAULT_FORMAT)).toBe("<fetch />");
+  });
+});

--- a/src/query/fetchXml.ts
+++ b/src/query/fetchXml.ts
@@ -1,0 +1,202 @@
+// FetchXML parse ⇄ serialize (#238). The keystone of the feature: because the generator UI and the
+// user's source file are two views of one model, this round trip has to be faithful enough that
+// re-serializing an untouched query reproduces it.
+//
+// Parsing uses fast-xml-parser (already a dependency) in `preserveOrder` mode, which yields
+// [{ tag: [...children], ":@": { "@_attr": "value" } }]. Serializing is hand-rolled rather than
+// XMLBuilder so we control quoting, indentation and self-closing precisely — the output goes back
+// into someone's source file, so "close enough" formatting is a diff in their repo.
+//
+// Pure (no `vscode`) → unit-tested.
+
+import { XMLParser, XMLValidator } from "fast-xml-parser";
+import { Attrs, COMMENT_TAG, QueryNode, makeNode } from "./queryModel";
+
+const ATTR_PREFIX = "@_";
+const ATTR_KEY = ":@";
+const TEXT_KEY = "#text";
+
+/** Roots we accept: a whole query, or a bare `<filter>` — the shape lookup filters take. */
+const VALID_ROOTS = ["fetch", "filter"];
+
+export interface ParsedQuery {
+  ok: true;
+  root: QueryNode;
+  /** Formatting of the source text, so a re-serialize keeps the user's existing style. */
+  format: XmlFormat;
+}
+
+export interface ParseFailure {
+  ok: false;
+  error: string;
+}
+
+export type ParseResult = ParsedQuery | ParseFailure;
+
+export interface XmlFormat {
+  /** One indent level, e.g. "  ". Empty string means the source was on one line. */
+  indent: string;
+  newline: string;
+  quote: "'" | '"';
+}
+
+export const DEFAULT_FORMAT: XmlFormat = { indent: "  ", newline: "\n", quote: '"' };
+
+/**
+ * Infer the formatting of an existing FetchXML string so serializing it back preserves the
+ * author's style. Getting this right is what makes "open the generator, change one condition, save"
+ * produce a one-line diff instead of reformatting the whole query.
+ */
+export function detectFormat(xml: string): XmlFormat {
+  const newline = xml.includes("\r\n") ? "\r\n" : "\n";
+  // Attribute quoting: whichever style the source used more often wins. Single quotes are the
+  // norm inside C#/TS literals precisely because they need no escaping there.
+  const singles = (xml.match(/=\s*'/g) ?? []).length;
+  const doubles = (xml.match(/=\s*"/g) ?? []).length;
+  const quote: "'" | '"' = singles > doubles ? "'" : '"';
+  // Indent unit: the leading whitespace of the first indented child line.
+  const lines = xml.split(/\r?\n/);
+  let indent = lines.length > 1 ? "  " : "";
+  for (const line of lines.slice(1)) {
+    const match = /^([ \t]+)\S/.exec(line);
+    if (match) {
+      indent = match[1];
+      break;
+    }
+  }
+  return { indent, newline, quote };
+}
+
+function toNode(raw: Record<string, unknown>): QueryNode | undefined {
+  const tag = Object.keys(raw).find((key) => key !== ATTR_KEY);
+  if (tag === undefined) {
+    return undefined;
+  }
+  const rawAttrs = (raw[ATTR_KEY] ?? {}) as Record<string, unknown>;
+  const attrs: Attrs = {};
+  for (const [key, value] of Object.entries(rawAttrs)) {
+    // A boolean attribute (`<all-attributes />` style) parses to true; keep it as an empty string
+    // so serializing writes the bare name back rather than `="true"`.
+    attrs[key.startsWith(ATTR_PREFIX) ? key.slice(ATTR_PREFIX.length) : key] = value === true ? "" : String(value);
+  }
+
+  const node = makeNode(tag, attrs);
+  const rawChildren = raw[tag];
+  if (!Array.isArray(rawChildren)) {
+    return node;
+  }
+  for (const child of rawChildren as Record<string, unknown>[]) {
+    if (TEXT_KEY in child && Object.keys(child).length === 1) {
+      const text = String(child[TEXT_KEY]);
+      node.text = (node.text ?? "") + text;
+      continue;
+    }
+    const childNode = toNode(child);
+    if (childNode) {
+      // fast-xml-parser models a comment as a node whose only child is its text.
+      if (childNode.tag === COMMENT_TAG && childNode.text === undefined) {
+        childNode.text = "";
+      }
+      node.children.push(childNode);
+    }
+  }
+  return node;
+}
+
+/** Parse FetchXML (or a `<filter>` fragment) into the canonical model. */
+export function parseFetchXml(xml: string): ParseResult {
+  const trimmed = xml.trim();
+  if (trimmed.length === 0) {
+    return { ok: false, error: "The query is empty." };
+  }
+  // XMLParser is lenient — it happily accepts `<fetch><entity></fetch>`. Validate first, both so a
+  // typo in hand-written XML gets a real message and so the write-back self-check can rely on
+  // malformed text failing to parse.
+  const validation = XMLValidator.validate(trimmed, { allowBooleanAttributes: true });
+  if (validation !== true) {
+    const { msg, line, col } = validation.err;
+    return { ok: false, error: `${msg} (line ${line}, column ${col})` };
+  }
+
+  const parser = new XMLParser({
+    ignoreAttributes: false,
+    attributeNamePrefix: ATTR_PREFIX,
+    preserveOrder: true,
+    parseAttributeValue: false,
+    parseTagValue: false,
+    trimValues: true,
+    allowBooleanAttributes: true,
+    commentPropName: COMMENT_TAG,
+  });
+
+  let parsed: unknown;
+  try {
+    parsed = parser.parse(trimmed);
+  } catch (error) {
+    return { ok: false, error: (error as Error).message };
+  }
+
+  if (!Array.isArray(parsed)) {
+    return { ok: false, error: "The query is not valid XML." };
+  }
+  const elements = (parsed as Record<string, unknown>[]).map(toNode).filter((node): node is QueryNode => node !== undefined && node.tag !== COMMENT_TAG);
+  if (elements.length === 0) {
+    return { ok: false, error: "The query has no elements." };
+  }
+  const root = elements[0];
+  if (!VALID_ROOTS.includes(root.tag)) {
+    return { ok: false, error: `Expected a <fetch> or <filter> root, found <${root.tag}>.` };
+  }
+  return { ok: true, root, format: detectFormat(trimmed) };
+}
+
+/** Escape a value for an XML attribute delimited by `quote`. The other quote needs no escaping. */
+export function escapeXmlAttribute(value: string, quote: "'" | '"'): string {
+  const escaped = value.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;");
+  return quote === '"' ? escaped.replace(/"/g, "&quot;") : escaped.replace(/'/g, "&apos;");
+}
+
+export function escapeXmlText(value: string): string {
+  return value.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;");
+}
+
+function serializeNode(node: QueryNode, format: XmlFormat, depth: number, out: string[]): void {
+  const pad = format.indent.repeat(depth);
+  if (node.tag === COMMENT_TAG) {
+    out.push(`${pad}<!--${node.text ?? ""}-->`);
+    return;
+  }
+
+  const attrs = Object.entries(node.attrs)
+    .map(([name, value]) => (value === "" ? ` ${name}` : ` ${name}=${format.quote}${escapeXmlAttribute(value, format.quote)}${format.quote}`))
+    .join("");
+
+  const text = node.text ?? "";
+  if (node.children.length === 0 && text.length === 0) {
+    out.push(`${pad}<${node.tag}${attrs} />`);
+    return;
+  }
+  // A node with text and no elements (a `<value>`) stays on one line.
+  if (node.children.length === 0) {
+    out.push(`${pad}<${node.tag}${attrs}>${escapeXmlText(text)}</${node.tag}>`);
+    return;
+  }
+  out.push(`${pad}<${node.tag}${attrs}>`);
+  for (const child of node.children) {
+    serializeNode(child, format, depth + 1, out);
+  }
+  out.push(`${pad}</${node.tag}>`);
+}
+
+/** Serialize the model back to FetchXML. Pass the `format` from `parseFetchXml` to preserve style. */
+export function serializeFetchXml(root: QueryNode, format: XmlFormat = DEFAULT_FORMAT): string {
+  const out: string[] = [];
+  serializeNode(root, format, 0, out);
+  // An empty indent means the source was one line; join without newlines so it stays that way.
+  return format.indent === "" ? out.join("") : out.join(format.newline);
+}
+
+/** Single-line form, used where the query rides in a URL (`?fetchXml=`) and length matters. */
+export function minifyFetchXml(root: QueryNode, quote: "'" | '"' = '"'): string {
+  return serializeFetchXml(root, { indent: "", newline: "", quote });
+}

--- a/src/query/generatorPanel.ts
+++ b/src/query/generatorPanel.ts
@@ -1,0 +1,425 @@
+// The FetchXML Generator webview (#238).
+//
+// The host owns the model. The webview posts INTENTS (select a node, set a field, add a child) and
+// this file applies them with the pure functions in edits.ts, recomputes the view-model in
+// generatorState.ts, and posts fresh state back. That is what keeps the webview a renderer and the
+// generator's behaviour unit-testable.
+//
+// Saving goes through computeWriteBack, which refuses anything it cannot re-read identically, and
+// applies the change as a single WorkspaceEdit so it is one undo step.
+
+import * as path from "path";
+import * as vscode from "vscode";
+import DataversePowerToolsContext from "../context";
+import { GeneratorState, ParameterRow, buildState, defaultsFor, scopeEntity } from "./generatorState";
+import { DetectedQuery, detectQueries } from "./detect";
+import { QueryEdit, applyEdit, newQuery } from "./edits";
+import { DEFAULT_FORMAT, XmlFormat, detectFormat, parseFetchXml, serializeFetchXml } from "./fetchXml";
+import { allTokenNames } from "./holes";
+import { languageFor } from "./literals";
+import { getMetadataCache } from "./metadataService";
+import { QueryParameter, collectParameters, inferParameterType, normalizeParameterValue, substituteParameters, validateParameterValue } from "./parameters";
+import { QueryNode, cloneNode, nodesEqual, walk } from "./queryModel";
+import { diagnoseQuery } from "./diagnostics";
+import { runFetchXml } from "./runQuery";
+import { showResults, showResultsError } from "./resultsPanel";
+import { computeWriteBack } from "./writeBack";
+import { UNKNOWN_CONSUMER } from "./consumers";
+
+function nonce(): string {
+  const chars = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789";
+  let value = "";
+  for (let i = 0; i < 32; i++) {
+    value += chars.charAt(Math.floor(Math.random() * chars.length));
+  }
+  return value;
+}
+
+/** Everything the open generator is working on. */
+interface Session {
+  panel: vscode.WebviewPanel;
+  /** The document the query came from, absent when building a brand-new query. */
+  document?: vscode.TextDocument;
+  /** Re-detected against the live document each time we save, so a shifted span is still correct. */
+  query?: DetectedQuery;
+  root: QueryNode;
+  original: QueryNode;
+  format: XmlFormat;
+  selection: number[];
+  /** Prompted parameter values, remembered for the session. */
+  values: Record<string, string>;
+  title: string;
+}
+
+let session: Session | undefined;
+
+/** Open the generator on a detected query, or with a fresh one when `query` is undefined. */
+export async function openGenerator(context: DataversePowerToolsContext, document: vscode.TextDocument | undefined, query: DetectedQuery | undefined): Promise<void> {
+  const parsed = query ? parseFetchXml(query.xml) : undefined;
+  const root = parsed?.ok ? parsed.root : newQuery();
+  const format = parsed?.ok ? parsed.format : DEFAULT_FORMAT;
+  const title = document ? `${document.fileName.split(/[\\/]/).pop()}` : "New query";
+
+  const panel =
+    session?.panel ??
+    vscode.window.createWebviewPanel("dataversePowerToolsQueryGenerator", "FetchXML Generator", vscode.ViewColumn.Active, {
+      enableScripts: true,
+      retainContextWhenHidden: true,
+      localResourceRoots: [vscode.Uri.joinPath(context.vscode.extensionUri, "media")],
+    });
+
+  const isNew = session?.panel !== panel;
+  session = { panel, document, query, root, original: cloneNode(root), format, selection: [], values: session?.values ?? {}, title };
+
+  if (isNew) {
+    panel.onDidDispose(() => {
+      session = undefined;
+    });
+    panel.webview.onDidReceiveMessage((message) => void onMessage(context, message));
+    panel.webview.html = html(panel.webview, context);
+  }
+
+  panel.title = `FetchXML Generator — ${title}`;
+  panel.reveal(vscode.ViewColumn.Active);
+  post(context);
+  // FINAL signal for this command: everything the generator needs is rendered. The e2e suite gates on
+  // this line rather than on the panel appearing, so a step can't start while the previous one runs.
+  let elements = 0;
+  walk(root, () => {
+    elements++;
+  });
+  context.channel.appendLine(
+    `[Query] Generator ready for ${title} — ${query?.consumer.label ?? "FetchXML"}, ${elements} elements${query?.writable === false ? ", read-only" : ""}`,
+  );
+  // Warm the table list in the background; the picker fills in when it lands.
+  void warmMetadata(context);
+}
+
+async function warmMetadata(context: DataversePowerToolsContext): Promise<void> {
+  const cache = getMetadataCache(context);
+  try {
+    // Log only on the fetch, not on every cache hit — this runs on each selection change.
+    const hadTables = cache.loadedTables() !== undefined;
+    const tables = await cache.getTables();
+    if (!hadTables) {
+      context.channel.appendLine(`[Query] Metadata ready: ${tables.length} tables`);
+    }
+    const entity = session ? scopeEntity(session.root, session.selection) : undefined;
+    if (entity && !entity.startsWith("@")) {
+      const hadColumns = cache.loadedAttributes(entity) !== undefined;
+      const columns = await cache.getAttributes(entity);
+      if (!hadColumns) {
+        context.channel.appendLine(`[Query] Metadata ready: ${columns.length} columns on ${entity}`);
+      }
+    }
+  } catch (error) {
+    context.channel.appendLine(`[Query] Could not load metadata: ${(error as Error).message}`);
+  }
+  post(context);
+}
+
+/** The query's parameters, resolved once and reused for both the prompt rows and the diagnostics. */
+function currentParameters(current: Session): QueryParameter[] {
+  const xml = serializeFetchXml(current.root, current.format);
+  const expressions = Object.fromEntries((current.query?.tokens ?? []).map((token) => [token.name, token.expression]));
+  return collectParameters(current.root, allTokenNames(xml), expressions);
+}
+
+function parameterRows(context: DataversePowerToolsContext, current: Session, parameters: readonly QueryParameter[]): ParameterRow[] {
+  const metadata = getMetadataCache(context);
+  return parameters.map((parameter) => ({
+    name: parameter.name,
+    type: inferParameterType(parameter, metadata),
+    expression: parameter.expression,
+    value: current.values[parameter.name] ?? "",
+  }));
+}
+
+function currentState(context: DataversePowerToolsContext, current: Session): GeneratorState {
+  const metadata = getMetadataCache(context);
+  const parameters = currentParameters(current);
+  const entity = scopeEntity(current.root, current.selection);
+  const attributes = entity && !entity.startsWith("@") ? metadata.loadedAttributes(entity) : undefined;
+
+  return buildState({
+    root: current.root,
+    format: current.format,
+    selection: current.selection,
+    diagnostics: diagnoseQuery({
+      root: current.root,
+      consumer: current.query?.consumer ?? UNKNOWN_CONSUMER,
+      language: current.query?.language ?? "csharp",
+      parameters,
+      metadata,
+    }),
+    parameters: parameterRows(context, current, parameters),
+    tables: metadata.loadedTables()?.map((table) => ({ logicalName: table.logicalName, displayName: table.displayName })),
+    attributes: attributes?.map((attribute) => ({ logicalName: attribute.logicalName, displayName: attribute.displayName })),
+    readOnly: current.query !== undefined && !current.query.writable,
+    consumerLabel: current.query?.consumer.label ?? "FetchXML",
+    title: current.title,
+    dirty: !nodesEqual(current.root, current.original),
+  });
+}
+
+function post(context: DataversePowerToolsContext): void {
+  if (!session) {
+    return;
+  }
+  void session.panel.webview.postMessage({ type: "state", state: currentState(context, session) });
+}
+
+async function onMessage(context: DataversePowerToolsContext, message: Record<string, unknown>): Promise<void> {
+  const current = session;
+  if (!current) {
+    return;
+  }
+
+  switch (message.type) {
+    case "ready":
+      post(context);
+      return;
+
+    case "select": {
+      current.selection = asPath(message.path);
+      post(context);
+      void warmMetadata(context);
+      return;
+    }
+
+    case "edit": {
+      const edit = asEdit(message.edit);
+      if (!edit) {
+        return;
+      }
+      const applied = applyEdit(current.root, edit);
+      if (!applied) {
+        return;
+      }
+      current.root = applied.root;
+      current.selection = applied.selection;
+      post(context);
+      if (edit.kind === "setAttr" && edit.name === "name") {
+        void warmMetadata(context);
+      }
+      return;
+    }
+
+    case "add": {
+      const tag = typeof message.tag === "string" ? message.tag : undefined;
+      if (!tag) {
+        return;
+      }
+      const applied = applyEdit(current.root, { kind: "addChild", path: asPath(message.path), tag, attrs: defaultsFor(tag) });
+      if (applied) {
+        current.root = applied.root;
+        current.selection = applied.selection;
+        post(context);
+      }
+      return;
+    }
+
+    case "setXml": {
+      // The XML pane is editable: parse it, and keep the text if it doesn't parse so the user can fix it.
+      const xml = typeof message.xml === "string" ? message.xml : "";
+      const parsed = parseFetchXml(xml);
+      if (!parsed.ok) {
+        void current.panel.webview.postMessage({ type: "xmlError", error: parsed.error });
+        return;
+      }
+      current.root = parsed.root;
+      current.format = detectFormat(xml);
+      current.selection = [];
+      post(context);
+      return;
+    }
+
+    case "setParameter": {
+      const name = typeof message.name === "string" ? message.name : undefined;
+      if (name) {
+        current.values[name] = typeof message.value === "string" ? message.value : "";
+      }
+      return;
+    }
+
+    case "run":
+      await runCurrent(context, current);
+      return;
+
+    case "save":
+      await saveCurrent(context, current);
+      return;
+
+    case "copyXml":
+      await vscode.env.clipboard.writeText(serializeFetchXml(current.root, current.format));
+      vscode.window.showInformationMessage("FetchXML copied.");
+      return;
+
+    case "refreshMetadata": {
+      getMetadataCache(context).clear();
+      await warmMetadata(context);
+      vscode.window.showInformationMessage("Metadata reloaded from the environment.");
+      return;
+    }
+  }
+}
+
+/** Collect any missing parameter values, then run. */
+async function runCurrent(context: DataversePowerToolsContext, current: Session): Promise<void> {
+  const parameters = parameterRows(context, current, currentParameters(current));
+  for (const parameter of parameters) {
+    if (parameter.value.length > 0 && validateParameterValue(parameter.type, parameter.value) === undefined) {
+      continue;
+    }
+    const entered = await vscode.window.showInputBox({
+      title: "Run FetchXML",
+      prompt: `${parameter.name}${parameter.expression ? ` (bound to ${parameter.expression})` : ""} — ${parameter.type}`,
+      value: parameter.value,
+      ignoreFocusOut: true,
+      validateInput: (value) => validateParameterValue(parameter.type, value),
+    });
+    if (entered === undefined) {
+      return; // cancelled
+    }
+    current.values[parameter.name] = entered;
+  }
+
+  const values = Object.fromEntries(parameters.map((parameter) => [parameter.name, normalizeParameterValue(parameter.type, current.values[parameter.name] ?? "")]));
+  const xml = substituteParameters(serializeFetchXml(current.root, current.format), values);
+
+  const outcome = await vscode.window.withProgress({ location: vscode.ProgressLocation.Notification, title: "Running FetchXML…" }, () => runFetchXml(context, xml));
+  if (outcome.ok) {
+    showResults(context, { table: outcome.table, context: outcome.context, xml, title: current.title });
+  } else {
+    showResultsError(context, current.title, outcome.error);
+  }
+}
+
+/** Write the edited query back into the source file. */
+async function saveCurrent(context: DataversePowerToolsContext, current: Session): Promise<void> {
+  if (!current.document || !current.query) {
+    vscode.window.showInformationMessage("This query isn't attached to a file. Use “Insert at cursor” from the palette instead.");
+    return;
+  }
+
+  // Re-detect against the CURRENT document text: the user may have edited the file since the generator
+  // opened, which would have shifted the span we captured.
+  const language = languageFor(current.document.languageId);
+  const fresh = language ? detectQueries(current.document.getText(), language) : [];
+  const target = fresh.find((candidate) => candidate.start === current.query?.start) ?? fresh.find((candidate) => candidate.xml === current.query?.xml);
+  if (!target) {
+    vscode.window.showWarningMessage("The original query is no longer where it was in the file — save it manually with Copy FetchXML.");
+    return;
+  }
+
+  const result = computeWriteBack(target, serializeFetchXml(current.root, current.format));
+  if (!result.ok) {
+    vscode.window.showErrorMessage(result.reason);
+    return;
+  }
+  if (!result.changed) {
+    vscode.window.showInformationMessage("No changes to write.");
+    return;
+  }
+
+  const edit = new vscode.WorkspaceEdit();
+  edit.replace(current.document.uri, new vscode.Range(current.document.positionAt(target.start), current.document.positionAt(target.end)), result.text);
+  const applied = await vscode.workspace.applyEdit(edit);
+  if (!applied) {
+    vscode.window.showErrorMessage("Could not apply the edit to the file.");
+    return;
+  }
+
+  // Then PERSIST it. `applyEdit` only changes the in-memory document, which would leave the button
+  // labelled "Save to code" having saved nothing — the file on disk (the one that compiles and
+  // deploys) would still hold the old query, and the user wouldn't necessarily notice the dirty
+  // marker. The edit stays a single undo step either way. Any other unsaved changes in this document
+  // are written too, which is why the notification names the file.
+  const saved = await current.document.save();
+  if (!saved) {
+    vscode.window.showWarningMessage(`The query was updated in the editor but ${path.basename(current.document.fileName)} could not be saved — save it yourself.`);
+  }
+
+  current.original = cloneNode(current.root);
+  current.query = detectQueries(current.document.getText(), language ?? "csharp").find((candidate) => candidate.start === target.start);
+  context.channel.appendLine(`[Query] Wrote the edited query back to ${current.document.fileName}${saved ? " (saved)" : " (UNSAVED — save it yourself)"}`);
+  if (saved) {
+    vscode.window.showInformationMessage(`Updated the FetchXML in ${path.basename(current.document.fileName)}.`);
+  }
+  post(context);
+}
+
+function asPath(value: unknown): number[] {
+  return Array.isArray(value) ? value.filter((entry): entry is number => typeof entry === "number" && entry >= 0) : [];
+}
+
+/** Validate an edit intent from the webview — it is our own code, but treat it as untrusted. */
+function asEdit(value: unknown): QueryEdit | undefined {
+  if (typeof value !== "object" || value === null) {
+    return undefined;
+  }
+  const candidate = value as Record<string, unknown>;
+  const path = asPath(candidate.path);
+  switch (candidate.kind) {
+    case "setAttr":
+      return typeof candidate.name === "string"
+        ? { kind: "setAttr", path, name: candidate.name, value: typeof candidate.value === "string" ? candidate.value : undefined }
+        : undefined;
+    case "addChild":
+      return typeof candidate.tag === "string" ? { kind: "addChild", path, tag: candidate.tag, attrs: defaultsFor(candidate.tag) } : undefined;
+    case "remove":
+      return { kind: "remove", path };
+    case "setText":
+      return typeof candidate.text === "string" ? { kind: "setText", path, text: candidate.text } : undefined;
+    case "move":
+      return typeof candidate.offset === "number" ? { kind: "move", path, offset: candidate.offset } : undefined;
+    default:
+      return undefined;
+  }
+}
+
+function html(webview: vscode.Webview, context: DataversePowerToolsContext): string {
+  const token = nonce();
+  const css = webview.asWebviewUri(vscode.Uri.joinPath(context.vscode.extensionUri, "media", "queryGenerator.css"));
+  const js = webview.asWebviewUri(vscode.Uri.joinPath(context.vscode.extensionUri, "media", "queryGenerator.js"));
+  return `<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta http-equiv="Content-Security-Policy" content="default-src 'none'; style-src ${webview.cspSource}; script-src 'nonce-${token}';">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <link href="${css}" rel="stylesheet">
+  <title>FetchXML Generator</title>
+</head>
+<body>
+  <header>
+    <div id="title"></div>
+    <div id="actions">
+      <button id="run" type="button">▶ Run</button>
+      <button id="save" type="button">Save to code</button>
+      <button id="copy" type="button">Copy FetchXML</button>
+      <button id="refresh" type="button" title="Reload tables and columns from the environment">Reload metadata</button>
+    </div>
+  </header>
+  <div id="notice" hidden></div>
+  <main>
+    <section id="treePane" aria-label="Query structure">
+      <div id="tree" role="tree"></div>
+      <div id="treeActions"></div>
+    </section>
+    <section id="propertiesPane" aria-label="Properties">
+      <div id="properties"></div>
+      <div id="otherAttributes"></div>
+      <div id="parameters"></div>
+      <div id="diagnostics"></div>
+    </section>
+  </main>
+  <section id="xmlPane">
+    <label for="xml">FetchXML</label>
+    <textarea id="xml" spellcheck="false" rows="10"></textarea>
+    <div id="xmlError" role="alert" hidden></div>
+  </section>
+  <script nonce="${token}" src="${js}"></script>
+</body>
+</html>`;
+}

--- a/src/query/generatorState.ts
+++ b/src/query/generatorState.ts
@@ -1,0 +1,327 @@
+// The generator's view-model (#238).
+//
+// Everything the webview renders is computed HERE, in a pure function, so the webview is a renderer
+// with no query knowledge and the whole generator — labels, which fields a node has, which children it
+// can take, which operators are offered — is unit-testable without a browser.
+//
+// Pure (no `vscode`) → unit-tested.
+
+import { QueryDiagnostic } from "./diagnostics";
+import { nodeAt } from "./edits";
+import { serializeFetchXml, XmlFormat } from "./fetchXml";
+import { ParameterType } from "./parameters";
+import { QueryNode, attrBool } from "./queryModel";
+
+/** FetchXML condition operators, grouped so the picker isn't a wall of 60 options. */
+export const OPERATOR_GROUPS: readonly { label: string; operators: readonly string[] }[] = [
+  { label: "Comparison", operators: ["eq", "ne", "gt", "ge", "lt", "le", "not-null", "null"] },
+  { label: "Text", operators: ["like", "not-like", "begins-with", "not-begin-with", "ends-with", "not-end-with"] },
+  { label: "Sets", operators: ["in", "not-in", "between", "not-between"] },
+  {
+    label: "Dates",
+    operators: [
+      "on",
+      "on-or-before",
+      "on-or-after",
+      "today",
+      "yesterday",
+      "tomorrow",
+      "this-week",
+      "this-month",
+      "this-year",
+      "last-week",
+      "last-month",
+      "last-year",
+      "next-week",
+      "next-month",
+      "next-year",
+      "last-x-days",
+      "next-x-days",
+      "last-x-hours",
+      "next-x-hours",
+      "last-x-weeks",
+      "next-x-weeks",
+      "last-x-months",
+      "next-x-months",
+      "last-x-years",
+      "next-x-years",
+      "older-than-x-days",
+      "older-than-x-months",
+      "older-than-x-years",
+    ],
+  },
+  { label: "User & team", operators: ["eq-userid", "ne-userid", "eq-userteams", "eq-useroruserteams", "eq-businessid", "ne-businessid"] },
+  { label: "Hierarchy", operators: ["under", "not-under", "under-or-equal", "above", "above-or-equal"] },
+];
+
+export const ALL_OPERATORS: readonly string[] = OPERATOR_GROUPS.flatMap((group) => group.operators);
+
+/** Operators that take no value at all — the value box is hidden for these. */
+export const VALUELESS_OPERATORS: ReadonlySet<string> = new Set([
+  "null",
+  "not-null",
+  "today",
+  "yesterday",
+  "tomorrow",
+  "this-week",
+  "this-month",
+  "this-year",
+  "last-week",
+  "last-month",
+  "last-year",
+  "next-week",
+  "next-month",
+  "next-year",
+  "eq-userid",
+  "ne-userid",
+  "eq-userteams",
+  "eq-useroruserteams",
+  "eq-businessid",
+  "ne-businessid",
+]);
+
+export const AGGREGATE_FUNCTIONS: readonly string[] = ["count", "countcolumn", "sum", "avg", "min", "max"];
+export const DATE_GROUPINGS: readonly string[] = ["day", "week", "month", "quarter", "year", "fiscal-period", "fiscal-year"];
+
+export type FieldKind = "text" | "select" | "boolean" | "entity" | "attribute" | "number";
+
+export interface FieldDescriptor {
+  /** XML attribute name. */
+  name: string;
+  label: string;
+  kind: FieldKind;
+  options?: readonly string[];
+  hint?: string;
+}
+
+/** The fields the generator offers per element. Anything not listed still round-trips — it shows in
+ * the "other attributes" row as read-only, so an exotic query is never silently simplified. */
+/* eslint-disable @typescript-eslint/naming-convention -- keys are FetchXML element and attribute
+   names (`all-attributes`, `link-entity`, `link-type`); they are wire format, not our naming. */
+const FIELDS: Record<string, readonly FieldDescriptor[]> = {
+  fetch: [
+    { name: "top", label: "Top", kind: "number", hint: "Maximum rows. Cannot be combined with paging." },
+    { name: "distinct", label: "Distinct", kind: "boolean" },
+    { name: "aggregate", label: "Aggregate", kind: "boolean", hint: "Every attribute must then aggregate or group." },
+    { name: "returntotalrecordcount", label: "Return total count", kind: "boolean" },
+    { name: "no-lock", label: "No lock", kind: "boolean" },
+    { name: "page", label: "Page", kind: "number" },
+    { name: "count", label: "Page size", kind: "number" },
+  ],
+  entity: [{ name: "name", label: "Table", kind: "entity" }],
+  attribute: [
+    { name: "name", label: "Column", kind: "attribute" },
+    { name: "alias", label: "Alias", kind: "text" },
+    { name: "aggregate", label: "Aggregate", kind: "select", options: AGGREGATE_FUNCTIONS },
+    { name: "groupby", label: "Group by", kind: "boolean" },
+    { name: "dategrouping", label: "Date grouping", kind: "select", options: DATE_GROUPINGS },
+    { name: "distinct", label: "Distinct", kind: "boolean" },
+  ],
+  "all-attributes": [],
+  order: [
+    { name: "attribute", label: "Column", kind: "attribute" },
+    { name: "alias", label: "Alias", kind: "text" },
+    { name: "descending", label: "Descending", kind: "boolean" },
+  ],
+  filter: [{ name: "type", label: "Match", kind: "select", options: ["and", "or"] }],
+  condition: [
+    { name: "attribute", label: "Column", kind: "attribute" },
+    { name: "operator", label: "Operator", kind: "select", options: ALL_OPERATORS },
+    { name: "value", label: "Value", kind: "text", hint: "Use @name for a parameter." },
+    { name: "entityname", label: "From alias", kind: "text", hint: "Alias of a link-entity to filter on." },
+  ],
+  value: [],
+  "link-entity": [
+    { name: "name", label: "Table", kind: "entity" },
+    { name: "from", label: "From column", kind: "text" },
+    { name: "to", label: "To column", kind: "attribute" },
+    { name: "alias", label: "Alias", kind: "text" },
+    { name: "link-type", label: "Join", kind: "select", options: ["inner", "outer", "any", "not any", "all", "not all", "exists", "in"] },
+    { name: "intersect", label: "Intersect", kind: "boolean", hint: "Set for the intersect table of a many-to-many join." },
+  ],
+};
+
+/** Which children each element may gain, in the order the Add menu shows them. */
+const ADDABLE: Record<string, readonly string[]> = {
+  fetch: ["entity"],
+  entity: ["attribute", "all-attributes", "filter", "order", "link-entity"],
+  "link-entity": ["attribute", "all-attributes", "filter", "order", "link-entity"],
+  filter: ["condition", "filter"],
+  condition: ["value"],
+  attribute: [],
+  order: [],
+  value: [],
+  "all-attributes": [],
+};
+
+/** Sensible defaults so an added node is immediately valid rather than blank. */
+const DEFAULTS: Record<string, Record<string, string>> = {
+  entity: { name: "account" },
+  filter: { type: "and" },
+  condition: { operator: "eq" },
+  "link-entity": { "link-type": "inner" },
+  order: {},
+  attribute: {},
+};
+/* eslint-enable @typescript-eslint/naming-convention */
+
+export interface TreeRow {
+  path: number[];
+  tag: string;
+  /** Rendered label, e.g. "condition  statecode eq 0". */
+  label: string;
+  depth: number;
+  /** True when this element isn't one the generator edits (a comment, an unknown tag). */
+  readOnly: boolean;
+}
+
+export interface ParameterRow {
+  name: string;
+  type: ParameterType;
+  /** The code expression it is bound to, absent for one typed in the generator. */
+  expression?: string;
+  value: string;
+}
+
+export interface GeneratorState {
+  xml: string;
+  tree: TreeRow[];
+  selection: number[];
+  selectedTag?: string;
+  fields: { descriptor: FieldDescriptor; value: string }[];
+  /** Attributes present on the selected node that the generator has no field for. */
+  otherAttributes: { name: string; value: string }[];
+  addable: readonly string[];
+  canRemove: boolean;
+  diagnostics: QueryDiagnostic[];
+  parameters: ParameterRow[];
+  /** Tables for the entity pickers; undefined until metadata loads. */
+  tables?: { logicalName: string; displayName: string }[];
+  /** Columns of the selected node's scope; undefined until metadata loads. */
+  attributes?: { logicalName: string; displayName: string }[];
+  readOnly: boolean;
+  consumerLabel: string;
+  title: string;
+  dirty: boolean;
+  operatorGroups: typeof OPERATOR_GROUPS;
+}
+
+export function fieldsFor(tag: string): readonly FieldDescriptor[] {
+  return FIELDS[tag] ?? [];
+}
+
+export function addableFor(tag: string): readonly string[] {
+  return ADDABLE[tag] ?? [];
+}
+
+export function defaultsFor(tag: string): Record<string, string> {
+  return DEFAULTS[tag] ?? {};
+}
+
+/** The logical name of the table a node's columns come from — what the attribute picker needs. */
+export function scopeEntity(root: QueryNode, path: readonly number[]): string | undefined {
+  for (let depth = path.length; depth >= 0; depth--) {
+    const node = nodeAt(root, path.slice(0, depth));
+    if (node && (node.tag === "entity" || node.tag === "link-entity")) {
+      return node.attrs.name;
+    }
+  }
+  return undefined;
+}
+
+/** One-line summary of a node, so the tree reads like the query rather than like XML. */
+export function labelFor(node: QueryNode): string {
+  switch (node.tag) {
+    case "fetch": {
+      const bits = [node.attrs.top ? `top ${node.attrs.top}` : "", attrBool(node, "distinct") ? "distinct" : "", attrBool(node, "aggregate") ? "aggregate" : ""].filter(Boolean);
+      return bits.join(" · ");
+    }
+    case "entity":
+      return node.attrs.name ?? "(no table)";
+    case "attribute": {
+      const name = node.attrs.name ?? "(no column)";
+      const aggregate = node.attrs.aggregate ? `${node.attrs.aggregate}(${name})` : name;
+      return node.attrs.alias ? `${aggregate} as ${node.attrs.alias}` : aggregate;
+    }
+    case "all-attributes":
+      return "all columns";
+    case "order":
+      return `${node.attrs.attribute ?? node.attrs.alias ?? "?"}${attrBool(node, "descending") ? " desc" : " asc"}`;
+    case "filter":
+      return (node.attrs.type ?? "and").toUpperCase();
+    case "condition": {
+      const attribute = node.attrs.entityname ? `${node.attrs.entityname}.${node.attrs.attribute ?? "?"}` : (node.attrs.attribute ?? "?");
+      const operator = node.attrs.operator ?? "?";
+      if (VALUELESS_OPERATORS.has(operator)) {
+        return `${attribute} ${operator}`;
+      }
+      const values = node.children.filter((child) => child.tag === "value").map((child) => child.text ?? "");
+      const value = values.length > 0 ? values.join(", ") : (node.attrs.value ?? "");
+      return `${attribute} ${operator} ${value}`.trim();
+    }
+    case "value":
+      return node.text ?? "";
+    case "link-entity": {
+      const join = node.attrs["link-type"] ?? "inner";
+      const alias = node.attrs.alias ? ` as ${node.attrs.alias}` : "";
+      return `${node.attrs.name ?? "?"}${alias} (${join}: ${node.attrs.from ?? "?"} → ${node.attrs.to ?? "?"})`;
+    }
+    case "#comment":
+      return `comment${node.text ? `: ${node.text.trim()}` : ""}`;
+    default:
+      return node.tag;
+  }
+}
+
+function flattenTree(node: QueryNode, path: number[], depth: number, rows: TreeRow[]): void {
+  rows.push({ path: [...path], tag: node.tag, label: labelFor(node), depth, readOnly: node.tag === "#comment" || FIELDS[node.tag] === undefined });
+  node.children.forEach((child, index) => flattenTree(child, [...path, index], depth + 1, rows));
+}
+
+export interface BuildStateInput {
+  root: QueryNode;
+  format: XmlFormat;
+  selection: number[];
+  diagnostics: QueryDiagnostic[];
+  parameters: ParameterRow[];
+  tables?: { logicalName: string; displayName: string }[];
+  attributes?: { logicalName: string; displayName: string }[];
+  readOnly: boolean;
+  consumerLabel: string;
+  title: string;
+  dirty: boolean;
+}
+
+/** Assemble everything the webview needs for one render. */
+export function buildState(input: BuildStateInput): GeneratorState {
+  const tree: TreeRow[] = [];
+  flattenTree(input.root, [], 0, tree);
+
+  // A selection that no longer resolves (its node was removed) falls back to the root.
+  const selected = nodeAt(input.root, input.selection) ? input.selection : [];
+  const node = nodeAt(input.root, selected) ?? input.root;
+  const descriptors = fieldsFor(node.tag);
+  const known = new Set(descriptors.map((descriptor) => descriptor.name));
+
+  return {
+    xml: serializeFetchXml(input.root, input.format),
+    tree,
+    selection: selected,
+    selectedTag: node.tag,
+    fields: descriptors.map((descriptor) => ({ descriptor, value: node.attrs[descriptor.name] ?? "" })),
+    otherAttributes: Object.entries(node.attrs)
+      .filter(([name]) => !known.has(name))
+      .map(([name, value]) => ({ name, value })),
+    addable: addableFor(node.tag),
+    canRemove: selected.length > 0,
+    diagnostics: input.diagnostics,
+    parameters: input.parameters,
+    tables: input.tables,
+    attributes: input.attributes,
+    readOnly: input.readOnly,
+    consumerLabel: input.consumerLabel,
+    title: input.title,
+    dirty: input.dirty,
+    operatorGroups: OPERATOR_GROUPS,
+  };
+}

--- a/src/query/holes.ts
+++ b/src/query/holes.ts
@@ -1,0 +1,223 @@
+// Interpolation ⇄ `@token` mapping (#238).
+//
+// A parameterised FetchXML string isn't valid XML, so before parsing we swap every code
+// interpolation for an `@token` placeholder and remember the original expression text. On the way
+// back the exact expression text is restored, which is why we never need to understand it.
+//
+//   $@"…value='{accountId}'…"   ->   …value='@accountId'…      (parse, edit, run)
+//   …value='@accountId'…        ->   $@"…value='{accountId}'…"  (write back)
+//
+// `@` was chosen over `{{…}}` because `{{…}}` is literally Liquid in the Power Pages target, and
+// because it matches OData's own `@parameter` alias syntax.
+//
+// Pure (no `vscode`) → unit-tested.
+
+import { StringPart } from "./literals";
+
+export interface HoleToken {
+  /** The placeholder as it appears in the XML, including the `@`. */
+  token: string;
+  /** Bare name, without the `@`. */
+  name: string;
+  /** The original code expression, written back verbatim. */
+  expression: string;
+}
+
+/**
+ * A token is only recognised when it is NOT preceded by a word character, so an email address in a
+ * value (`value="a@b.com"`) is never mistaken for a parameter — a false positive there would
+ * rewrite someone's literal data into an interpolation.
+ *
+ * Built fresh per call rather than shared: a `/g` regex carries `lastIndex`, and one shared instance
+ * across these functions would be mutable state that a nested scan could corrupt.
+ */
+function tokenPattern(): RegExp {
+  return /(^|[^A-Za-z0-9_@])@([A-Za-z_][A-Za-z0-9_]*)/g;
+}
+
+/** Strip a C# alignment/format specifier: `{since:yyyy-MM-dd}` names itself after `since`. */
+function withoutFormatSpecifier(expression: string): string {
+  let depth = 0;
+  for (let i = 0; i < expression.length; i++) {
+    const char = expression[i];
+    if (char === "(" || char === "[") {
+      depth++;
+    } else if (char === ")" || char === "]") {
+      depth--;
+    } else if (depth === 0 && (char === ":" || char === ",")) {
+      return expression.slice(0, i);
+    }
+  }
+  return expression;
+}
+
+/** Words that are never a useful parameter name. */
+const NOT_A_NAME = new Set([
+  "new",
+  "this",
+  "base",
+  "await",
+  "typeof",
+  "nameof",
+  "null",
+  "true",
+  "false",
+  "var",
+  "let",
+  "const",
+  "string",
+  "int",
+  "Guid",
+  "DateTime",
+  "Date",
+  "Convert",
+  "System",
+]);
+
+/**
+ * Derive a readable token name from a code expression, so the XML reads `value='@accountId'` rather
+ * than `value='@p1'`.
+ *
+ * The rule: take the last identifier that is NOT immediately followed by `(` — a called name
+ * describes the operation, while the identifier beside it names the value. That gives `accountId`
+ * from `accountId`, `UserId` from `context.UserId`, `since` from `since.toISOString()` and `name`
+ * from `Escape(name)`. Anything with no usable identifier falls back to `p1`, `p2`.
+ */
+export function identifierFrom(expression: string, fallbackIndex: number): string {
+  const bare = withoutFormatSpecifier(expression).trim();
+  if (/^[A-Za-z_][A-Za-z0-9_]*$/.test(bare)) {
+    return bare;
+  }
+
+  // Blank out string contents first: a name lifted from inside a literal (`dict["some key"]`)
+  // describes nothing.
+  const scannable = bare.replace(/"[^"]*"|'[^']*'|`[^`]*`/g, (quoted) => " ".repeat(quoted.length));
+
+  const candidates: string[] = [];
+  const pattern = /[A-Za-z_][A-Za-z0-9_]*/g;
+  for (let match = pattern.exec(scannable); match !== null; match = pattern.exec(scannable)) {
+    const isCall = scannable[pattern.lastIndex] === "(";
+    if (!isCall && !NOT_A_NAME.has(match[0])) {
+      candidates.push(match[0]);
+    }
+  }
+  return candidates.length > 0 ? (candidates.pop() as string) : `p${fallbackIndex}`;
+}
+
+/**
+ * Replace holes with `@token` placeholders, producing parseable XML. Identical expressions share
+ * one token, so a value used twice becomes one parameter prompted for once.
+ */
+export function tokenizeParts(parts: StringPart[]): { xml: string; tokens: HoleToken[] } {
+  const tokens: HoleToken[] = [];
+  const byExpression = new Map<string, HoleToken>();
+  const usedNames = new Set<string>();
+  let fallbackIndex = 1;
+  let xml = "";
+
+  for (const part of parts) {
+    if (part.kind === "text") {
+      xml += part.value;
+      continue;
+    }
+    const existing = byExpression.get(part.expression);
+    if (existing) {
+      xml += existing.token;
+      continue;
+    }
+    let name = identifierFrom(part.expression, fallbackIndex);
+    if (name === `p${fallbackIndex}`) {
+      fallbackIndex++;
+    }
+    if (usedNames.has(name)) {
+      let suffix = 2;
+      while (usedNames.has(`${name}${suffix}`)) {
+        suffix++;
+      }
+      name = `${name}${suffix}`;
+    }
+    usedNames.add(name);
+    const token: HoleToken = { token: `@${name}`, name, expression: part.expression };
+    tokens.push(token);
+    byExpression.set(part.expression, token);
+    xml += token.token;
+  }
+
+  return { xml, tokens };
+}
+
+/**
+ * Turn XML back into code parts. Known tokens restore their original expression; an `@newName` the
+ * user typed in the generator becomes a NEW hole whose expression is that name — so it compiles if
+ * such a variable is in scope and fails loudly and locally if it isn't.
+ */
+export function detokenizeXml(xml: string, tokens: HoleToken[]): StringPart[] {
+  const byName = new Map(tokens.map((token) => [token.name, token]));
+  const parts: StringPart[] = [];
+  let lastIndex = 0;
+
+  const pattern = tokenPattern();
+  for (let match = pattern.exec(xml); match !== null; match = pattern.exec(xml)) {
+    const [whole, prefix, name] = match;
+    const tokenStart = match.index + prefix.length;
+    const text = xml.slice(lastIndex, tokenStart);
+    if (text.length > 0) {
+      parts.push({ kind: "text", value: text });
+    }
+    parts.push({ kind: "hole", expression: byName.get(name)?.expression ?? name });
+    lastIndex = match.index + whole.length;
+    // Overlapping matches: the character we consumed as a prefix may start the next token.
+    pattern.lastIndex = lastIndex;
+  }
+
+  if (lastIndex < xml.length) {
+    parts.push({ kind: "text", value: xml.slice(lastIndex) });
+  }
+  return parts;
+}
+
+/**
+ * Replace every `@token` in the XML using `resolve`. Returning undefined leaves the token in place.
+ * Shared by write-back (token → code expression) and test runs (token → an escaped literal value),
+ * so both use exactly the same boundary rules and neither can rewrite an email address.
+ */
+export function replaceTokens(xml: string, resolve: (name: string) => string | undefined): string {
+  let out = "";
+  let lastIndex = 0;
+  const pattern = tokenPattern();
+  for (let match = pattern.exec(xml); match !== null; match = pattern.exec(xml)) {
+    const [whole, prefix, name] = match;
+    const replacement = resolve(name);
+    if (replacement !== undefined) {
+      out += xml.slice(lastIndex, match.index + prefix.length) + replacement;
+      lastIndex = match.index + whole.length;
+    }
+    pattern.lastIndex = match.index + whole.length;
+  }
+  return out + xml.slice(lastIndex);
+}
+
+/** Tokens still present in the XML — the generator drops parameters whose condition was deleted. */
+export function tokensInXml(xml: string, tokens: HoleToken[]): HoleToken[] {
+  return tokens.filter((token) => {
+    const pattern = tokenPattern();
+    for (let match = pattern.exec(xml); match !== null; match = pattern.exec(xml)) {
+      if (match[2] === token.name) {
+        return true;
+      }
+    }
+    return false;
+  });
+}
+
+/** Every `@token` in the XML, known or newly typed, in first-appearance order. */
+export function allTokenNames(xml: string): string[] {
+  const names: string[] = [];
+  const pattern = tokenPattern();
+  for (let match = pattern.exec(xml); match !== null; match = pattern.exec(xml)) {
+    if (!names.includes(match[2])) {
+      names.push(match[2]);
+    }
+  }
+  return names;
+}

--- a/src/query/literals/csharp.ts
+++ b/src/query/literals/csharp.ts
@@ -1,0 +1,257 @@
+// C# string-literal reading and writing (#238).
+//
+// Covers the four forms FetchXML actually shows up in — `"…"`, `@"…"`, `$"…"`, `$@"…"` — plus raw
+// strings (`"""…"""`, C# 11) which are READ so Run and diagnostics work but never written back:
+// their content depends on indentation stripping rules subtle enough that re-emitting one risks
+// corrupting the query, and a wrong write is far worse than a disabled button.
+//
+// Pure (no `vscode`) → unit-tested.
+
+import { LiteralForm, LiteralReader, ReadLiteral, StringPart, decodeEscape, hasHoles, readBalancedHole, skipCStyleTrivia } from "./scan";
+
+/** Read `@"…"` / `$@"…"` — a doubled `""` is one quote, and there are no backslash escapes. */
+function readVerbatim(text: string, contentStart: number, interpolated: boolean): ReadLiteral | undefined {
+  const parts: StringPart[] = [];
+  let buffer = "";
+  let i = contentStart;
+  while (i < text.length) {
+    const char = text[i];
+    if (char === '"') {
+      if (text[i + 1] === '"') {
+        buffer += '"';
+        i += 2;
+        continue;
+      }
+      if (buffer.length > 0) {
+        parts.push({ kind: "text", value: buffer });
+      }
+      return { end: i + 1, parts, form: interpolated ? "interpolatedVerbatim" : "verbatim", writable: true };
+    }
+    if (interpolated && char === "{") {
+      if (text[i + 1] === "{") {
+        buffer += "{";
+        i += 2;
+        continue;
+      }
+      const hole = readBalancedHole(text, i + 1, "}");
+      if (!hole) {
+        return undefined;
+      }
+      if (buffer.length > 0) {
+        parts.push({ kind: "text", value: buffer });
+        buffer = "";
+      }
+      parts.push({ kind: "hole", expression: hole.expression });
+      i = hole.end;
+      continue;
+    }
+    if (interpolated && char === "}" && text[i + 1] === "}") {
+      buffer += "}";
+      i += 2;
+      continue;
+    }
+    buffer += char;
+    i++;
+  }
+  return undefined; // unterminated
+}
+
+/** Read `"…"` / `$"…"` — backslash escapes, and no raw newlines. */
+function readRegular(text: string, contentStart: number, interpolated: boolean): ReadLiteral | undefined {
+  const parts: StringPart[] = [];
+  let buffer = "";
+  let i = contentStart;
+  while (i < text.length) {
+    const char = text[i];
+    if (char === "\n") {
+      return undefined; // unterminated — a non-verbatim literal cannot span lines
+    }
+    if (char === "\\") {
+      const decoded = decodeEscape(text, i);
+      buffer += decoded.value;
+      i = decoded.next;
+      continue;
+    }
+    if (char === '"') {
+      if (buffer.length > 0) {
+        parts.push({ kind: "text", value: buffer });
+      }
+      return { end: i + 1, parts, form: interpolated ? "interpolated" : "regular", writable: true };
+    }
+    if (interpolated && char === "{") {
+      if (text[i + 1] === "{") {
+        buffer += "{";
+        i += 2;
+        continue;
+      }
+      const hole = readBalancedHole(text, i + 1, "}");
+      if (!hole) {
+        return undefined;
+      }
+      if (buffer.length > 0) {
+        parts.push({ kind: "text", value: buffer });
+        buffer = "";
+      }
+      parts.push({ kind: "hole", expression: hole.expression });
+      i = hole.end;
+      continue;
+    }
+    if (interpolated && char === "}" && text[i + 1] === "}") {
+      buffer += "}";
+      i += 2;
+      continue;
+    }
+    buffer += char;
+    i++;
+  }
+  return undefined;
+}
+
+/**
+ * Read a raw string literal (`"""…"""`). Multi-line raw strings strip the closing delimiter's
+ * indentation from every line — replicated here so the XML we parse matches what the compiler
+ * sees. Always `writable: false`.
+ */
+function readRaw(text: string, quoteStart: number, interpolated: boolean): ReadLiteral | undefined {
+  let quotes = 0;
+  while (text[quoteStart + quotes] === '"') {
+    quotes++;
+  }
+  const delimiter = '"'.repeat(quotes);
+  const contentStart = quoteStart + quotes;
+  const closeIndex = text.indexOf(delimiter, contentStart);
+  if (closeIndex === -1) {
+    return undefined;
+  }
+  let content = text.slice(contentStart, closeIndex);
+
+  // Multi-line form: drop the first and last newline, then dedent by the closing indentation.
+  if (content.includes("\n")) {
+    const lineStart = text.lastIndexOf("\n", closeIndex);
+    const closingIndent = text.slice(lineStart + 1, closeIndex);
+    const lines = content
+      .replace(/^[^\n]*\n/, "")
+      .replace(/\n[^\n]*$/, "")
+      .split("\n");
+    content = lines.map((line) => (line.startsWith(closingIndent) ? line.slice(closingIndent.length) : line.replace(/^\s+/, ""))).join("\n");
+  }
+
+  const parts: StringPart[] = [];
+  if (interpolated) {
+    let buffer = "";
+    let i = 0;
+    while (i < content.length) {
+      if (content[i] === "{") {
+        const hole = readBalancedHole(content, i + 1, "}");
+        if (hole) {
+          if (buffer.length > 0) {
+            parts.push({ kind: "text", value: buffer });
+            buffer = "";
+          }
+          parts.push({ kind: "hole", expression: hole.expression });
+          i = hole.end;
+          continue;
+        }
+      }
+      buffer += content[i];
+      i++;
+    }
+    if (buffer.length > 0) {
+      parts.push({ kind: "text", value: buffer });
+    }
+  } else if (content.length > 0) {
+    parts.push({ kind: "text", value: content });
+  }
+
+  return { end: closeIndex + quotes, parts, form: "raw", writable: false };
+}
+
+export const csharpReader: LiteralReader = {
+  skipTrivia: skipCStyleTrivia,
+
+  readLiteral(text, i) {
+    // Prefixes, longest first: $@" / @$" / @" / $""" / $" / """ / "
+    if ((text.startsWith('$@"', i) || text.startsWith('@$"', i)) && !text.startsWith('$@"""', i)) {
+      return readVerbatim(text, i + 3, true);
+    }
+    if (text.startsWith('@"', i)) {
+      return readVerbatim(text, i + 2, false);
+    }
+    if (text.startsWith('$"""', i)) {
+      return readRaw(text, i + 1, true);
+    }
+    if (text.startsWith('"""', i)) {
+      return readRaw(text, i, false);
+    }
+    if (text.startsWith('$"', i)) {
+      return readRegular(text, i + 2, true);
+    }
+    if (text.startsWith('"', i)) {
+      return readRegular(text, i + 1, false);
+    }
+    return undefined;
+  },
+
+  /** A char literal — `'"'` would otherwise open a phantom string and desynchronise the scan. */
+  readAtomic(text, i) {
+    if (text[i] !== "'") {
+      return undefined;
+    }
+    let position = i + 1;
+    while (position < text.length && position < i + 12) {
+      if (text[position] === "\\") {
+        position += 2;
+        continue;
+      }
+      if (text[position] === "'") {
+        return position + 1;
+      }
+      position++;
+    }
+    return undefined;
+  },
+};
+
+/**
+ * Pick the literal form to write. Keeps the author's form when it can still express the content and
+ * upgrades only when it cannot: a query that gained a newline needs a verbatim string, one that
+ * gained a parameter needs an interpolated one.
+ */
+export function chooseCsharpForm(original: LiteralForm, parts: StringPart[]): LiteralForm {
+  const multiline = parts.some((part) => part.kind === "text" && /[\r\n]/.test(part.value));
+  const holes = hasHoles(parts);
+  if (multiline) {
+    return holes ? "interpolatedVerbatim" : original === "interpolatedVerbatim" || original === "interpolated" ? "interpolatedVerbatim" : "verbatim";
+  }
+  if (holes) {
+    return original === "verbatim" || original === "interpolatedVerbatim" ? "interpolatedVerbatim" : "interpolated";
+  }
+  return original === "verbatim" || original === "interpolatedVerbatim" ? "verbatim" : "regular";
+}
+
+/** Emit C# source for the parts, including delimiters, in the given form. */
+export function encodeCsharp(parts: StringPart[], form: LiteralForm): string {
+  const verbatim = form === "verbatim" || form === "interpolatedVerbatim";
+  const interpolated = form === "interpolated" || form === "interpolatedVerbatim";
+
+  const body = parts
+    .map((part) => {
+      if (part.kind === "hole") {
+        return `{${part.expression}}`;
+      }
+      let value = part.value;
+      if (verbatim) {
+        value = value.replace(/"/g, '""');
+      } else {
+        value = value.replace(/\\/g, "\\\\").replace(/"/g, '\\"').replace(/\r/g, "\\r").replace(/\n/g, "\\n").replace(/\t/g, "\\t");
+      }
+      if (interpolated) {
+        value = value.replace(/\{/g, "{{").replace(/\}/g, "}}");
+      }
+      return value;
+    })
+    .join("");
+
+  const prefix = interpolated ? (verbatim ? "$@" : "$") : verbatim ? "@" : "";
+  return `${prefix}"${body}"`;
+}

--- a/src/query/literals/index.ts
+++ b/src/query/literals/index.ts
@@ -1,0 +1,39 @@
+// Language dispatch for the literal scanners (#238). Everything above this layer works in terms of
+// a `Language` and never knows which reader is behind it, which is what keeps adding a third host
+// language (Liquid, for Power Pages) to a single file.
+
+import { CodeString, Language, LiteralForm, StringPart, scanCodeStrings } from "./scan";
+import { chooseCsharpForm, csharpReader, encodeCsharp } from "./csharp";
+import { chooseTypescriptForm, encodeTypescript, typescriptReader } from "./typescript";
+
+export * from "./scan";
+export { csharpReader, encodeCsharp, chooseCsharpForm } from "./csharp";
+export { typescriptReader, encodeTypescript, chooseTypescriptForm } from "./typescript";
+
+/** VS Code language ids we can scan, mapped to our two readers. */
+const LANGUAGE_IDS: Record<string, Language> = {
+  csharp: "csharp",
+  typescript: "typescript",
+  typescriptreact: "typescript",
+  javascript: "typescript",
+  javascriptreact: "typescript",
+};
+
+/** The scanner for a VS Code `document.languageId`, or undefined when we don't handle it. */
+export function languageFor(languageId: string): Language | undefined {
+  return LANGUAGE_IDS[languageId];
+}
+
+export function scanLanguage(text: string, language: Language): CodeString[] {
+  return scanCodeStrings(text, language === "csharp" ? csharpReader : typescriptReader, language);
+}
+
+/** The form to write given the author's original form and the new content. */
+export function chooseForm(language: Language, original: LiteralForm, parts: StringPart[]): LiteralForm {
+  return language === "csharp" ? chooseCsharpForm(original, parts) : chooseTypescriptForm(original, parts);
+}
+
+/** Emit source text for the parts — the literal that replaces the original span. */
+export function encodeLiteral(language: Language, parts: StringPart[], form: LiteralForm): string {
+  return language === "csharp" ? encodeCsharp(parts, form) : encodeTypescript(parts, form);
+}

--- a/src/query/literals/literals.spec.ts
+++ b/src/query/literals/literals.spec.ts
@@ -1,0 +1,272 @@
+import { describe, it, expect } from "vitest";
+import { CodeString, Language, chooseForm, encodeLiteral, languageFor, partsText, scanLanguage } from "./index";
+
+function only(source: string, language: Language): CodeString {
+  const found = scanLanguage(source, language);
+  expect(found.length, `expected exactly one string, got ${found.length}`).toBe(1);
+  return found[0];
+}
+
+/** The span the scanner claims, lifted straight out of the source — proves the offsets are right. */
+function span(source: string, found: CodeString): string {
+  return source.slice(found.start, found.end);
+}
+
+/** Scan → encode → scan again and assert the parts survive. Write-back fidelity in one line. */
+function assertReEncodes(source: string, language: Language): string {
+  const first = only(source, language);
+  const form = chooseForm(language, first.form, first.parts);
+  const encoded = encodeLiteral(language, first.parts, form);
+  const second = only(encoded, language);
+  expect(second.parts).toEqual(first.parts);
+  return encoded;
+}
+
+describe("language mapping", () => {
+  it("maps the VS Code language ids we handle", () => {
+    expect(languageFor("csharp")).toBe("csharp");
+    expect(languageFor("typescript")).toBe("typescript");
+    expect(languageFor("typescriptreact")).toBe("typescript");
+    expect(languageFor("javascript")).toBe("typescript");
+    expect(languageFor("liquid")).toBeUndefined();
+    expect(languageFor("plaintext")).toBeUndefined();
+  });
+});
+
+describe("C# literals", () => {
+  it("reads a regular string with escapes", () => {
+    const found = only(`var x = "a\\"b\\n";`, "csharp");
+    expect(found.parts).toEqual([{ kind: "text", value: 'a"b\n' }]);
+    expect(found.form).toBe("regular");
+  });
+
+  it("reads a verbatim string, doubled quotes and all", () => {
+    const source = `var x = @"<fetch><entity name=""account"" /></fetch>";`;
+    const found = only(source, "csharp");
+    expect(partsText(found.parts)).toBe(`<fetch><entity name="account" /></fetch>`);
+    expect(found.form).toBe("verbatim");
+    expect(span(source, found)).toBe(`@"<fetch><entity name=""account"" /></fetch>"`);
+  });
+
+  it("reads a multi-line verbatim string", () => {
+    const source = `var x = @"<fetch>\n  <entity name='account' />\n</fetch>";`;
+    expect(partsText(only(source, "csharp").parts)).toBe(`<fetch>\n  <entity name='account' />\n</fetch>`);
+  });
+
+  it("reads interpolation holes in $@ strings and keeps the expression verbatim", () => {
+    const found = only(`var x = $@"<condition value='{accountId}' />";`, "csharp");
+    expect(found.parts).toEqual([
+      { kind: "text", value: "<condition value='" },
+      { kind: "hole", expression: "accountId" },
+      { kind: "text", value: "' />" },
+    ]);
+    expect(found.form).toBe("interpolatedVerbatim");
+  });
+
+  it("accepts the @$ prefix order too", () => {
+    expect(only(`var x = @$"a{b}c";`, "csharp").form).toBe("interpolatedVerbatim");
+  });
+
+  it("keeps a format specifier as part of the expression", () => {
+    const found = only(`var x = $"{since:yyyy-MM-dd}";`, "csharp");
+    expect(found.parts).toEqual([{ kind: "hole", expression: "since:yyyy-MM-dd" }]);
+  });
+
+  it("handles a hole containing braces and a string", () => {
+    const found = only(`var x = $"{dict["a"]}";`, "csharp");
+    expect(found.parts).toEqual([{ kind: "hole", expression: 'dict["a"]' }]);
+  });
+
+  it("unescapes doubled braces in an interpolated string", () => {
+    expect(partsText(only(`var x = $"{{literal}}";`, "csharp").parts)).toBe("{literal}");
+  });
+
+  it("does not treat a char literal's quote as a string delimiter", () => {
+    const found = scanLanguage(`var q = '"'; var x = "real";`, "csharp");
+    expect(found.map((f) => partsText(f.parts))).toEqual(["real"]);
+  });
+
+  it("ignores strings inside comments", () => {
+    const found = scanLanguage(`// var x = "commented";\n/* "block" */\nvar y = "live";`, "csharp");
+    expect(found.map((f) => partsText(f.parts))).toEqual(["live"]);
+  });
+
+  it("reads a raw string but marks it unwritable", () => {
+    const source = 'var x = """\n    <fetch />\n    """;';
+    const found = only(source, "csharp");
+    expect(partsText(found.parts)).toBe("<fetch />");
+    expect(found.writable).toBe(false);
+  });
+
+  it("joins a + concatenation chain into one span with holes for the operands", () => {
+    const source = `var x = "<condition value='" + accountId + "' />";`;
+    const found = only(source, "csharp");
+    expect(found.form).toBe("concat");
+    expect(found.parts).toEqual([
+      { kind: "text", value: "<condition value='" },
+      { kind: "hole", expression: "accountId" },
+      { kind: "text", value: "' />" },
+    ]);
+    expect(span(source, found)).toBe(`"<condition value='" + accountId + "' />"`);
+  });
+
+  it("keeps a method call as a single operand", () => {
+    const found = only(`var x = "a" + Escape(name, "x") + "b";`, "csharp");
+    expect(found.parts).toEqual([
+      { kind: "text", value: "a" },
+      { kind: "hole", expression: 'Escape(name, "x")' },
+      { kind: "text", value: "b" },
+    ]);
+  });
+
+  it("merges adjacent literals in a chain into one text part", () => {
+    expect(only(`var x = "a" + "b" + "c";`, "csharp").parts).toEqual([{ kind: "text", value: "abc" }]);
+  });
+
+  it("stops the chain at the statement end", () => {
+    const source = `var x = "a" + b;\nvar y = "c";`;
+    const found = scanLanguage(source, "csharp");
+    expect(found).toHaveLength(2);
+    expect(span(source, found[0])).toBe(`"a" + b`);
+    expect(found[1].parts).toEqual([{ kind: "text", value: "c" }]);
+  });
+
+  it("spans a chain that wraps across lines", () => {
+    const source = `var x = "<fetch>"\n  + inner\n  + "</fetch>";`;
+    const found = only(source, "csharp");
+    expect(found.parts).toEqual([
+      { kind: "text", value: "<fetch>" },
+      { kind: "hole", expression: "inner" },
+      { kind: "text", value: "</fetch>" },
+    ]);
+  });
+
+  it("does not join across a StringBuilder append — each literal stays separate", () => {
+    const source = `sb.Append("<fetch>");\nsb.Append("<entity />");\nsb.Append("</fetch>");`;
+    expect(scanLanguage(source, "csharp")).toHaveLength(3);
+  });
+});
+
+describe("TypeScript literals", () => {
+  it("reads single and double quoted strings", () => {
+    const found = scanLanguage(`const a = 'x'; const b = "y";`, "typescript");
+    expect(found.map((f) => [f.form, partsText(f.parts)])).toEqual([
+      ["single", "x"],
+      ["regular", "y"],
+    ]);
+  });
+
+  it("reads a template literal with holes", () => {
+    const found = only("const x = `<condition value='${accountId}' />`;", "typescript");
+    expect(found.form).toBe("template");
+    expect(found.parts).toEqual([
+      { kind: "text", value: "<condition value='" },
+      { kind: "hole", expression: "accountId" },
+      { kind: "text", value: "' />" },
+    ]);
+  });
+
+  it("reads a multi-line template literal", () => {
+    expect(partsText(only("const x = `<fetch>\n  <entity name='a' />\n</fetch>`;", "typescript").parts)).toBe("<fetch>\n  <entity name='a' />\n</fetch>");
+  });
+
+  it("handles a hole containing a nested template and braces", () => {
+    const found = only("const x = `${obj[`k`] + f({a: 1})}`;", "typescript");
+    expect(found.parts).toEqual([{ kind: "hole", expression: "obj[`k`] + f({a: 1})" }]);
+  });
+
+  it("unescapes \\${ so it is text, not a hole", () => {
+    expect(only("const x = `\\${notAHole}`;", "typescript").parts).toEqual([{ kind: "text", value: "${notAHole}" }]);
+  });
+
+  it("does not treat a quote inside a regex as a string delimiter", () => {
+    const found = scanLanguage(`const r = /["']/g; const s = "real";`, "typescript");
+    expect(found.map((f) => partsText(f.parts))).toEqual(["real"]);
+  });
+
+  it("still reads division as division", () => {
+    const found = scanLanguage(`const n = a / b; const s = "real";`, "typescript");
+    expect(found.map((f) => partsText(f.parts))).toEqual(["real"]);
+  });
+
+  it("joins a + concatenation chain", () => {
+    const found = only(`const x = "<condition value='" + accountId + "' />";`, "typescript");
+    expect(found.form).toBe("concat");
+    expect(found.parts).toEqual([
+      { kind: "text", value: "<condition value='" },
+      { kind: "hole", expression: "accountId" },
+      { kind: "text", value: "' />" },
+    ]);
+  });
+
+  it("mixes quote styles across a chain", () => {
+    expect(only(`const x = 'a' + b + "c";`, "typescript").parts).toEqual([
+      { kind: "text", value: "a" },
+      { kind: "hole", expression: "b" },
+      { kind: "text", value: "c" },
+    ]);
+  });
+});
+
+describe("form selection and re-encoding", () => {
+  it("keeps a single-line C# verbatim string verbatim", () => {
+    expect(assertReEncodes(`var x = @"<fetch />";`, "csharp")).toBe(`@"<fetch />"`);
+  });
+
+  it("upgrades a C# regular string to verbatim once it spans lines", () => {
+    const found = only(`var x = "<fetch />";`, "csharp");
+    found.parts = [{ kind: "text", value: "<fetch>\n</fetch>" }];
+    expect(chooseForm("csharp", found.form, found.parts)).toBe("verbatim");
+    expect(encodeLiteral("csharp", found.parts, "verbatim")).toBe(`@"<fetch>\n</fetch>"`);
+  });
+
+  it("upgrades a C# verbatim string to interpolated verbatim once a parameter appears", () => {
+    const parts = [
+      { kind: "text" as const, value: "<condition value='" },
+      { kind: "hole" as const, expression: "accountId" },
+      { kind: "text" as const, value: "' />" },
+    ];
+    expect(chooseForm("csharp", "verbatim", parts)).toBe("interpolatedVerbatim");
+    expect(encodeLiteral("csharp", parts, "interpolatedVerbatim")).toBe(`$@"<condition value='{accountId}' />"`);
+  });
+
+  it("escapes braces and quotes when writing an interpolated verbatim string", () => {
+    const encoded = encodeLiteral("csharp", [{ kind: "text", value: `a "b" {c}` }], "interpolatedVerbatim");
+    expect(encoded).toBe(`$@"a ""b"" {{c}}"`);
+    expect(partsText(only(`var x = ${encoded};`, "csharp").parts)).toBe(`a "b" {c}`);
+  });
+
+  it("collapses a C# concatenation chain into one interpolated verbatim string", () => {
+    const source = `var x = "<fetch>" + inner + "</fetch>";`;
+    const found = only(source, "csharp");
+    const form = chooseForm("csharp", found.form, found.parts);
+    expect(form).toBe("interpolated");
+    expect(encodeLiteral("csharp", found.parts, form)).toBe(`$"<fetch>{inner}</fetch>"`);
+  });
+
+  it("sends any parameterised or multi-line TS string to a template literal", () => {
+    expect(chooseForm("typescript", "regular", [{ kind: "hole", expression: "x" }])).toBe("template");
+    expect(chooseForm("typescript", "single", [{ kind: "text", value: "a\nb" }])).toBe("template");
+    expect(chooseForm("typescript", "single", [{ kind: "text", value: "a" }])).toBe("single");
+  });
+
+  it("escapes backticks and ${ when writing a template literal", () => {
+    const encoded = encodeLiteral("typescript", [{ kind: "text", value: "a `b` ${c}" }], "template");
+    expect(encoded).toBe("`a \\`b\\` \\${c}`");
+    expect(partsText(only(`const x = ${encoded};`, "typescript").parts)).toBe("a `b` ${c}");
+  });
+
+  it("re-encodes every shape without losing parts", () => {
+    for (const [source, language] of [
+      [`var x = @"<fetch><entity name=""a"" /></fetch>";`, "csharp"],
+      [`var x = $@"<fetch>{id}</fetch>";`, "csharp"],
+      [`var x = "<fetch>" + id + "</fetch>";`, "csharp"],
+      [`var x = "plain";`, "csharp"],
+      ["const x = `<fetch>${id}</fetch>`;", "typescript"],
+      [`const x = '<fetch />';`, "typescript"],
+      [`const x = "<fetch>" + id + "</fetch>";`, "typescript"],
+    ] as [string, Language][]) {
+      assertReEncodes(source, language);
+    }
+  });
+});

--- a/src/query/literals/scan.ts
+++ b/src/query/literals/scan.ts
@@ -1,0 +1,325 @@
+// Shared string-literal / concatenation-chain scanner (#238).
+//
+// Finding FetchXML in code needs real lexing, not a regex: you cannot tell `"` inside `@"a""b"`
+// from a closing quote, or `${`…`}` nesting inside a template literal, without walking the text.
+// This module owns the language-INDEPENDENT half — the walk, and the `+` chain logic — and each
+// language supplies a reader for its own literal syntax.
+//
+// The output models all three shapes developers actually write FetchXML in as one thing:
+//
+//   $"<fetch>…value='{id}'…</fetch>"          one interpolated literal
+//   `<fetch>…value='${id}'…</fetch>`          one template literal
+//   "<fetch>…value='" + id + "'…</fetch>"     a concatenation chain
+//
+// All become { parts: [text, hole, text] }. A query assembled with a StringBuilder or across loop
+// iterations never yields a complete <fetch>…</fetch> in one span, so it simply isn't found — the
+// honest failure mode, rather than a half-parsed query we might mangle on save.
+//
+// Pure (no `vscode`) → unit-tested.
+
+export type Language = "csharp" | "typescript";
+
+/** How the span was written. Drives how we re-encode it on write-back. */
+export type LiteralForm =
+  | "regular" // "…"           (C# and TS)
+  | "single" // '…'            (TS only)
+  | "verbatim" // @"…"          (C#)
+  | "interpolated" // $"…"      (C#)
+  | "interpolatedVerbatim" // $@"…" / @$"…"
+  | "raw" // """…"""            (C# 11)
+  | "template" // `…`           (TS)
+  | "concat"; // a + chain of the above
+
+export type StringPart = { kind: "text"; value: string } | { kind: "hole"; expression: string };
+
+export interface CodeString {
+  /** Offsets into the source of the whole span to replace on write-back. */
+  start: number;
+  end: number;
+  parts: StringPart[];
+  form: LiteralForm;
+  language: Language;
+  /** False when the span cannot be faithfully re-emitted (an interpolated C# raw string). Such a
+   * query is still detected — Run and diagnostics work — but the generator opens read-only. */
+  writable: boolean;
+}
+
+export interface ReadLiteral {
+  end: number;
+  parts: StringPart[];
+  form: LiteralForm;
+  writable: boolean;
+}
+
+export interface LiteralReader {
+  /** Read a literal starting at `i`, or undefined if none starts there. */
+  readLiteral(text: string, i: number): ReadLiteral | undefined;
+  /** Consume whitespace and comments; return the next significant offset. */
+  skipTrivia(text: string, i: number): number;
+  /** Consume a token that is neither trivia nor a string but must not be lexed as one — a C# char
+   * literal, a TS regex — returning its end offset, or undefined. Without this, `'"'` would open a
+   * phantom string and desynchronise the whole scan. */
+  readAtomic(text: string, i: number, previousSignificant: string): number | undefined;
+}
+
+/** Cap on a single concatenation operand, so a runaway scan can't swallow a whole file. */
+const MAX_OPERAND_LENGTH = 400;
+/** Cap on chain links — far above any real query, a backstop against pathological input. */
+const MAX_CHAIN_PARTS = 500;
+
+const OPERAND_TERMINATORS = new Set(["+", ";", ",", ")", "]", "}"]);
+
+/**
+ * Read a non-literal operand of a `+` chain — the `id` in `"a" + id + "b"`. Returns the raw
+ * expression text, which is written back verbatim, so it does not need to be understood, only
+ * delimited. Bracket depth is tracked and nested strings/comments are skipped so a call like
+ * `Escape("a+b")` survives intact.
+ */
+function readOperand(text: string, start: number, reader: LiteralReader): { end: number; expression: string } | undefined {
+  let i = start;
+  let depth = 0;
+  while (i < text.length && i - start < MAX_OPERAND_LENGTH) {
+    const trivia = reader.skipTrivia(text, i);
+    if (trivia !== i) {
+      i = trivia;
+      continue;
+    }
+    const literal = reader.readLiteral(text, i);
+    if (literal) {
+      i = literal.end;
+      continue;
+    }
+    const atomic = reader.readAtomic(text, i, text[i - 1] ?? "");
+    if (atomic !== undefined) {
+      i = atomic;
+      continue;
+    }
+    const char = text[i];
+    if (char === "(" || char === "[" || char === "{") {
+      depth++;
+    } else if (char === ")" || char === "]" || char === "}") {
+      if (depth === 0) {
+        break; // closes the expression we sit inside
+      }
+      depth--;
+    } else if (depth === 0 && OPERAND_TERMINATORS.has(char)) {
+      break;
+    } else if (char === "\n" && depth === 0) {
+      // A bare newline only continues the operand if a `+` follows; otherwise the statement ended.
+      const next = reader.skipTrivia(text, i);
+      if (text[next] !== "+") {
+        break;
+      }
+    }
+    i++;
+  }
+  const expression = text.slice(start, i).trim();
+  return expression.length === 0 ? undefined : { end: start + text.slice(start, i).trimEnd().length, expression };
+}
+
+/**
+ * Find every string literal and `+` concatenation chain in `text`. Chains are returned as one
+ * CodeString spanning the whole expression, because writing back a chain replaces all of it.
+ */
+export function scanCodeStrings(text: string, reader: LiteralReader, language: Language): CodeString[] {
+  const found: CodeString[] = [];
+  let i = 0;
+  let previousSignificant = "";
+
+  while (i < text.length) {
+    const trivia = reader.skipTrivia(text, i);
+    if (trivia !== i) {
+      i = trivia;
+      continue;
+    }
+
+    const literal = reader.readLiteral(text, i);
+    if (!literal) {
+      const atomic = reader.readAtomic(text, i, previousSignificant);
+      if (atomic !== undefined) {
+        i = atomic;
+        previousSignificant = "";
+        continue;
+      }
+      if (!/\s/.test(text[i])) {
+        previousSignificant = text[i];
+      }
+      i++;
+      continue;
+    }
+
+    // A literal starts here: gather the whole `+` chain hanging off it.
+    const start = i;
+    const parts: StringPart[] = [...literal.parts];
+    let end = literal.end;
+    let writable = literal.writable;
+    let links = 1;
+
+    for (;;) {
+      if (parts.length > MAX_CHAIN_PARTS) {
+        writable = false;
+        break;
+      }
+      const afterOperand = reader.skipTrivia(text, end);
+      if (text[afterOperand] !== "+") {
+        break;
+      }
+      const afterPlus = reader.skipTrivia(text, afterOperand + 1);
+      const nextLiteral = reader.readLiteral(text, afterPlus);
+      if (nextLiteral) {
+        parts.push(...nextLiteral.parts);
+        end = nextLiteral.end;
+        writable = writable && nextLiteral.writable;
+        links++;
+        continue;
+      }
+      const operand = readOperand(text, afterPlus, reader);
+      if (!operand) {
+        break;
+      }
+      parts.push({ kind: "hole", expression: operand.expression });
+      end = operand.end;
+      links++;
+    }
+
+    found.push({ start, end, parts: mergeAdjacentText(parts), form: links > 1 ? "concat" : literal.form, language, writable });
+    previousSignificant = "";
+    i = end;
+  }
+
+  return found;
+}
+
+/** Collapse runs of text parts so the XML we hand to the parser is contiguous. */
+export function mergeAdjacentText(parts: StringPart[]): StringPart[] {
+  const merged: StringPart[] = [];
+  for (const part of parts) {
+    const last = merged[merged.length - 1];
+    if (part.kind === "text" && last?.kind === "text") {
+      merged[merged.length - 1] = { kind: "text", value: last.value + part.value };
+    } else {
+      merged.push(part);
+    }
+  }
+  return merged;
+}
+
+/** The decoded string with holes removed — used only to test whether a span contains FetchXML. */
+export function partsText(parts: StringPart[]): string {
+  return parts.map((part) => (part.kind === "text" ? part.value : "")).join("");
+}
+
+export function hasHoles(parts: StringPart[]): boolean {
+  return parts.some((part) => part.kind === "hole");
+}
+
+/** Shared by both languages: `// line` and `/* block *​/` comments plus whitespace. */
+export function skipCStyleTrivia(text: string, i: number): number {
+  let position = i;
+  for (;;) {
+    while (position < text.length && /\s/.test(text[position])) {
+      position++;
+    }
+    if (text.startsWith("//", position)) {
+      const newline = text.indexOf("\n", position);
+      position = newline === -1 ? text.length : newline + 1;
+      continue;
+    }
+    if (text.startsWith("/*", position)) {
+      const close = text.indexOf("*/", position + 2);
+      position = close === -1 ? text.length : close + 2;
+      continue;
+    }
+    return position;
+  }
+}
+
+/** Read the balanced body of an interpolation hole starting after its opening brace. Nested
+ * braces, strings and template literals inside the expression are skipped so `{d[","]}` works. */
+export function readBalancedHole(text: string, start: number, closeChar: string): { end: number; expression: string } | undefined {
+  let i = start;
+  let depth = 0;
+  while (i < text.length) {
+    const char = text[i];
+    if (char === '"' || char === "'" || char === "`") {
+      i = skipSimpleString(text, i);
+      continue;
+    }
+    if (char === "{" || char === "(" || char === "[") {
+      depth++;
+    } else if (char === ")" || char === "]") {
+      depth--;
+    } else if (char === closeChar) {
+      if (depth === 0) {
+        return { end: i + 1, expression: text.slice(start, i) };
+      }
+      depth--;
+    }
+    i++;
+  }
+  return undefined;
+}
+
+/** Skip a quoted run, honouring backslash escapes. Used only inside hole expressions. */
+function skipSimpleString(text: string, i: number): number {
+  const quote = text[i];
+  let position = i + 1;
+  while (position < text.length) {
+    if (text[position] === "\\") {
+      position += 2;
+      continue;
+    }
+    if (text[position] === quote) {
+      return position + 1;
+    }
+    position++;
+  }
+  return text.length;
+}
+
+/** Decode one backslash escape at `i` (which points at the backslash). */
+export function decodeEscape(text: string, i: number): { value: string; next: number } {
+  const char = text[i + 1];
+  switch (char) {
+    case "n":
+      return { value: "\n", next: i + 2 };
+    case "r":
+      return { value: "\r", next: i + 2 };
+    case "t":
+      return { value: "\t", next: i + 2 };
+    case "b":
+      return { value: "\b", next: i + 2 };
+    case "f":
+      return { value: "\f", next: i + 2 };
+    case "v":
+      return { value: "\v", next: i + 2 };
+    case "0":
+      return { value: "\0", next: i + 2 };
+    case "\r":
+      // A TS line continuation: the newline vanishes.
+      return { value: "", next: text[i + 2] === "\n" ? i + 3 : i + 2 };
+    case "\n":
+      return { value: "", next: i + 2 };
+    case "x": {
+      const hex = text.slice(i + 2, i + 4);
+      return /^[0-9a-fA-F]{2}$/.test(hex) ? { value: String.fromCharCode(parseInt(hex, 16)), next: i + 4 } : { value: "x", next: i + 2 };
+    }
+    case "u": {
+      if (text[i + 2] === "{") {
+        const close = text.indexOf("}", i + 3);
+        const hex = close === -1 ? "" : text.slice(i + 3, close);
+        if (/^[0-9a-fA-F]{1,6}$/.test(hex)) {
+          return { value: String.fromCodePoint(parseInt(hex, 16)), next: close + 1 };
+        }
+        return { value: "u", next: i + 2 };
+      }
+      const hex = text.slice(i + 2, i + 6);
+      return /^[0-9a-fA-F]{4}$/.test(hex) ? { value: String.fromCharCode(parseInt(hex, 16)), next: i + 6 } : { value: "u", next: i + 2 };
+    }
+    case undefined:
+      return { value: "", next: i + 1 };
+    default:
+      // Covers \\ \" \' \` \$ and anything unrecognised, which drops the backslash.
+      return { value: char, next: i + 2 };
+  }
+}

--- a/src/query/literals/typescript.ts
+++ b/src/query/literals/typescript.ts
@@ -1,0 +1,160 @@
+// TypeScript / JavaScript string-literal reading and writing (#238).
+//
+// Three forms matter: `'…'`, `"…"` and the template literal `` `…${expr}…` `` — the last being how
+// almost all modern web-resource code builds a parameterised FetchXML string.
+//
+// Regex literals get their own handling: `/["']/` would otherwise open a phantom string and
+// desynchronise the whole scan. Telling `/` as division from `/` as a regex needs the previous
+// significant character, which is why LiteralReader is handed it.
+//
+// Pure (no `vscode`) → unit-tested.
+
+import { LiteralForm, LiteralReader, ReadLiteral, StringPart, decodeEscape, hasHoles, readBalancedHole, skipCStyleTrivia } from "./scan";
+
+/** Characters after which a `/` starts a regex rather than dividing. */
+const REGEX_PRECEDERS = new Set(["(", ",", "=", ":", "[", "!", "&", "|", "?", "{", "}", ";", "+", "*", "%", "~", "^", "<", ">", "", "\n"]);
+
+function readQuoted(text: string, contentStart: number, quote: '"' | "'"): ReadLiteral | undefined {
+  let buffer = "";
+  let i = contentStart;
+  while (i < text.length) {
+    const char = text[i];
+    if (char === "\n") {
+      return undefined; // a quoted TS string cannot span lines
+    }
+    if (char === "\\") {
+      const decoded = decodeEscape(text, i);
+      buffer += decoded.value;
+      i = decoded.next;
+      continue;
+    }
+    if (char === quote) {
+      const parts: StringPart[] = buffer.length > 0 ? [{ kind: "text", value: buffer }] : [];
+      return { end: i + 1, parts, form: quote === "'" ? "single" : "regular", writable: true };
+    }
+    buffer += char;
+    i++;
+  }
+  return undefined;
+}
+
+function readTemplate(text: string, contentStart: number): ReadLiteral | undefined {
+  const parts: StringPart[] = [];
+  let buffer = "";
+  let i = contentStart;
+  while (i < text.length) {
+    const char = text[i];
+    if (char === "\\") {
+      const decoded = decodeEscape(text, i);
+      buffer += decoded.value;
+      i = decoded.next;
+      continue;
+    }
+    if (char === "$" && text[i + 1] === "{") {
+      const hole = readBalancedHole(text, i + 2, "}");
+      if (!hole) {
+        return undefined;
+      }
+      if (buffer.length > 0) {
+        parts.push({ kind: "text", value: buffer });
+        buffer = "";
+      }
+      parts.push({ kind: "hole", expression: hole.expression.trim() });
+      i = hole.end;
+      continue;
+    }
+    if (char === "`") {
+      if (buffer.length > 0) {
+        parts.push({ kind: "text", value: buffer });
+      }
+      return { end: i + 1, parts, form: "template", writable: true };
+    }
+    buffer += char;
+    i++;
+  }
+  return undefined;
+}
+
+export const typescriptReader: LiteralReader = {
+  skipTrivia: skipCStyleTrivia,
+
+  readLiteral(text, i) {
+    const char = text[i];
+    if (char === '"') {
+      return readQuoted(text, i + 1, '"');
+    }
+    if (char === "'") {
+      return readQuoted(text, i + 1, "'");
+    }
+    if (char === "`") {
+      return readTemplate(text, i + 1);
+    }
+    return undefined;
+  },
+
+  readAtomic(text, i, previousSignificant) {
+    if (text[i] !== "/" || !REGEX_PRECEDERS.has(previousSignificant)) {
+      return undefined;
+    }
+    // Comments are trivia and already handled; anything else here is a regex body.
+    if (text[i + 1] === "/" || text[i + 1] === "*") {
+      return undefined;
+    }
+    let position = i + 1;
+    let inClass = false;
+    while (position < text.length && text[position] !== "\n") {
+      const char = text[position];
+      if (char === "\\") {
+        position += 2;
+        continue;
+      }
+      if (char === "[") {
+        inClass = true;
+      } else if (char === "]") {
+        inClass = false;
+      } else if (char === "/" && !inClass) {
+        position++;
+        while (position < text.length && /[a-z]/.test(text[position])) {
+          position++; // flags
+        }
+        return position;
+      }
+      position++;
+    }
+    return undefined;
+  },
+};
+
+/**
+ * Pick the literal form to write. A template literal is the only TS form that can hold both a
+ * newline and a parameter, so any multi-line or parameterised query becomes one; a plain
+ * single-line query keeps the author's quote style.
+ */
+export function chooseTypescriptForm(original: LiteralForm, parts: StringPart[]): LiteralForm {
+  const multiline = parts.some((part) => part.kind === "text" && /[\r\n]/.test(part.value));
+  if (multiline || hasHoles(parts)) {
+    return "template";
+  }
+  return original === "single" ? "single" : original === "template" ? "template" : "regular";
+}
+
+/** Emit TypeScript source for the parts, including delimiters, in the given form. */
+export function encodeTypescript(parts: StringPart[], form: LiteralForm): string {
+  if (form === "template") {
+    const body = parts.map((part) => (part.kind === "hole" ? `\${${part.expression}}` : part.value.replace(/\\/g, "\\\\").replace(/`/g, "\\`").replace(/\$\{/g, "\\${"))).join("");
+    return `\`${body}\``;
+  }
+
+  const quote = form === "single" ? "'" : '"';
+  const body = parts
+    .map((part) => {
+      if (part.kind === "hole") {
+        // Unreachable for a well-formed call — chooseTypescriptForm sends holes to a template —
+        // but concatenating keeps the emitted code valid rather than silently dropping a parameter.
+        return `${quote} + ${part.expression} + ${quote}`;
+      }
+      return part.value.replace(/\\/g, "\\\\").replace(new RegExp(quote, "g"), `\\${quote}`).replace(/\r/g, "\\r").replace(/\n/g, "\\n").replace(/\t/g, "\\t");
+    })
+    .join("");
+  return `${quote}${body}${quote}`;
+}

--- a/src/query/metadata/cache.ts
+++ b/src/query/metadata/cache.ts
@@ -1,0 +1,160 @@
+// Lazy, session-scoped Dataverse metadata (#238).
+//
+// Deliberately NOT persisted to disk. The people using this are changing metadata while they use
+// it — add a column in the maker portal, come back, expect to see it — so a cache that outlived the
+// session would actively lie. In-memory for the session, cleared explicitly or whenever the
+// connection changes, is both cheaper and more correct.
+//
+// Three tiers, each fetched on first use: the table list when the generator opens, a table's
+// attributes when it is selected, its relationships when a join is added.
+//
+// The cache is pure (the fetcher is injected) → unit-tested without a network or `vscode`.
+
+export interface TableMetadata {
+  logicalName: string;
+  displayName: string;
+  /** Needed to build the Web API URL — `?fetchXml=` hangs off the entity SET name, not the
+   * logical name, and getting this wrong is a 404 on every query. */
+  entitySetName: string;
+  primaryIdAttribute: string;
+  primaryNameAttribute: string;
+}
+
+export interface AttributeMetadata {
+  logicalName: string;
+  displayName: string;
+  /** Dataverse AttributeType, e.g. "Uniqueidentifier", "Lookup", "DateTime", "Picklist". */
+  attributeType: string;
+  /** Lookup targets, when this is a lookup. */
+  targets?: string[];
+}
+
+export interface RelationshipMetadata {
+  schemaName: string;
+  kind: "OneToMany" | "ManyToOne" | "ManyToMany";
+  /** The entity on the other end — the `name` of the `<link-entity>`. */
+  relatedEntity: string;
+  /** `from`/`to` as they should appear on the `<link-entity>` for this direction. */
+  from: string;
+  to: string;
+  intersect?: boolean;
+}
+
+export interface MetadataFetcher {
+  tables(): Promise<TableMetadata[]>;
+  attributes(logicalName: string): Promise<AttributeMetadata[]>;
+  relationships(logicalName: string): Promise<RelationshipMetadata[]>;
+}
+
+/** The read-only view diagnostics need. `undefined` means "not loaded", never "does not exist", so
+ * an un-warmed cache produces no false warnings. */
+export interface MetadataLookup {
+  knownEntity(logicalName: string): boolean | undefined;
+  knownAttribute(logicalName: string, attribute: string): boolean | undefined;
+  attributeType(logicalName: string, attribute: string): string | undefined;
+}
+
+export interface MetadataCache extends MetadataLookup {
+  getTables(): Promise<TableMetadata[]>;
+  getAttributes(logicalName: string): Promise<AttributeMetadata[]>;
+  getRelationships(logicalName: string): Promise<RelationshipMetadata[]>;
+  entitySetName(logicalName: string): string | undefined;
+  /** Already-loaded values, for a synchronous render — undefined means "not loaded yet". */
+  loadedTables(): TableMetadata[] | undefined;
+  loadedAttributes(logicalName: string): AttributeMetadata[] | undefined;
+  clear(): void;
+}
+
+/** Share one in-flight promise per key so a burst of requests makes a single HTTP call. */
+function memoize<K, V>(store: Map<K, V>, pending: Map<K, Promise<V>>, key: K, load: () => Promise<V>): Promise<V> {
+  const cached = store.get(key);
+  if (cached !== undefined) {
+    return Promise.resolve(cached);
+  }
+  const inFlight = pending.get(key);
+  if (inFlight) {
+    return inFlight;
+  }
+  const promise = load()
+    .then((value) => {
+      store.set(key, value);
+      return value;
+    })
+    .finally(() => pending.delete(key));
+  pending.set(key, promise);
+  return promise;
+}
+
+export function createMetadataCache(fetcher: MetadataFetcher): MetadataCache {
+  let tables: TableMetadata[] | undefined;
+  let tablesPending: Promise<TableMetadata[]> | undefined;
+  const attributes = new Map<string, AttributeMetadata[]>();
+  const attributesPending = new Map<string, Promise<AttributeMetadata[]>>();
+  const relationships = new Map<string, RelationshipMetadata[]>();
+  const relationshipsPending = new Map<string, Promise<RelationshipMetadata[]>>();
+
+  function attributeOf(logicalName: string, attribute: string): AttributeMetadata | undefined {
+    return attributes.get(logicalName)?.find((candidate) => candidate.logicalName === attribute.toLowerCase());
+  }
+
+  return {
+    getTables() {
+      if (tables !== undefined) {
+        return Promise.resolve(tables);
+      }
+      if (!tablesPending) {
+        tablesPending = fetcher
+          .tables()
+          .then((loaded) => {
+            tables = loaded;
+            return loaded;
+          })
+          .finally(() => {
+            tablesPending = undefined;
+          });
+      }
+      return tablesPending;
+    },
+
+    getAttributes(logicalName) {
+      return memoize(attributes, attributesPending, logicalName.toLowerCase(), () => fetcher.attributes(logicalName.toLowerCase()));
+    },
+
+    getRelationships(logicalName) {
+      return memoize(relationships, relationshipsPending, logicalName.toLowerCase(), () => fetcher.relationships(logicalName.toLowerCase()));
+    },
+
+    entitySetName(logicalName) {
+      return tables?.find((table) => table.logicalName === logicalName.toLowerCase())?.entitySetName;
+    },
+
+    loadedTables() {
+      return tables;
+    },
+
+    loadedAttributes(logicalName) {
+      return attributes.get(logicalName.toLowerCase());
+    },
+
+    knownEntity(logicalName) {
+      return tables === undefined ? undefined : tables.some((table) => table.logicalName === logicalName.toLowerCase());
+    },
+
+    knownAttribute(logicalName, attribute) {
+      return attributes.has(logicalName.toLowerCase()) ? attributeOf(logicalName, attribute) !== undefined : undefined;
+    },
+
+    attributeType(logicalName, attribute) {
+      return attributeOf(logicalName, attribute)?.attributeType;
+    },
+
+    clear() {
+      tables = undefined;
+      tablesPending = undefined;
+      attributes.clear();
+      attributesPending.clear();
+      relationships.clear();
+      relationshipsPending.clear();
+    },
+  };
+}

--- a/src/query/metadata/dataverseFetcher.ts
+++ b/src/query/metadata/dataverseFetcher.ts
@@ -1,0 +1,148 @@
+// The real metadata fetcher behind the cache (#238).
+//
+// Kept separate from cache.ts so the caching logic stays pure and unit-tested while this file holds
+// only the HTTP shapes. Every call goes through the extension's own token, so it works identically
+// under service-principal and interactive (OAuth) auth — no `tenantId` anywhere near it.
+
+import fetch from "node-fetch";
+import DataversePowerToolsContext from "../../context";
+import { Options } from "../../general/dataverse/dataverseContext";
+import { dataverseApiUrl, logDataverseHttpError } from "../../general/dataverse/webApi";
+import { AttributeMetadata, MetadataFetcher, RelationshipMetadata, TableMetadata } from "./cache";
+
+/* eslint-disable @typescript-eslint/naming-convention -- the metadata API's own property names. */
+interface Label {
+  UserLocalizedLabel?: { Label?: string } | null;
+}
+/* eslint-enable @typescript-eslint/naming-convention */
+
+function labelText(label: Label | undefined | null, fallback: string): string {
+  return label?.UserLocalizedLabel?.Label ?? fallback;
+}
+
+async function getJson(context: DataversePowerToolsContext, resource: string, operation: string): Promise<Record<string, unknown> | undefined> {
+  const token = await context.dataverse.getAuthorizationToken();
+  if (!token || !context.dataverse.organizationUrl) {
+    return undefined;
+  }
+  /* eslint-disable @typescript-eslint/naming-convention */
+  const options = {
+    method: "GET",
+    headers: { Authorization: `Bearer ${token}`, "Content-Type": "application/json", Accept: "application/json" },
+  } as Options;
+  /* eslint-enable @typescript-eslint/naming-convention */
+
+  const response = await fetch(dataverseApiUrl(context.dataverse.organizationUrl, resource), options);
+  if (!response.ok) {
+    await logDataverseHttpError(context.channel, operation, response);
+    throw new Error(`${operation} failed with ${response.status}.`);
+  }
+  return (await response.json()) as Record<string, unknown>;
+}
+
+function records(payload: Record<string, unknown> | undefined): Record<string, unknown>[] {
+  return Array.isArray(payload?.value) ? (payload?.value as Record<string, unknown>[]) : [];
+}
+
+export function createDataverseMetadataFetcher(context: DataversePowerToolsContext): MetadataFetcher {
+  return {
+    async tables(): Promise<TableMetadata[]> {
+      // EntitySetName is the part the query URL needs; without it every run 404s.
+      const payload = await getJson(
+        context,
+        "EntityDefinitions?$select=LogicalName,EntitySetName,PrimaryIdAttribute,PrimaryNameAttribute,DisplayName&$filter=IsPrivate eq false",
+        "load table metadata",
+      );
+      return records(payload)
+        .map((record) => ({
+          logicalName: String(record.LogicalName ?? ""),
+          displayName: labelText(record.DisplayName as Label, String(record.LogicalName ?? "")),
+          entitySetName: String(record.EntitySetName ?? ""),
+          primaryIdAttribute: String(record.PrimaryIdAttribute ?? ""),
+          primaryNameAttribute: String(record.PrimaryNameAttribute ?? ""),
+        }))
+        .filter((table) => table.logicalName.length > 0)
+        .sort((a, b) => a.logicalName.localeCompare(b.logicalName));
+    },
+
+    async attributes(logicalName: string): Promise<AttributeMetadata[]> {
+      const escaped = logicalName.replace(/'/g, "''");
+      const payload = await getJson(
+        context,
+        `EntityDefinitions(LogicalName='${escaped}')/Attributes?$select=LogicalName,AttributeType,DisplayName&$filter=AttributeOf eq null`,
+        `load columns for '${logicalName}'`,
+      );
+      return records(payload)
+        .map((record) => ({
+          logicalName: String(record.LogicalName ?? ""),
+          displayName: labelText(record.DisplayName as Label, String(record.LogicalName ?? "")),
+          attributeType: String(record.AttributeType ?? ""),
+        }))
+        .filter((attribute) => attribute.logicalName.length > 0)
+        .sort((a, b) => a.logicalName.localeCompare(b.logicalName));
+    },
+
+    async relationships(logicalName: string): Promise<RelationshipMetadata[]> {
+      const escaped = logicalName.replace(/'/g, "''");
+      const base = `EntityDefinitions(LogicalName='${escaped}')`;
+      // Three collections, fetched in parallel so adding a join costs one round trip.
+      const [oneToMany, manyToOne, manyToMany] = await Promise.all([
+        getJson(
+          context,
+          `${base}/OneToManyRelationships?$select=SchemaName,ReferencingEntity,ReferencingAttribute,ReferencedEntity,ReferencedAttribute`,
+          `load relationships for '${logicalName}'`,
+        ),
+        getJson(
+          context,
+          `${base}/ManyToOneRelationships?$select=SchemaName,ReferencingEntity,ReferencingAttribute,ReferencedEntity,ReferencedAttribute`,
+          `load relationships for '${logicalName}'`,
+        ),
+        getJson(
+          context,
+          `${base}/ManyToManyRelationships?$select=SchemaName,Entity1LogicalName,Entity1IntersectAttribute,Entity2LogicalName,Entity2IntersectAttribute,IntersectEntityName`,
+          `load relationships for '${logicalName}'`,
+        ),
+      ]);
+
+      const found: RelationshipMetadata[] = [];
+
+      // This entity is the PARENT: the join goes out to the child's foreign key.
+      for (const record of records(oneToMany)) {
+        found.push({
+          schemaName: String(record.SchemaName ?? ""),
+          kind: "OneToMany",
+          relatedEntity: String(record.ReferencingEntity ?? ""),
+          from: String(record.ReferencingAttribute ?? ""),
+          to: String(record.ReferencedAttribute ?? ""),
+        });
+      }
+
+      // This entity is the CHILD: the join goes up to the parent's primary key, so from/to swap.
+      for (const record of records(manyToOne)) {
+        found.push({
+          schemaName: String(record.SchemaName ?? ""),
+          kind: "ManyToOne",
+          relatedEntity: String(record.ReferencedEntity ?? ""),
+          from: String(record.ReferencedAttribute ?? ""),
+          to: String(record.ReferencingAttribute ?? ""),
+        });
+      }
+
+      // Many-to-many: the first hop is the intersect table, keyed on this entity's own column.
+      for (const record of records(manyToMany)) {
+        const isEntity1 = String(record.Entity1LogicalName ?? "").toLowerCase() === logicalName.toLowerCase();
+        const ownAttribute = String((isEntity1 ? record.Entity1IntersectAttribute : record.Entity2IntersectAttribute) ?? "");
+        found.push({
+          schemaName: String(record.SchemaName ?? ""),
+          kind: "ManyToMany",
+          relatedEntity: String(record.IntersectEntityName ?? ""),
+          from: ownAttribute,
+          to: ownAttribute,
+          intersect: true,
+        });
+      }
+
+      return found.filter((relationship) => relationship.relatedEntity.length > 0).sort((a, b) => a.relatedEntity.localeCompare(b.relatedEntity));
+    },
+  };
+}

--- a/src/query/metadataService.ts
+++ b/src/query/metadataService.ts
@@ -1,0 +1,33 @@
+// Session-scoped metadata caches, one per environment (#238).
+//
+// Keying on the organization URL means switching environment gets a fresh cache for free, with no
+// listener to remember to wire up. Nothing is written to disk on purpose (see cache.ts): people are
+// changing metadata while they use this, so a cache that outlived the session would lie.
+
+import DataversePowerToolsContext from "../context";
+import { MetadataCache, createMetadataCache } from "./metadata/cache";
+import { createDataverseMetadataFetcher } from "./metadata/dataverseFetcher";
+import { forgetConnectedIdentity } from "./runQuery";
+
+const caches = new Map<string, MetadataCache>();
+
+/** The cache for the currently connected environment, created on first use. */
+export function getMetadataCache(context: DataversePowerToolsContext): MetadataCache {
+  const key = context.dataverse?.organizationUrl ?? "";
+  const existing = caches.get(key);
+  if (existing) {
+    return existing;
+  }
+  const cache = createMetadataCache(createDataverseMetadataFetcher(context));
+  caches.set(key, cache);
+  return cache;
+}
+
+/** Forget everything — the "Clear Metadata Cache" command, and any connection change. */
+export function clearMetadataCaches(): void {
+  for (const cache of caches.values()) {
+    cache.clear();
+  }
+  caches.clear();
+  forgetConnectedIdentity();
+}

--- a/src/query/parameters.spec.ts
+++ b/src/query/parameters.spec.ts
@@ -1,0 +1,326 @@
+import { describe, it, expect } from "vitest";
+import { collectParameters, inferParameterType, normalizeParameterValue, substituteParameters, validateParameterValue } from "./parameters";
+import { diagnoseQuery } from "./diagnostics";
+import { detectQueries } from "./detect";
+import { parseFetchXml } from "./fetchXml";
+import { allTokenNames } from "./holes";
+import { consumerById, UNKNOWN_CONSUMER } from "./consumers";
+import { MetadataLookup } from "./metadata/cache";
+import { QueryNode } from "./queryModel";
+
+function rootOf(xml: string): QueryNode {
+  const parsed = parseFetchXml(xml);
+  if (!parsed.ok) {
+    throw new Error(parsed.error);
+  }
+  return parsed.root;
+}
+
+/** A metadata stand-in: knows one table, so it can answer both "yes" and "no" definitively. */
+const metadata: MetadataLookup = {
+  knownEntity: (entity) => ["incident", "account"].includes(entity),
+  knownAttribute: (entity, attribute) => (entity === "incident" ? ["customerid", "createdon", "title", "statecode", "ticketnumber"].includes(attribute) : undefined),
+  attributeType: (entity, attribute) =>
+    entity === "incident" ? { customerid: "Customer", createdon: "DateTime", title: "String", statecode: "State", ticketnumber: "String" }[attribute] : undefined,
+};
+
+const PARAMETERISED = `<fetch>
+  <entity name="incident">
+    <filter type="and">
+      <condition attribute="customerid" operator="eq" value="@accountId" />
+      <condition attribute="createdon" operator="on-or-after" value="@since" />
+      <condition attribute="title" operator="like" value="%@term%" />
+      <condition attribute="createdon" operator="last-x-days" value="@days" />
+    </filter>
+  </entity>
+</fetch>`;
+
+describe("collecting parameters", () => {
+  const root = rootOf(PARAMETERISED);
+  const parameters = collectParameters(root, allTokenNames(PARAMETERISED));
+
+  it("finds every parameter in document order with its usage", () => {
+    expect(parameters.map((p) => p.name)).toEqual(["accountId", "since", "term", "days"]);
+    expect(parameters[0].usages).toEqual([{ entity: "incident", attribute: "customerid", operator: "eq" }]);
+  });
+
+  it("records both usages of a parameter used twice, so it is prompted for once", () => {
+    const xml = `<fetch><entity name="incident"><filter><condition attribute="createdon" operator="on-or-after" value="@d" /><condition attribute="createdon" operator="on-or-before" value="@d" /></filter></entity></fetch>`;
+    const collected = collectParameters(rootOf(xml), allTokenNames(xml));
+    expect(collected).toHaveLength(1);
+    expect(collected[0].usages).toHaveLength(2);
+  });
+
+  it("finds a parameter inside <value> children of an in condition", () => {
+    const xml = `<fetch><entity name="incident"><filter><condition attribute="statecode" operator="in"><value>@first</value><value>1</value></condition></filter></entity></fetch>`;
+    expect(collectParameters(rootOf(xml), allTokenNames(xml)).map((p) => p.name)).toEqual(["first"]);
+  });
+
+  it("prefers a condition's entityname over the enclosing scope", () => {
+    const xml = `<fetch><entity name="account"><link-entity name="contact" from="parentcustomerid" to="accountid" alias="c" /><filter><condition entityname="c" attribute="fullname" operator="eq" value="@who" /></filter></entity></fetch>`;
+    expect(collectParameters(rootOf(xml), allTokenNames(xml))[0].usages[0].entity).toBe("c");
+  });
+
+  it("attaches the code expression when there is one", () => {
+    const query = detectQueries(
+      `var x = $@"<fetch><entity name='incident'><filter><condition attribute='customerid' operator='eq' value='{accountId}' /></filter></entity></fetch>";`,
+      "csharp",
+    )[0];
+    const collected = collectParameters(query.root, allTokenNames(query.xml), Object.fromEntries(query.tokens.map((t) => [t.name, t.expression])));
+    expect(collected[0].expression).toBe("accountId");
+  });
+
+  it("drops a parameter whose condition the user deleted", () => {
+    const xml = `<fetch><entity name="incident" /></fetch>`;
+    expect(collectParameters(rootOf(xml), ["accountId"])).toEqual([]);
+  });
+});
+
+describe("inferring a parameter type", () => {
+  const parameters = collectParameters(rootOf(PARAMETERISED), allTokenNames(PARAMETERISED));
+  const byName = Object.fromEntries(parameters.map((p) => [p.name, p]));
+
+  it("reads the type from metadata", () => {
+    expect(inferParameterType(byName.accountId, metadata)).toBe("guid");
+    expect(inferParameterType(byName.since, metadata)).toBe("datetime");
+    expect(inferParameterType(byName.term, metadata)).toBe("string");
+  });
+
+  it("treats an -x-days operator as a COUNT, not a date, even on a date column", () => {
+    expect(inferParameterType(byName.days, metadata)).toBe("number");
+  });
+
+  it("falls back to naming and operator heuristics with no metadata", () => {
+    expect(inferParameterType(byName.accountId)).toBe("guid");
+    expect(inferParameterType(byName.since)).toBe("datetime");
+    expect(inferParameterType(byName.term)).toBe("string");
+    expect(inferParameterType(byName.days)).toBe("number");
+  });
+
+  it("defaults to string when it knows nothing", () => {
+    expect(inferParameterType({ name: "x", token: "@x", usages: [{}] })).toBe("string");
+  });
+});
+
+describe("validating and normalising prompted values", () => {
+  it("accepts a guid in any common shape and normalises it", () => {
+    expect(validateParameterValue("guid", "{6B29FC40-CA47-1067-B31D-00DD010662DA}")).toBeUndefined();
+    expect(normalizeParameterValue("guid", "{6B29FC40-CA47-1067-B31D-00DD010662DA}")).toBe("6b29fc40-ca47-1067-b31d-00dd010662da");
+    expect(validateParameterValue("guid", "not-a-guid")).toContain("GUID");
+  });
+
+  it("rejects a non-number and accepts a decimal", () => {
+    expect(validateParameterValue("number", "12.5")).toBeUndefined();
+    expect(validateParameterValue("number", "ten")).toContain("number");
+  });
+
+  it("normalises a date to UTC, because FetchXML compares in UTC", () => {
+    expect(normalizeParameterValue("datetime", "2026-01-31T00:00:00Z")).toBe("2026-01-31T00:00:00Z");
+    expect(normalizeParameterValue("datetime", "2026-01-31T12:34:56.789Z")).toBe("2026-01-31T12:34:56Z");
+    expect(validateParameterValue("datetime", "nonsense")).toContain("date");
+  });
+
+  it("normalises booleans to the 1/0 FetchXML expects", () => {
+    expect(normalizeParameterValue("boolean", "true")).toBe("1");
+    expect(normalizeParameterValue("boolean", "False")).toBe("0");
+    expect(validateParameterValue("boolean", "maybe")).toContain("true or false");
+  });
+
+  it("requires a value", () => {
+    expect(validateParameterValue("string", "  ")).toBe("Enter a value.");
+  });
+});
+
+describe("substituting values for a run", () => {
+  it("replaces tokens and leaves the rest alone", () => {
+    expect(substituteParameters(`<condition value="@a" other="@b" />`, { a: "1" })).toBe(`<condition value="1" other="@b" />`);
+  });
+
+  it("escapes both quote styles, so a value cannot break out of its attribute", () => {
+    expect(substituteParameters(`<condition value='@a' />`, { a: `O'Brien & "co" <x>` })).toBe(`<condition value='O&apos;Brien &amp; &quot;co&quot; &lt;x&gt;' />`);
+  });
+
+  it("produces XML that still parses after substitution", () => {
+    const substituted = substituteParameters(PARAMETERISED, { accountId: "6b29fc40-ca47-1067-b31d-00dd010662da", since: "2026-01-01T00:00:00Z", term: "a & b", days: "7" });
+    expect(parseFetchXml(substituted).ok).toBe(true);
+    expect(allTokenNames(substituted)).toEqual([]);
+  });
+});
+
+describe("diagnostics", () => {
+  function diagnose(source: string, language: "csharp" | "typescript") {
+    const query = detectQueries(source, language)[0];
+    const parameters = collectParameters(query.root, allTokenNames(query.xml), Object.fromEntries(query.tokens.map((t) => [t.name, t.expression])));
+    return diagnoseQuery({ root: query.root, consumer: query.consumer, language, parameters, metadata });
+  }
+
+  it("flags an unescaped string value interpolated into an attribute", () => {
+    const found = diagnose(
+      `var x = new FetchExpression($@"<fetch><entity name='incident'><filter><condition attribute='title' operator='like' value='%{term}%' /></filter></entity></fetch>");`,
+      "csharp",
+    );
+    expect(found.map((d) => d.code)).toContain("unescapedValue");
+    expect(found.find((d) => d.code === "unescapedValue")?.expression).toBe("term");
+  });
+
+  it("does not flag a value that is already escaped", () => {
+    const found = diagnose(
+      `var x = new FetchExpression($@"<fetch><entity name='incident'><filter><condition attribute='title' operator='like' value='%{SecurityElement.Escape(term)}%' /></filter></entity></fetch>");`,
+      "csharp",
+    );
+    expect(found.map((d) => d.code)).not.toContain("unescapedValue");
+  });
+
+  it("does not flag a guid or date parameter, which cannot carry an injection", () => {
+    const found = diagnose(
+      `var x = new FetchExpression($@"<fetch><entity name='incident'><filter><condition attribute='customerid' operator='eq' value='{accountId}' /></filter></entity></fetch>");`,
+      "csharp",
+    );
+    expect(found.map((d) => d.code)).not.toContain("unescapedValue");
+  });
+
+  it("flags a local-time date compared against a UTC column in C#", () => {
+    const found = diagnose(
+      `var x = new FetchExpression($@"<fetch><entity name='incident'><filter><condition attribute='createdon' operator='on-or-after' value='{DateTime.Now}' /></filter></entity></fetch>");`,
+      "csharp",
+    );
+    expect(found.map((d) => d.code)).toContain("localTime");
+  });
+
+  it("does not flag DateTime.UtcNow", () => {
+    const found = diagnose(
+      `var x = new FetchExpression($@"<fetch><entity name='incident'><filter><condition attribute='createdon' operator='on-or-after' value='{DateTime.UtcNow}' /></filter></entity></fetch>");`,
+      "csharp",
+    );
+    expect(found.map((d) => d.code)).not.toContain("localTime");
+  });
+
+  it("flags a raw new Date() in TypeScript but not one that was converted", () => {
+    const bad = diagnose(
+      "const q = `<fetch><entity name='incident'><filter><condition attribute='createdon' operator='on-or-after' value='${new Date()}' /></filter></entity></fetch>`;\nXrm.WebApi.retrieveMultipleRecords('incident', q);",
+      "typescript",
+    );
+    expect(bad.map((d) => d.code)).toContain("localTime");
+
+    const good = diagnose(
+      "const q = `<fetch><entity name='incident'><filter><condition attribute='createdon' operator='on-or-after' value='${new Date().toISOString()}' /></filter></entity></fetch>`;\nXrm.WebApi.retrieveMultipleRecords('incident', q);",
+      "typescript",
+    );
+    expect(good.map((d) => d.code)).not.toContain("localTime");
+  });
+
+  it("errors when a <fetch> is handed to a consumer that wants a <filter>", () => {
+    const found = diagnose(`lookup.addCustomFilter("<fetch><entity name='account' /></fetch>", "account");`, "typescript");
+    expect(found.find((d) => d.code === "wrongRoot")?.severity).toBe("error");
+  });
+
+  it("errors on an aggregate query in a consumer that rejects them", () => {
+    const found = diagnoseQuery({
+      root: rootOf(`<fetch aggregate="true"><entity name="account"><attribute name="accountid" aggregate="count" alias="n" /></entity></fetch>`),
+      consumer: consumerById("savedQuery"),
+      language: "csharp",
+      parameters: [],
+    });
+    expect(found.map((d) => d.code)).toContain("aggregateRejected");
+  });
+
+  it("warns when a URL-bound query is too long", () => {
+    const columns = Array.from({ length: 200 }, (_, i) => `<attribute name="column_with_a_long_name_${i}" />`).join("");
+    const found = diagnoseQuery({
+      root: rootOf(`<fetch><entity name="account">${columns}</entity></fetch>`),
+      consumer: consumerById("webApi"),
+      language: "typescript",
+      parameters: [],
+    });
+    expect(found.map((d) => d.code)).toContain("urlTooLong");
+  });
+
+  it("errors on an aggregate attribute with no alias and warns on one that neither aggregates nor groups", () => {
+    const found = diagnoseQuery({
+      root: rootOf(`<fetch aggregate="true"><entity name="account"><attribute name="accountid" aggregate="count" /><attribute name="name" /></entity></fetch>`),
+      consumer: UNKNOWN_CONSUMER,
+      language: "csharp",
+      parameters: [],
+    });
+    expect(found.map((d) => d.code)).toContain("aggregateNeedsAlias");
+    expect(found.map((d) => d.code)).toContain("aggregateNeedsGroupBy");
+  });
+
+  it("warns that top cannot be combined with paging", () => {
+    const found = diagnoseQuery({
+      root: rootOf(`<fetch top="10" page="2" count="50"><entity name="account" /></fetch>`),
+      consumer: UNKNOWN_CONSUMER,
+      language: "csharp",
+      parameters: [],
+    });
+    expect(found.map((d) => d.code)).toContain("topWithPaging");
+  });
+
+  it("warns about unknown tables and columns, and stays quiet about correct ones", () => {
+    const bad = diagnoseQuery({
+      root: rootOf(`<fetch><entity name="nosuchtable"><attribute name="title" /></entity></fetch>`),
+      consumer: UNKNOWN_CONSUMER,
+      language: "csharp",
+      parameters: [],
+      metadata,
+    });
+    expect(bad.map((d) => d.code)).toContain("unknownEntity");
+
+    const worse = diagnoseQuery({
+      root: rootOf(`<fetch><entity name="incident"><attribute name="nosuchcolumn" /></entity></fetch>`),
+      consumer: UNKNOWN_CONSUMER,
+      language: "csharp",
+      parameters: [],
+      metadata,
+    });
+    expect(worse.map((d) => d.code)).toContain("unknownAttribute");
+
+    const fine = diagnoseQuery({
+      root: rootOf(`<fetch><entity name="incident"><attribute name="title" /></entity></fetch>`),
+      consumer: UNKNOWN_CONSUMER,
+      language: "csharp",
+      parameters: [],
+      metadata,
+    });
+    expect(fine.filter((d) => d.code.startsWith("unknown"))).toEqual([]);
+  });
+
+  it("says nothing about names when metadata has not loaded", () => {
+    const found = diagnoseQuery({
+      root: rootOf(`<fetch><entity name="whatever"><attribute name="mystery" /></entity></fetch>`),
+      consumer: UNKNOWN_CONSUMER,
+      language: "csharp",
+      parameters: [],
+    });
+    expect(found.filter((d) => d.code.startsWith("unknown"))).toEqual([]);
+  });
+
+  it("does not treat a tokenised name as an unknown table", () => {
+    const found = diagnoseQuery({ root: rootOf(`<fetch><entity name="@table" /></fetch>`), consumer: UNKNOWN_CONSUMER, language: "csharp", parameters: [], metadata });
+    expect(found.map((d) => d.code)).not.toContain("unknownEntity");
+  });
+
+  it("mentions all-attributes and a query that selects nothing", () => {
+    expect(
+      diagnoseQuery({ root: rootOf(`<fetch><entity name="account"><all-attributes /></entity></fetch>`), consumer: UNKNOWN_CONSUMER, language: "csharp", parameters: [] }).map(
+        (d) => d.code,
+      ),
+    ).toContain("allAttributes");
+    expect(
+      diagnoseQuery({ root: rootOf(`<fetch><entity name="account" /></fetch>`), consumer: UNKNOWN_CONSUMER, language: "csharp", parameters: [] }).map((d) => d.code),
+    ).toContain("noColumns");
+  });
+
+  it("finds nothing to say about a clean query", () => {
+    const found = diagnoseQuery({
+      root: rootOf(
+        `<fetch top="50"><entity name="incident"><attribute name="title" /><filter><condition attribute="statecode" operator="eq" value="0" /></filter></entity></fetch>`,
+      ),
+      consumer: consumerById("sdkFetchExpression"),
+      language: "csharp",
+      parameters: [],
+      metadata,
+    });
+    expect(found).toEqual([]);
+  });
+});

--- a/src/query/parameters.ts
+++ b/src/query/parameters.ts
@@ -1,0 +1,226 @@
+// Query parameters: where the `@token` placeholders sit, what type they are, and how a prompted
+// value becomes safe FetchXML (#238).
+//
+// The nice property of detecting queries in place is that a parameter's type does not have to be
+// declared — the condition it sits in names the attribute, and the attribute's metadata gives the
+// type. `<condition attribute="accountid" operator="eq" value="@accountId" />` is a Uniqueidentifier
+// whether or not anyone said so, which is what lets the run prompt validate properly.
+//
+// Pure (no `vscode`) → unit-tested.
+
+import { replaceTokens } from "./holes";
+import { MetadataLookup } from "./metadata/cache";
+import { QueryNode, walk } from "./queryModel";
+
+export type ParameterType = "guid" | "number" | "datetime" | "boolean" | "string";
+
+export interface ParameterUsage {
+  /** Logical name of the entity/link-entity the condition sits in, when it can be determined. */
+  entity?: string;
+  attribute?: string;
+  operator?: string;
+}
+
+export interface QueryParameter {
+  name: string;
+  token: string;
+  /** The code expression this parameter came from, absent for one typed in the generator. */
+  expression?: string;
+  usages: ParameterUsage[];
+}
+
+/** Operators whose value is a COUNT, not a date — `last-x-days` takes 7, not a timestamp. The
+ * single most likely thing to get wrong when inferring a type from a date attribute. */
+const COUNT_OPERATORS = /-x-(days|hours|weeks|months|years)$|^(last|next)-x-/;
+
+const DATE_OPERATORS = new Set(["on", "on-or-before", "on-or-after"]);
+
+const ATTRIBUTE_TYPE_MAP: Record<string, ParameterType> = {
+  uniqueidentifier: "guid",
+  lookup: "guid",
+  customer: "guid",
+  owner: "guid",
+  integer: "number",
+  bigint: "number",
+  decimal: "number",
+  double: "number",
+  money: "number",
+  picklist: "number",
+  state: "number",
+  status: "number",
+  datetime: "datetime",
+  boolean: "boolean",
+  string: "string",
+  memo: "string",
+};
+
+/** Tokens appearing in this node's own value(s). */
+function tokensOfCondition(node: QueryNode, names: readonly string[]): string[] {
+  const haystack = [node.attrs.value ?? "", ...node.children.filter((child) => child.tag === "value").map((child) => child.text ?? "")].join(" ");
+  return names.filter((name) => {
+    let found = false;
+    replaceTokens(haystack, (candidate) => {
+      if (candidate === name) {
+        found = true;
+      }
+      return undefined;
+    });
+    return found;
+  });
+}
+
+/** The logical name of the nearest enclosing entity/link-entity. */
+function enclosingEntity(parents: readonly QueryNode[]): string | undefined {
+  for (let i = parents.length - 1; i >= 0; i--) {
+    if (parents[i].tag === "entity" || parents[i].tag === "link-entity") {
+      return parents[i].attrs.name;
+    }
+  }
+  return undefined;
+}
+
+/**
+ * Collect the parameters of a query in document order, together with every place each is used —
+ * a parameter used in two conditions is prompted for once and validated against both.
+ */
+export function collectParameters(root: QueryNode, tokenNames: readonly string[], expressions: Readonly<Record<string, string>> = {}): QueryParameter[] {
+  const byName = new Map<string, QueryParameter>();
+
+  const record = (name: string, usage: ParameterUsage): void => {
+    const existing = byName.get(name);
+    if (existing) {
+      existing.usages.push(usage);
+      return;
+    }
+    byName.set(name, { name, token: `@${name}`, expression: expressions[name], usages: [usage] });
+  };
+
+  walk(root, (node, parents) => {
+    if (node.tag === "condition") {
+      for (const name of tokensOfCondition(node, tokenNames)) {
+        record(name, {
+          // `entityname` on a condition points at a link-entity alias, which is a better answer
+          // than the enclosing scope when present.
+          entity: node.attrs.entityname ?? enclosingEntity(parents),
+          attribute: node.attrs.attribute,
+          operator: node.attrs.operator,
+        });
+      }
+      return;
+    }
+    // A token somewhere unusual (an entity name, an alias) is still a parameter — it just has no
+    // attribute to infer a type from.
+    for (const value of Object.values(node.attrs)) {
+      for (const name of tokenNames) {
+        replaceTokens(value, (candidate) => {
+          if (candidate === name && !byName.has(name)) {
+            record(name, {});
+          }
+          return undefined;
+        });
+      }
+    }
+  });
+
+  // Anything declared in code but no longer used in the XML is intentionally absent — the user
+  // deleted that condition in the generator.
+  return [...byName.values()];
+}
+
+/**
+ * Infer a parameter's type. Metadata is authoritative; without it we fall back to conservative
+ * naming/operator heuristics, which is enough to validate a guid or a count.
+ */
+export function inferParameterType(parameter: QueryParameter, metadata?: MetadataLookup): ParameterType {
+  for (const usage of parameter.usages) {
+    if (usage.operator && COUNT_OPERATORS.test(usage.operator)) {
+      return "number";
+    }
+    const declared = usage.entity && usage.attribute ? metadata?.attributeType(usage.entity, usage.attribute) : undefined;
+    const mapped = declared ? ATTRIBUTE_TYPE_MAP[declared.toLowerCase()] : undefined;
+    if (mapped) {
+      return mapped;
+    }
+  }
+  for (const usage of parameter.usages) {
+    if (usage.operator && DATE_OPERATORS.has(usage.operator)) {
+      return "datetime";
+    }
+    if (usage.attribute && looksLikeIdColumn(usage.attribute)) {
+      return "guid";
+    }
+  }
+  return "string";
+}
+
+/** English words ending in "id" that are plausible column names — `valid` is not a GUID. */
+const NOT_ID_COLUMNS = new Set(["valid", "invalid", "liquid", "hybrid", "rapid", "solid", "avoid", "candid"]);
+
+/**
+ * Dataverse names key and lookup columns by appending `id` (`accountid`, `customerid`), so the
+ * suffix is a strong signal. Only used when metadata has NOT loaded, and only to pick the prompt's
+ * validation — metadata overrides it — so the odd false positive costs a stricter prompt, nothing more.
+ */
+function looksLikeIdColumn(attribute: string): boolean {
+  const name = attribute.toLowerCase();
+  return name.endsWith("id") && name.length > 4 && !NOT_ID_COLUMNS.has(name);
+}
+
+const GUID_PATTERN = /^\{?[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}\}?$/;
+
+/** Validate a prompted value; returns a message when it is wrong, undefined when it is fine. */
+export function validateParameterValue(type: ParameterType, raw: string): string | undefined {
+  const value = raw.trim();
+  if (value.length === 0) {
+    return "Enter a value.";
+  }
+  switch (type) {
+    case "guid":
+      return GUID_PATTERN.test(value) ? undefined : "Enter a GUID, e.g. 00000000-0000-0000-0000-000000000000.";
+    case "number":
+      return /^-?\d+(\.\d+)?$/.test(value) ? undefined : "Enter a number.";
+    case "datetime":
+      return Number.isNaN(new Date(value).getTime()) ? "Enter a date, e.g. 2026-01-31 or 2026-01-31T09:00:00Z." : undefined;
+    case "boolean":
+      return /^(true|false|0|1)$/i.test(value) ? undefined : "Enter true or false.";
+    default:
+      return undefined;
+  }
+}
+
+/**
+ * Canonicalise a prompted value for FetchXML. Dates become UTC because FetchXML compares dates in
+ * UTC — passing a local-time string is the classic silent wrong-results bug.
+ */
+export function normalizeParameterValue(type: ParameterType, raw: string): string {
+  const value = raw.trim();
+  switch (type) {
+    case "guid":
+      return value.replace(/[{}]/g, "").toLowerCase();
+    case "boolean":
+      return /^(true|1)$/i.test(value) ? "1" : "0";
+    case "datetime": {
+      const parsed = new Date(value);
+      return Number.isNaN(parsed.getTime()) ? value : `${parsed.toISOString().slice(0, 19)}Z`;
+    }
+    default:
+      return value;
+  }
+}
+
+/** Escape BOTH quote styles: a token is substituted blind, without knowing which delimiter
+ * surrounds it, so escaping only one of them would let a value break out of its attribute. */
+function escapeSubstitutedValue(value: string): string {
+  return value.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;").replace(/"/g, "&quot;").replace(/'/g, "&apos;");
+}
+
+/**
+ * Substitute prompted values into the tokenized XML, ready to run. Values are XML-escaped on the way
+ * in — the reason a run can't be broken (or abused) by a value containing a quote.
+ */
+export function substituteParameters(xml: string, values: Readonly<Record<string, string>>): string {
+  return replaceTokens(xml, (name) => {
+    const value = values[name];
+    return value === undefined ? undefined : escapeSubstitutedValue(value);
+  });
+}

--- a/src/query/queryCommands.ts
+++ b/src/query/queryCommands.ts
@@ -1,0 +1,176 @@
+// Command registration for the FetchXML query tools (#238).
+//
+// Registered ONCE from extension.ts — never from a per-component `initialise*`, where a second
+// component of the same type would throw "command already exists" (#47, shipped in 0.8.4).
+//
+// The three palette commands double as the CodeLens targets: called with (uri, offset) they act on
+// that query, called with no arguments they act on the cursor.
+
+import * as vscode from "vscode";
+import DataversePowerToolsContext from "../context";
+import { openGenerator } from "./generatorPanel";
+import {
+  FetchXmlCodeActionProvider,
+  FetchXmlCodeLensProvider,
+  OPEN_GENERATOR_COMMAND,
+  QUERY_DOCUMENT_SELECTOR,
+  RUN_QUERY_COMMAND,
+  queriesIn,
+  refreshDiagnostics,
+} from "./codeLens";
+import { DetectedQuery, queryAtOffset } from "./detect";
+import { newQuery } from "./edits";
+import { DEFAULT_FORMAT, serializeFetchXml } from "./fetchXml";
+import { languageFor } from "./literals";
+import { clearMetadataCaches, getMetadataCache } from "./metadataService";
+import { collectParameters, inferParameterType, normalizeParameterValue, substituteParameters, validateParameterValue } from "./parameters";
+import { allTokenNames } from "./holes";
+import { runFetchXml } from "./runQuery";
+import { showResults, showResultsError } from "./resultsPanel";
+import { buildInsertion } from "./writeBack";
+
+export const CLEAR_METADATA_COMMAND = "dataverse-powertools.clearQueryMetadataCache";
+
+/** Resolve the query a command should act on: the one named by the lens, or the one at the cursor. */
+async function resolveTarget(uri?: vscode.Uri, offset?: number): Promise<{ document: vscode.TextDocument; query: DetectedQuery } | undefined> {
+  const document = uri ? await vscode.workspace.openTextDocument(uri) : vscode.window.activeTextEditor?.document;
+  if (!document || !languageFor(document.languageId)) {
+    return undefined;
+  }
+  const queries = queriesIn(document);
+  if (queries.length === 0) {
+    return undefined;
+  }
+  const position = offset ?? (vscode.window.activeTextEditor?.document === document ? document.offsetAt(vscode.window.activeTextEditor.selection.active) : 0);
+  const query = queries.find((candidate) => candidate.start === offset) ?? queryAtOffset(queries, position);
+  return query ? { document, query } : undefined;
+}
+
+/** Prompt for any parameter the query needs, then run it and show the results. */
+async function runQuery(context: DataversePowerToolsContext, document: vscode.TextDocument, query: DetectedQuery): Promise<void> {
+  const expressions = Object.fromEntries(query.tokens.map((token) => [token.name, token.expression]));
+  const parameters = collectParameters(query.root, allTokenNames(query.xml), expressions);
+  const metadata = getMetadataCache(context);
+  const title = document.fileName.split(/[\\/]/).pop() ?? "query";
+
+  const remembered = context.vscode.workspaceState;
+  const values: Record<string, string> = {};
+  for (const parameter of parameters) {
+    const type = inferParameterType(parameter, metadata);
+    // Remembered in workspaceState, never in the file: these are real record ids.
+    const key = `dvpt.queryParam.${document.uri.toString()}.${parameter.name}`;
+    const entered = await vscode.window.showInputBox({
+      title: "Run FetchXML",
+      prompt: `${parameter.name}${parameter.expression ? ` (bound to ${parameter.expression})` : ""} — ${type}`,
+      value: remembered.get<string>(key) ?? "",
+      ignoreFocusOut: true,
+      validateInput: (value) => validateParameterValue(type, value),
+    });
+    if (entered === undefined) {
+      return;
+    }
+    await remembered.update(key, entered);
+    values[parameter.name] = normalizeParameterValue(type, entered);
+  }
+
+  const xml = substituteParameters(query.xml, values);
+  const outcome = await vscode.window.withProgress({ location: vscode.ProgressLocation.Notification, title: "Running FetchXML…" }, () => runFetchXml(context, xml));
+  if (outcome.ok) {
+    showResults(context, { table: outcome.table, context: outcome.context, xml, title });
+  } else {
+    showResultsError(context, title, outcome.error);
+  }
+}
+
+/** Insert a starter query at the cursor, in the active file's language. */
+async function insertNewQuery(context: DataversePowerToolsContext): Promise<void> {
+  const editor = vscode.window.activeTextEditor;
+  const language = editor ? languageFor(editor.document.languageId) : undefined;
+  if (!editor || !language) {
+    // No suitable editor: still useful — open the generator on a fresh query so it can be copied out.
+    await openGenerator(context, undefined, undefined);
+    return;
+  }
+
+  const xml = serializeFetchXml(newQuery(), DEFAULT_FORMAT);
+  const line = editor.document.lineAt(editor.selection.active.line);
+  const indent = /^[ \t]*/.exec(line.text)?.[0] ?? "";
+  await editor.edit((generator) => generator.replace(editor.selection, buildInsertion(xml, language, indent)));
+
+  // Then open the generator on what was just inserted, so the flow continues into the UI.
+  const inserted = queriesIn(editor.document);
+  const target = queryAtOffset(inserted, editor.document.offsetAt(editor.selection.active));
+  await openGenerator(context, editor.document, target);
+}
+
+export function registerQueryCommands(context: DataversePowerToolsContext): void {
+  const subscriptions = context.vscode.subscriptions;
+  const lensProvider = new FetchXmlCodeLensProvider(context);
+  const diagnostics = vscode.languages.createDiagnosticCollection("dataverse-powertools-fetchxml");
+
+  subscriptions.push(
+    diagnostics,
+    vscode.languages.registerCodeLensProvider(QUERY_DOCUMENT_SELECTOR, lensProvider),
+    vscode.languages.registerCodeActionsProvider(QUERY_DOCUMENT_SELECTOR, new FetchXmlCodeActionProvider(), {
+      providedCodeActionKinds: FetchXmlCodeActionProvider.providedCodeActionKinds,
+    }),
+
+    vscode.commands.registerCommand(OPEN_GENERATOR_COMMAND, async (uri?: vscode.Uri, offset?: number) => {
+      const target = await resolveTarget(uri, offset);
+      if (!target) {
+        // Nothing to edit where the cursor is: offer to start a new query instead of doing nothing.
+        await insertNewQuery(context);
+        return;
+      }
+      await openGenerator(context, target.document, target.query);
+    }),
+
+    vscode.commands.registerCommand(RUN_QUERY_COMMAND, async (uri?: vscode.Uri, offset?: number) => {
+      const target = await resolveTarget(uri, offset);
+      if (!target) {
+        vscode.window.showInformationMessage("No FetchXML found at the cursor.");
+        return;
+      }
+      await runQuery(context, target.document, target.query);
+    }),
+
+    vscode.commands.registerCommand(CLEAR_METADATA_COMMAND, async () => {
+      clearMetadataCaches();
+      context.channel.appendLine("[Query] Metadata cache cleared.");
+      lensProvider.refresh();
+      const editor = vscode.window.activeTextEditor;
+      if (editor) {
+        refreshDiagnostics(context, diagnostics, editor.document);
+      }
+      vscode.window.showInformationMessage("Dataverse metadata cache cleared. It reloads on next use.");
+    }),
+  );
+
+  // Diagnostics follow the open documents.
+  const update = (document: vscode.TextDocument): void => {
+    if (languageFor(document.languageId)) {
+      refreshDiagnostics(context, diagnostics, document);
+    }
+  };
+  subscriptions.push(
+    vscode.workspace.onDidOpenTextDocument(update),
+    vscode.workspace.onDidChangeTextDocument((event) => update(event.document)),
+    vscode.workspace.onDidCloseTextDocument((document) => diagnostics.delete(document.uri)),
+    vscode.window.onDidChangeActiveTextEditor((editor) => {
+      if (editor) {
+        update(editor.document);
+      }
+    }),
+    // The whole feature is preview-gated, so flipping the flag has to add or remove the lenses and
+    // squiggles immediately rather than at the next reload.
+    vscode.workspace.onDidChangeConfiguration((event) => {
+      if (event.affectsConfiguration("dataverse-powertools.previewFeatures")) {
+        lensProvider.refresh();
+        vscode.workspace.textDocuments.forEach(update);
+      }
+    }),
+  );
+  vscode.workspace.textDocuments.forEach(update);
+
+  context.channel.appendLine("[Query] FetchXML query tools registered.");
+}

--- a/src/query/queryGenerator.dom.spec.ts
+++ b/src/query/queryGenerator.dom.spec.ts
@@ -1,0 +1,290 @@
+// @vitest-environment jsdom
+//
+// Webview DOM test for the FetchXML Generator's browser script (#238), following the pattern
+// menuPanel.dom.spec.ts established: load the SHIPPING media/queryGenerator.js unchanged into jsdom,
+// feed it real state over the message protocol, and assert both the rendered DOM and the intents it
+// posts back. The host-side view-model (generatorState.ts) is unit-tested separately; this covers the
+// half that turns it into DOM, which would otherwise have no coverage outside the UI suites.
+import { describe, it, expect, beforeEach } from "vitest";
+import * as fs from "fs";
+import * as path from "path";
+import { buildState } from "./generatorState";
+import { DEFAULT_FORMAT, parseFetchXml } from "./fetchXml";
+import { QueryNode } from "./queryModel";
+
+const SCRIPT = fs.readFileSync(path.resolve(__dirname, "../../media/queryGenerator.js"), "utf8");
+
+interface PostedMessage {
+  type: string;
+  [key: string]: unknown;
+}
+
+/** The element ids generatorPanel.ts's HTML shell provides. Kept in step with that shell. */
+const SHELL = `
+  <div id="title"></div>
+  <div id="notice" hidden></div>
+  <div id="tree"></div>
+  <div id="treeActions"></div>
+  <div id="properties"></div>
+  <div id="otherAttributes"></div>
+  <div id="parameters"></div>
+  <div id="diagnostics"></div>
+  <textarea id="xml"></textarea>
+  <div id="xmlError" hidden></div>
+  <button id="run"></button>
+  <button id="save"></button>
+  <button id="copy"></button>
+  <button id="refresh"></button>
+`;
+
+function loadBuilder(): { posted: PostedMessage[] } {
+  const posted: PostedMessage[] = [];
+  (globalThis as unknown as { acquireVsCodeApi: () => unknown }).acquireVsCodeApi = () => ({
+    postMessage: (message: PostedMessage) => posted.push(message),
+    getState: () => undefined,
+    setState: () => undefined,
+  });
+  document.body.innerHTML = SHELL;
+  new Function(SCRIPT)();
+  return { posted };
+}
+
+function postState(state: unknown): void {
+  window.dispatchEvent(new MessageEvent("message", { data: { type: "state", state } }));
+}
+
+function rootOf(xml: string): QueryNode {
+  const parsed = parseFetchXml(xml);
+  if (!parsed.ok) {
+    throw new Error(parsed.error);
+  }
+  return parsed.root;
+}
+
+const QUERY = rootOf(`<fetch top="50">
+  <entity name="account">
+    <attribute name="name" />
+    <filter type="and">
+      <condition attribute="statecode" operator="eq" value="0" />
+    </filter>
+  </entity>
+</fetch>`);
+
+/** Real state, straight from the host's own view-model generator — no hand-written fixture to drift. */
+function state(overrides: Partial<ReturnType<typeof buildState>> = {}, selection: number[] = []): ReturnType<typeof buildState> {
+  return {
+    ...buildState({
+      root: QUERY,
+      format: DEFAULT_FORMAT,
+      selection,
+      diagnostics: [],
+      parameters: [],
+      readOnly: false,
+      consumerLabel: "FetchExpression (SDK)",
+      title: "Plugin.cs",
+      dirty: false,
+    }),
+    ...overrides,
+  };
+}
+
+describe("queryGenerator.js (webview DOM)", () => {
+  beforeEach(() => {
+    document.body.innerHTML = "";
+  });
+
+  it("announces itself as ready so the host sends the first state", () => {
+    const { posted } = loadBuilder();
+    expect(posted).toEqual([{ type: "ready" }]);
+  });
+
+  it("renders the tree with one row per node, indented by depth", () => {
+    loadBuilder();
+    postState(state());
+    const rows = [...document.querySelectorAll("#tree .row")];
+    expect(rows).toHaveLength(5);
+    expect(rows.map((row) => row.querySelector(".tag")?.textContent)).toEqual(["fetch", "entity", "attribute", "filter", "condition"]);
+    expect(rows.map((row) => row.querySelector(".label")?.textContent)).toEqual(["top 50", "account", "name", "AND", "statecode eq 0"]);
+    expect((rows[4] as HTMLElement).style.paddingLeft).toBe("56px");
+  });
+
+  it("posts a select intent with the clicked node's path", () => {
+    const { posted } = loadBuilder();
+    postState(state());
+    (document.querySelectorAll("#tree .row")[4] as HTMLElement).click();
+    expect(posted).toContainEqual({ type: "select", path: [0, 1, 0] });
+  });
+
+  it("marks the selected row and offers the children that node can take", () => {
+    loadBuilder();
+    postState(state({}, [0, 1]));
+    expect(document.querySelector("#tree .row.selected")?.querySelector(".label")?.textContent).toBe("AND");
+    expect([...document.querySelectorAll("#treeActions button")].map((button) => button.textContent)).toEqual(["+ condition", "+ filter", "Remove", "Move up", "Move down"]);
+  });
+
+  it("has no Remove button when the root is selected", () => {
+    loadBuilder();
+    postState(state({}, []));
+    expect([...document.querySelectorAll("#treeActions button")].map((button) => button.textContent)).toEqual(["+ entity"]);
+  });
+
+  it("posts an add intent for the selected path", () => {
+    const { posted } = loadBuilder();
+    postState(state({}, [0, 1]));
+    ([...document.querySelectorAll("#treeActions button")].find((button) => button.textContent === "+ condition") as HTMLElement).click();
+    expect(posted).toContainEqual({ type: "add", path: [0, 1], tag: "condition" });
+  });
+
+  it("renders the selected node's fields and posts setAttr on change", () => {
+    const { posted } = loadBuilder();
+    postState(state({}, [0, 1, 0]));
+
+    const operator = document.getElementById("field-operator") as HTMLSelectElement;
+    expect(operator).toBeTruthy();
+    expect(operator.value).toBe("eq");
+    // Operators arrive grouped, so the picker stays navigable at ~60 options.
+    expect(operator.querySelectorAll("optgroup").length).toBeGreaterThan(3);
+
+    const value = document.getElementById("field-value") as HTMLInputElement;
+    value.value = "1";
+    value.dispatchEvent(new Event("change"));
+    expect(posted).toContainEqual({ type: "edit", edit: { kind: "setAttr", path: [0, 1, 0], name: "value", value: "1" } });
+  });
+
+  it("renders a checkbox for a boolean field and clears the attribute when unticked", () => {
+    const { posted } = loadBuilder();
+    postState(state({}, []));
+    const distinct = document.getElementById("field-distinct") as HTMLInputElement;
+    expect(distinct.type).toBe("checkbox");
+    expect(distinct.checked).toBe(false);
+    distinct.checked = true;
+    distinct.dispatchEvent(new Event("change"));
+    expect(posted).toContainEqual({ type: "edit", edit: { kind: "setAttr", path: [], name: "distinct", value: "true" } });
+
+    distinct.checked = false;
+    distinct.dispatchEvent(new Event("change"));
+    expect(posted).toContainEqual({ type: "edit", edit: { kind: "setAttr", path: [], name: "distinct", value: "" } });
+  });
+
+  it("shows a loading placeholder until metadata arrives, then the tables", () => {
+    loadBuilder();
+    postState(state({}, [0]));
+    expect((document.getElementById("field-name") as HTMLSelectElement).textContent).toContain("loading tables…");
+
+    postState(state({ tables: [{ logicalName: "account", displayName: "Account" }] }, [0]));
+    const picker = document.getElementById("field-name") as HTMLSelectElement;
+    expect([...picker.options].map((option) => option.value)).toContain("account");
+    expect(picker.value).toBe("account");
+  });
+
+  it("keeps a current value the picker doesn't offer, so selecting nothing can't silently change it", () => {
+    loadBuilder();
+    // Metadata loaded, but the query names a table it doesn't list.
+    postState(state({ tables: [{ logicalName: "contact", displayName: "Contact" }] }, [0]));
+    const picker = document.getElementById("field-name") as HTMLSelectElement;
+    expect(picker.value).toBe("account");
+    expect([...picker.options].map((option) => option.textContent)).toContain("account (current)");
+  });
+
+  it("renders parameters with their type as the placeholder and posts value changes", () => {
+    const { posted } = loadBuilder();
+    postState(state({ parameters: [{ name: "accountId", type: "guid", expression: "accountId", value: "" }] }));
+    const input = document.getElementById("param-accountId") as HTMLInputElement;
+    expect(input.placeholder).toBe("guid");
+    expect(document.getElementById("parameters")?.textContent).toContain("Bound to `accountId`");
+
+    input.value = "6b29fc40-ca47-1067-b31d-00dd010662da";
+    input.dispatchEvent(new Event("change"));
+    expect(posted).toContainEqual({ type: "setParameter", name: "accountId", value: "6b29fc40-ca47-1067-b31d-00dd010662da" });
+  });
+
+  it("lists diagnostics with a severity marker", () => {
+    loadBuilder();
+    postState(
+      state({
+        diagnostics: [
+          { code: "unescapedValue", severity: "warning", message: "`term` is interpolated without escaping." },
+          { code: "wrongRoot", severity: "error", message: "This consumer takes a <filter>." },
+        ],
+      }),
+    );
+    const rows = [...document.querySelectorAll("#diagnostics .diagnostic")];
+    expect(rows).toHaveLength(2);
+    expect(rows[0].className).toContain("warning");
+    expect(rows[0].querySelector(".severity")?.textContent).toBe("⚠");
+    expect(rows[1].querySelector(".message")?.textContent).toContain("takes a <filter>");
+  });
+
+  it("surfaces attributes it has no field for rather than hiding them", () => {
+    loadBuilder();
+    postState(state({ otherAttributes: [{ name: "latematerialize", value: "true" }] }));
+    expect(document.getElementById("otherAttributes")?.textContent).toContain("latematerialize = true");
+  });
+
+  it("shows the XML and only enables Save when there are unsaved changes", () => {
+    loadBuilder();
+    postState(state({ dirty: false }));
+    expect((document.getElementById("xml") as HTMLTextAreaElement).value).toContain('<condition attribute="statecode"');
+    expect((document.getElementById("save") as HTMLButtonElement).disabled).toBe(true);
+
+    postState(state({ dirty: true }));
+    expect((document.getElementById("save") as HTMLButtonElement).disabled).toBe(false);
+    expect(document.getElementById("title")?.textContent).toContain("unsaved");
+  });
+
+  it("posts the edited XML on blur and shows the parse error the host reports", () => {
+    const { posted } = loadBuilder();
+    postState(state());
+    const xml = document.getElementById("xml") as HTMLTextAreaElement;
+    xml.dispatchEvent(new Event("focus"));
+    xml.value = "<fetch><entity></fetch>";
+    xml.dispatchEvent(new Event("blur"));
+    expect(posted).toContainEqual({ type: "setXml", xml: "<fetch><entity></fetch>" });
+
+    window.dispatchEvent(new MessageEvent("message", { data: { type: "xmlError", error: "Closing tag mismatch" } }));
+    const error = document.getElementById("xmlError") as HTMLElement;
+    expect(error.hidden).toBe(false);
+    expect(error.textContent).toBe("Closing tag mismatch");
+  });
+
+  it("does not overwrite the XML box while it is being edited", () => {
+    loadBuilder();
+    postState(state());
+    const xml = document.getElementById("xml") as HTMLTextAreaElement;
+    xml.dispatchEvent(new Event("focus"));
+    xml.value = "half-typed";
+    postState(state({ dirty: true }));
+    expect(xml.value).toBe("half-typed");
+  });
+
+  it("disables editing and explains itself when the query is read-only", () => {
+    loadBuilder();
+    postState(state({ readOnly: true }, [0, 1, 0]));
+    const notice = document.getElementById("notice") as HTMLElement;
+    expect(notice.hidden).toBe(false);
+    expect(notice.textContent).toContain("read-only");
+    expect((document.getElementById("field-value") as HTMLInputElement).disabled).toBe(true);
+    expect((document.getElementById("save") as HTMLButtonElement).disabled).toBe(true);
+    expect([...document.querySelectorAll("#treeActions button")].every((button) => (button as HTMLButtonElement).disabled)).toBe(true);
+  });
+
+  it("posts the toolbar intents", () => {
+    const { posted } = loadBuilder();
+    postState(state({ dirty: true }));
+    for (const id of ["run", "save", "copy", "refresh"]) {
+      (document.getElementById(id) as HTMLElement).click();
+    }
+    expect(posted).toContainEqual({ type: "run" });
+    expect(posted).toContainEqual({ type: "save" });
+    expect(posted).toContainEqual({ type: "copyXml" });
+    expect(posted).toContainEqual({ type: "refreshMetadata" });
+  });
+
+  it("renders org-supplied text as text, never as markup", () => {
+    loadBuilder();
+    // A table name containing angle brackets must not become an element.
+    postState(state({ tables: [{ logicalName: "account", displayName: "<img src=x onerror=alert(1)>" }] }, [0]));
+    expect(document.querySelector("#properties img")).toBeNull();
+    expect((document.getElementById("field-name") as HTMLSelectElement).textContent).toContain("<img src=x onerror=alert(1)>");
+  });
+});

--- a/src/query/queryModel.ts
+++ b/src/query/queryModel.ts
@@ -1,0 +1,102 @@
+// The canonical FetchXML document model (#238).
+//
+// Deliberately UNIFORM: every element is { tag, attrs, children }, with attributes kept as an
+// insertion-ordered string map. Nothing is hoisted into typed fields (no `distinct: boolean`, no
+// `entity.name`) because this model has to survive a round trip back into a user's SOURCE FILE —
+// an attribute we forgot to model would silently disappear from their code the first time they
+// saved from the generator. Typed reads go through the accessors at the bottom instead.
+//
+// Pure (no `vscode`, no I/O) so the parser, the serializer, the generator view-model and the
+// write-back self-check all share one definition.
+
+/** Element attributes, in the order they appeared. */
+export type Attrs = Record<string, string>;
+
+/** One FetchXML element. `tag` is the literal element name — including `#comment`, which we keep
+ * as a node so comments survive a round trip rather than being quietly deleted. */
+export interface QueryNode {
+  tag: string;
+  attrs: Attrs;
+  children: QueryNode[];
+  /** Text content. Only meaningful for `<value>` and `#comment`. */
+  text?: string;
+}
+
+export const COMMENT_TAG = "#comment";
+
+/** Tags the generator understands. Anything else is preserved but shown as read-only. */
+export const KNOWN_TAGS = ["fetch", "entity", "attribute", "all-attributes", "order", "filter", "condition", "value", "link-entity"] as const;
+
+export function makeNode(tag: string, attrs: Attrs = {}, children: QueryNode[] = []): QueryNode {
+  return { tag, attrs, children };
+}
+
+/** Deep copy — the generator edits a working copy so "cancel" and the unchanged-model check both work. */
+export function cloneNode(node: QueryNode): QueryNode {
+  return {
+    tag: node.tag,
+    attrs: { ...node.attrs },
+    children: node.children.map(cloneNode),
+    ...(node.text === undefined ? {} : { text: node.text }),
+  };
+}
+
+export function childrenWithTag(node: QueryNode, tag: string): QueryNode[] {
+  return node.children.filter((child) => child.tag === tag);
+}
+
+export function firstChildWithTag(node: QueryNode, tag: string): QueryNode | undefined {
+  return node.children.find((child) => child.tag === tag);
+}
+
+/** Depth-first walk, root included. */
+export function walk(node: QueryNode, visit: (node: QueryNode, parents: QueryNode[]) => void, parents: QueryNode[] = []): void {
+  visit(node, parents);
+  const nextParents = [...parents, node];
+  for (const child of node.children) {
+    walk(child, visit, nextParents);
+  }
+}
+
+/** FetchXML booleans are written both `true` and `1`; treat either as set. */
+export function attrBool(node: QueryNode, name: string): boolean {
+  const raw = node.attrs[name];
+  return raw === "true" || raw === "1";
+}
+
+/** The `<entity>` of a full query, or undefined for a `<filter>` fragment / a malformed fetch. */
+export function queryEntity(root: QueryNode): QueryNode | undefined {
+  return root.tag === "fetch" ? firstChildWithTag(root, "entity") : undefined;
+}
+
+/** True when the query aggregates — the single biggest per-consumer capability split. */
+export function isAggregate(root: QueryNode): boolean {
+  return root.tag === "fetch" && attrBool(root, "aggregate");
+}
+
+/** Every entity/link-entity node in the query, outermost first — the join list the generator shows. */
+export function entityScopes(root: QueryNode): QueryNode[] {
+  const scopes: QueryNode[] = [];
+  walk(root, (node) => {
+    if (node.tag === "entity" || node.tag === "link-entity") {
+      scopes.push(node);
+    }
+  });
+  return scopes;
+}
+
+/** Structural comparison, used by the write-back self-check ("does re-parsing what we are about
+ * to write give the same query?") and by the unchanged-model guard that stops a no-op save from
+ * touching the file. Attribute ORDER is deliberately ignored — it carries no meaning — while
+ * child order is not, because it is visible in the user's file. */
+export function nodesEqual(a: QueryNode, b: QueryNode): boolean {
+  if (a.tag !== b.tag || (a.text ?? "") !== (b.text ?? "")) {
+    return false;
+  }
+  const aKeys = Object.keys(a.attrs).sort();
+  const bKeys = Object.keys(b.attrs).sort();
+  if (aKeys.length !== bKeys.length || aKeys.some((key, i) => key !== bKeys[i] || a.attrs[key] !== b.attrs[key])) {
+    return false;
+  }
+  return a.children.length === b.children.length && a.children.every((child, i) => nodesEqual(child, b.children[i]));
+}

--- a/src/query/queryResults.dom.spec.ts
+++ b/src/query/queryResults.dom.spec.ts
@@ -1,0 +1,175 @@
+// @vitest-environment jsdom
+//
+// Webview DOM test for the results grid's browser script (#238). This renderer is the one that puts
+// DATA FROM THE ENVIRONMENT on screen, so the important assertions here are that it renders values as
+// text rather than markup, and that it states the things that silently change what a run means — the
+// identity the query ran as, and the row cap.
+import { describe, it, expect, beforeEach } from "vitest";
+import * as fs from "fs";
+import * as path from "path";
+import { flattenResults } from "./results";
+
+const SCRIPT = fs.readFileSync(path.resolve(__dirname, "../../media/queryResults.js"), "utf8");
+
+interface PostedMessage {
+  type: string;
+  [key: string]: unknown;
+}
+
+/** The element ids resultsPanel.ts's HTML shell provides. */
+const SHELL = `
+  <header id="summary"></header>
+  <div id="error" hidden></div>
+  <div id="grid"></div>
+  <button id="copyCsv"></button>
+  <button id="copyJson"></button>
+  <button id="copyXml"></button>
+`;
+
+function loadResults(): { posted: PostedMessage[] } {
+  const posted: PostedMessage[] = [];
+  (globalThis as unknown as { acquireVsCodeApi: () => unknown }).acquireVsCodeApi = () => ({
+    postMessage: (message: PostedMessage) => posted.push(message),
+    getState: () => undefined,
+    setState: () => undefined,
+  });
+  document.body.innerHTML = SHELL;
+  new Function(SCRIPT)();
+  return { posted };
+}
+
+/** Post the payload shape resultsPanel.ts sends (cells only, raw records stripped). */
+function postResults(payload: unknown): void {
+  window.dispatchEvent(new MessageEvent("message", { data: { type: "results", payload } }));
+}
+
+function payloadFrom(response: unknown, context: Record<string, unknown> = { organizationUrl: "https://org.crm.dynamics.com", identity: "Ada Lovelace", rowCap: 50 }): unknown {
+  const table = flattenResults(response);
+  return {
+    columns: table.columns,
+    rows: table.rows.map((row) => row.cells),
+    totalRecordCount: table.totalRecordCount,
+    moreRecords: table.moreRecords,
+    context,
+    title: "Plugin.cs",
+  };
+}
+
+/* eslint-disable @typescript-eslint/naming-convention -- Web API key names. */
+const RESPONSE = {
+  "@Microsoft.Dynamics.CRM.totalrecordcount": 120,
+  "@Microsoft.Dynamics.CRM.morerecords": true,
+  value: [
+    { title: "Broken widget", statecode: 0, "statecode@OData.Community.Display.V1.FormattedValue": "Active" },
+    { title: "Late delivery", statecode: 1, "statecode@OData.Community.Display.V1.FormattedValue": "Resolved" },
+  ],
+};
+/* eslint-enable @typescript-eslint/naming-convention */
+
+describe("queryResults.js (webview DOM)", () => {
+  beforeEach(() => {
+    document.body.innerHTML = "";
+  });
+
+  it("renders a header row and one row per record, using formatted values", () => {
+    loadResults();
+    postResults(payloadFrom(RESPONSE));
+    expect([...document.querySelectorAll("#grid th")].map((th) => th.textContent)).toEqual(["title", "statecode"]);
+    const rows = [...document.querySelectorAll("#grid tbody tr")];
+    expect(rows).toHaveLength(2);
+    expect([...rows[0].querySelectorAll("td")].map((td) => td.textContent)).toEqual(["Broken widget", "Active"]);
+    expect([...rows[1].querySelectorAll("td")].map((td) => td.textContent)).toEqual(["Late delivery", "Resolved"]);
+  });
+
+  it("states the row count, the total, and that more are available", () => {
+    loadResults();
+    postResults(payloadFrom(RESPONSE));
+    const summary = document.getElementById("summary")?.textContent ?? "";
+    expect(summary).toContain("2 rows");
+    expect(summary).toContain("of 120 matching");
+    expect(summary).toContain("more available");
+  });
+
+  it("states the environment and identity the query ran as", () => {
+    // The run happens as the CONNECTED identity, not as whoever will run the plugin — row-level
+    // security and eq-userid resolve differently at runtime, so this has to be on screen.
+    loadResults();
+    postResults(payloadFrom(RESPONSE));
+    const ranAs = document.querySelector("#summary .ran-as")?.textContent ?? "";
+    expect(ranAs).toContain("https://org.crm.dynamics.com");
+    expect(ranAs).toContain("as Ada Lovelace");
+  });
+
+  it("says when the rows were capped for a test run", () => {
+    loadResults();
+    postResults(payloadFrom(RESPONSE));
+    expect(document.querySelector("#summary .capped")?.textContent).toContain("capped at 50");
+  });
+
+  it("omits the cap note when the query set its own paging", () => {
+    loadResults();
+    postResults(payloadFrom(RESPONSE, { organizationUrl: "https://org.crm.dynamics.com" }));
+    expect(document.querySelector("#summary .capped")).toBeNull();
+  });
+
+  it("says so plainly when nothing matched", () => {
+    loadResults();
+    postResults(payloadFrom({ value: [] }));
+    expect(document.querySelector("#grid .no-rows")?.textContent).toBe("No rows matched.");
+    expect(document.querySelector("#grid table")).toBeNull();
+  });
+
+  it("marks an empty cell rather than leaving it indistinguishable", () => {
+    loadResults();
+    postResults(payloadFrom({ value: [{ title: "x", ticketnumber: null }] }));
+    const cells = [...document.querySelectorAll("#grid tbody td")];
+    expect(cells[1].className).toBe("empty-value");
+    expect(cells[1].textContent).toBe("");
+  });
+
+  it("leaves a column blank on a row that doesn't have it", () => {
+    loadResults();
+    postResults(payloadFrom({ value: [{ title: "a" }, { title: "b", ticketnumber: "CAS-01" }] }));
+    const rows = [...document.querySelectorAll("#grid tbody tr")];
+    expect([...rows[0].querySelectorAll("td")].map((td) => td.textContent)).toEqual(["a", ""]);
+    expect([...rows[1].querySelectorAll("td")].map((td) => td.textContent)).toEqual(["b", "CAS-01"]);
+  });
+
+  it("renders a cell containing markup as TEXT — org data is untrusted", () => {
+    loadResults();
+    postResults(payloadFrom({ value: [{ name: "<img src=x onerror=alert(1)>" }] }));
+    expect(document.querySelector("#grid img")).toBeNull();
+    expect(document.querySelector("#grid tbody td")?.textContent).toBe("<img src=x onerror=alert(1)>");
+  });
+
+  it("renders a column NAME containing markup as text too", () => {
+    loadResults();
+    // A column name is org-controlled too (an alias in the query, a schema name).
+    // eslint-disable-next-line @typescript-eslint/naming-convention -- deliberately hostile key.
+    postResults(payloadFrom({ value: [{ "<script>x</script>": "v" }] }));
+    expect(document.querySelector("#grid script")).toBeNull();
+    expect(document.querySelector("#grid th")?.textContent).toBe("<script>x</script>");
+  });
+
+  it("shows a Dataverse error in place of the grid, and clears it on the next run", () => {
+    loadResults();
+    window.dispatchEvent(new MessageEvent("message", { data: { type: "error", error: "'name' is not a valid column.", title: "Plugin.cs" } }));
+    const error = document.getElementById("error") as HTMLElement;
+    expect(error.hidden).toBe(false);
+    expect(error.textContent).toContain("not a valid column");
+    expect(document.querySelector("#grid table")).toBeNull();
+
+    postResults(payloadFrom(RESPONSE));
+    expect(error.hidden).toBe(true);
+    expect(document.querySelectorAll("#grid tbody tr")).toHaveLength(2);
+  });
+
+  it("posts the copy intents rather than handling data itself", () => {
+    const { posted } = loadResults();
+    postResults(payloadFrom(RESPONSE));
+    for (const id of ["copyCsv", "copyJson", "copyXml"]) {
+      (document.getElementById(id) as HTMLElement).click();
+    }
+    expect(posted).toEqual([{ type: "copyCsv" }, { type: "copyJson" }, { type: "copyXml" }]);
+  });
+});

--- a/src/query/results.spec.ts
+++ b/src/query/results.spec.ts
@@ -1,0 +1,217 @@
+import { describe, it, expect, vi } from "vitest";
+import { flattenResults, resultsToCsv } from "./results";
+import { AttributeMetadata, MetadataFetcher, RelationshipMetadata, TableMetadata, createMetadataCache } from "./metadata/cache";
+
+/* eslint-disable @typescript-eslint/naming-convention -- these ARE the Web API's key names; the
+   point of the fixture is that they match the wire format exactly. */
+/** A response shaped exactly like the Web API's: annotations, aliases and a lookup raw value. */
+const RESPONSE = {
+  "@odata.context": "https://org.crm.dynamics.com/api/data/v9.2/$metadata#incidents",
+  "@Microsoft.Dynamics.CRM.totalrecordcount": 2,
+  "@Microsoft.Dynamics.CRM.morerecords": true,
+  "@Microsoft.Dynamics.CRM.fetchxmlpagingcookie": "<cookie page='1' />",
+  value: [
+    {
+      "@odata.etag": 'W/"123"',
+      title: "Broken widget",
+      statecode: 0,
+      "statecode@OData.Community.Display.V1.FormattedValue": "Active",
+      _customerid_value: "6b29fc40-ca47-1067-b31d-00dd010662da",
+      "_customerid_value@OData.Community.Display.V1.FormattedValue": "Contoso Ltd",
+      "c.fullname": "Ada Lovelace",
+      incidentid: "aaaaaaaa-0000-0000-0000-000000000000",
+    },
+    {
+      title: "Late delivery",
+      statecode: 1,
+      "statecode@OData.Community.Display.V1.FormattedValue": "Resolved",
+      _customerid_value: null,
+      "c.fullname": null,
+      incidentid: "bbbbbbbb-0000-0000-0000-000000000000",
+      ticketnumber: "CAS-01",
+    },
+  ],
+};
+/* eslint-enable @typescript-eslint/naming-convention */
+
+describe("flattening a response", () => {
+  const table = flattenResults(RESPONSE);
+
+  it("drops odata annotations from the columns", () => {
+    expect(table.columns.map((column) => column.key)).toEqual(["title", "statecode", "_customerid_value", "c.fullname", "incidentid", "ticketnumber"]);
+    expect(table.columns.some((column) => column.key.includes("@"))).toBe(false);
+  });
+
+  it("labels a lookup's raw value readably", () => {
+    expect(table.columns.find((column) => column.key === "_customerid_value")?.label).toBe("customerid");
+  });
+
+  it("keeps a link-entity alias column as its own column", () => {
+    expect(table.rows[0].cells["c.fullname"]).toBe("Ada Lovelace");
+  });
+
+  it("shows formatted values, not raw option-set ints or lookup guids", () => {
+    expect(table.rows[0].cells.statecode).toBe("Active");
+    expect(table.rows[1].cells.statecode).toBe("Resolved");
+    expect(table.rows[0].cells._customerid_value).toBe("Contoso Ltd");
+  });
+
+  it("keeps the raw record available for copy and record links", () => {
+    expect(table.rows[0].raw.statecode).toBe(0);
+    expect(table.rows[0].raw._customerid_value).toBe("6b29fc40-ca47-1067-b31d-00dd010662da");
+  });
+
+  it("renders nulls as empty rather than the string null", () => {
+    expect(table.rows[1].cells["c.fullname"]).toBe("");
+    expect(table.rows[1].cells._customerid_value).toBe("");
+  });
+
+  it("picks up a column that only appears on a later row", () => {
+    expect(table.columns.map((column) => column.key)).toContain("ticketnumber");
+    expect(table.rows[0].cells.ticketnumber).toBeUndefined();
+  });
+
+  it("reads the paging and count annotations", () => {
+    expect(table.totalRecordCount).toBe(2);
+    expect(table.moreRecords).toBe(true);
+    expect(table.pagingCookie).toContain("cookie");
+  });
+
+  it("survives an empty or malformed payload", () => {
+    expect(flattenResults({ value: [] })).toEqual({ columns: [], rows: [] });
+    expect(flattenResults(undefined)).toEqual({ columns: [], rows: [] });
+    expect(flattenResults({ nope: 1 })).toEqual({ columns: [], rows: [] });
+  });
+
+  it("stringifies a nested object rather than showing [object Object]", () => {
+    const nested = flattenResults({ value: [{ thing: { a: 1 } }] });
+    expect(nested.rows[0].cells.thing).toBe('{"a":1}');
+  });
+});
+
+describe("csv export", () => {
+  it("writes a header and quotes values containing commas or quotes", () => {
+    const csv = resultsToCsv(flattenResults({ value: [{ name: 'Contoso, "the" Ltd', n: 1 }] }));
+    expect(csv).toBe('name,n\n"Contoso, ""the"" Ltd",1');
+  });
+});
+
+describe("metadata cache", () => {
+  const tables: TableMetadata[] = [
+    { logicalName: "account", displayName: "Account", entitySetName: "accounts", primaryIdAttribute: "accountid", primaryNameAttribute: "name" },
+    { logicalName: "incident", displayName: "Case", entitySetName: "incidents", primaryIdAttribute: "incidentid", primaryNameAttribute: "title" },
+  ];
+  const attributes: AttributeMetadata[] = [
+    { logicalName: "name", displayName: "Name", attributeType: "String" },
+    { logicalName: "accountid", displayName: "Account", attributeType: "Uniqueidentifier" },
+  ];
+  const relationships: RelationshipMetadata[] = [
+    { schemaName: "contact_customer_accounts", kind: "OneToMany", relatedEntity: "contact", from: "parentcustomerid", to: "accountid" },
+  ];
+
+  function fetcher(): MetadataFetcher & { calls: { tables: number; attributes: number; relationships: number } } {
+    const calls = { tables: 0, attributes: 0, relationships: 0 };
+    return {
+      calls,
+      tables: vi.fn(async () => {
+        calls.tables++;
+        return tables;
+      }),
+      attributes: vi.fn(async () => {
+        calls.attributes++;
+        return attributes;
+      }),
+      relationships: vi.fn(async () => {
+        calls.relationships++;
+        return relationships;
+      }),
+    };
+  }
+
+  it("fetches lazily and only once per key", async () => {
+    const source = fetcher();
+    const cache = createMetadataCache(source);
+    expect(source.calls.tables).toBe(0);
+
+    await cache.getTables();
+    await cache.getTables();
+    expect(source.calls.tables).toBe(1);
+
+    await cache.getAttributes("account");
+    await cache.getAttributes("ACCOUNT");
+    expect(source.calls.attributes).toBe(1);
+
+    await cache.getRelationships("account");
+    await cache.getRelationships("account");
+    expect(source.calls.relationships).toBe(1);
+  });
+
+  it("collapses a concurrent burst into a single request", async () => {
+    const source = fetcher();
+    const cache = createMetadataCache(source);
+    await Promise.all([cache.getTables(), cache.getTables(), cache.getTables()]);
+    expect(source.calls.tables).toBe(1);
+    await Promise.all([cache.getAttributes("account"), cache.getAttributes("account")]);
+    expect(source.calls.attributes).toBe(1);
+  });
+
+  it("resolves the entity SET name, which the query URL needs", async () => {
+    const cache = createMetadataCache(fetcher());
+    expect(cache.entitySetName("incident")).toBeUndefined();
+    await cache.getTables();
+    expect(cache.entitySetName("incident")).toBe("incidents");
+    expect(cache.entitySetName("INCIDENT")).toBe("incidents");
+  });
+
+  it("answers 'not loaded' as undefined and never as 'does not exist'", async () => {
+    const cache = createMetadataCache(fetcher());
+    expect(cache.knownEntity("account")).toBeUndefined();
+    expect(cache.knownAttribute("account", "name")).toBeUndefined();
+    expect(cache.attributeType("account", "name")).toBeUndefined();
+
+    await cache.getTables();
+    expect(cache.knownEntity("account")).toBe(true);
+    expect(cache.knownEntity("nosuchtable")).toBe(false);
+    // Still undefined: this table's attributes have not been asked for yet.
+    expect(cache.knownAttribute("account", "name")).toBeUndefined();
+
+    await cache.getAttributes("account");
+    expect(cache.knownAttribute("account", "name")).toBe(true);
+    expect(cache.knownAttribute("account", "nope")).toBe(false);
+    expect(cache.attributeType("account", "accountid")).toBe("Uniqueidentifier");
+  });
+
+  it("re-fetches after a clear, so a column added in the maker portal shows up", async () => {
+    const source = fetcher();
+    const cache = createMetadataCache(source);
+    await cache.getTables();
+    await cache.getAttributes("account");
+
+    cache.clear();
+    expect(cache.knownEntity("account")).toBeUndefined();
+    expect(cache.loadedTables()).toBeUndefined();
+
+    await cache.getTables();
+    await cache.getAttributes("account");
+    expect(source.calls.tables).toBe(2);
+    expect(source.calls.attributes).toBe(2);
+  });
+
+  it("does not cache a failure, so a transient error can be retried", async () => {
+    let attempts = 0;
+    const cache = createMetadataCache({
+      tables: async () => {
+        attempts++;
+        if (attempts === 1) {
+          throw new Error("offline");
+        }
+        return tables;
+      },
+      attributes: async () => [],
+      relationships: async () => [],
+    });
+
+    await expect(cache.getTables()).rejects.toThrow("offline");
+    await expect(cache.getTables()).resolves.toEqual(tables);
+  });
+});

--- a/src/query/results.ts
+++ b/src/query/results.ts
@@ -1,0 +1,102 @@
+// Flattening a Web API FetchXML response into a grid (#238).
+//
+// Two things make this more than Object.keys(). First, annotations: Dataverse returns an option set
+// as `statecode: 0` plus `statecode@OData.Community.Display.V1.FormattedValue: "Active"`, and a grid
+// showing `0` is useless — so the formatted value wins for display while the raw one stays available.
+// Second, link-entity columns come back as `alias.attribute`, and aggregates as their alias, so the
+// column set is discovered from the rows rather than assumed.
+//
+// Pure (no `vscode`) → unit-tested.
+
+const FORMATTED_SUFFIX = "@OData.Community.Display.V1.FormattedValue";
+const TOTAL_COUNT = "@Microsoft.Dynamics.CRM.totalrecordcount";
+const MORE_RECORDS = "@Microsoft.Dynamics.CRM.morerecords";
+const PAGING_COOKIE = "@Microsoft.Dynamics.CRM.fetchxmlpagingcookie";
+
+export interface ResultColumn {
+  /** Key into each row's `cells`. */
+  key: string;
+  /** Header text — the lookup-friendly name, e.g. `customerid` for `_customerid_value`. */
+  label: string;
+}
+
+export interface ResultRow {
+  cells: Record<string, string>;
+  /** Raw values, for "copy as JSON" and for building a record URL. */
+  raw: Record<string, unknown>;
+}
+
+export interface ResultTable {
+  columns: ResultColumn[];
+  rows: ResultRow[];
+  totalRecordCount?: number;
+  moreRecords?: boolean;
+  pagingCookie?: string;
+}
+
+/** `_customerid_value` is how the Web API names a lookup's raw id; show it as `customerid`. */
+function labelFor(key: string): string {
+  const match = /^_(.+)_value$/.exec(key);
+  return match ? match[1] : key;
+}
+
+function isAnnotation(key: string): boolean {
+  return key.includes("@");
+}
+
+function displayValue(value: unknown): string {
+  if (value === null || value === undefined) {
+    return "";
+  }
+  if (typeof value === "object") {
+    return JSON.stringify(value);
+  }
+  return String(value);
+}
+
+/** Flatten a `{ value: [...] }` Web API response. */
+export function flattenResults(payload: unknown): ResultTable {
+  const body = (payload ?? {}) as Record<string, unknown>;
+  const records = Array.isArray(body.value) ? (body.value as Record<string, unknown>[]) : [];
+
+  const columns: ResultColumn[] = [];
+  const seen = new Set<string>();
+  const rows: ResultRow[] = [];
+
+  for (const record of records) {
+    const cells: Record<string, string> = {};
+    for (const [key, value] of Object.entries(record)) {
+      if (key.startsWith("@odata.") || isAnnotation(key)) {
+        continue;
+      }
+      if (!seen.has(key)) {
+        seen.add(key);
+        columns.push({ key, label: labelFor(key) });
+      }
+      // A formatted value is what a user recognises; keep the raw one in `raw`.
+      const formatted = record[`${key}${FORMATTED_SUFFIX}`];
+      cells[key] = formatted === undefined ? displayValue(value) : displayValue(formatted);
+    }
+    rows.push({ cells, raw: record });
+  }
+
+  const table: ResultTable = { columns, rows };
+  if (typeof body[TOTAL_COUNT] === "number") {
+    table.totalRecordCount = body[TOTAL_COUNT] as number;
+  }
+  if (typeof body[MORE_RECORDS] === "boolean") {
+    table.moreRecords = body[MORE_RECORDS] as boolean;
+  }
+  if (typeof body[PAGING_COOKIE] === "string") {
+    table.pagingCookie = body[PAGING_COOKIE] as string;
+  }
+  return table;
+}
+
+/** Rows as CSV, for the results view's copy action. */
+export function resultsToCsv(table: ResultTable): string {
+  const escape = (value: string): string => (/[",\r\n]/.test(value) ? `"${value.replace(/"/g, '""')}"` : value);
+  const header = table.columns.map((column) => escape(column.label)).join(",");
+  const lines = table.rows.map((row) => table.columns.map((column) => escape(row.cells[column.key] ?? "")).join(","));
+  return [header, ...lines].join("\n");
+}

--- a/src/query/resultsPanel.ts
+++ b/src/query/resultsPanel.ts
@@ -1,0 +1,124 @@
+// The query results view (#238) — one webview panel, reused by both entry points (the generator's Run
+// button and the CodeLens ▶ Run), so there is a single renderer to keep correct.
+//
+// Every cell is org data, i.e. untrusted input, so the grid is built with textContent in the
+// webview and NOTHING here interpolates a value into HTML. The strict CSP mirrors the actions panel.
+
+import * as vscode from "vscode";
+import DataversePowerToolsContext from "../context";
+import { ResultTable, resultsToCsv } from "./results";
+import { RunContext } from "./runQuery";
+
+function nonce(): string {
+  const chars = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789";
+  let value = "";
+  for (let i = 0; i < 32; i++) {
+    value += chars.charAt(Math.floor(Math.random() * chars.length));
+  }
+  return value;
+}
+
+export interface ResultsPayload {
+  table: ResultTable;
+  context: RunContext;
+  /** The FetchXML that actually ran, parameters substituted. */
+  xml: string;
+  title: string;
+}
+
+let panel: vscode.WebviewPanel | undefined;
+let latest: ResultsPayload | undefined;
+
+/** Show (or refresh) the results view beside the editor. */
+export function showResults(context: DataversePowerToolsContext, payload: ResultsPayload): void {
+  latest = payload;
+  if (!panel) {
+    panel = vscode.window.createWebviewPanel(
+      "dataversePowerToolsQueryResults",
+      "FetchXML results",
+      { viewColumn: vscode.ViewColumn.Beside, preserveFocus: true },
+      {
+        enableScripts: true,
+        retainContextWhenHidden: true,
+        localResourceRoots: [vscode.Uri.joinPath(context.vscode.extensionUri, "media")],
+      },
+    );
+    panel.onDidDispose(() => {
+      panel = undefined;
+    });
+    panel.webview.onDidReceiveMessage(async (message: { type?: string }) => {
+      // The webview can only ask for a copy of data the host already holds — it never names a path,
+      // a command or a URL.
+      if (!latest) {
+        return;
+      }
+      if (message?.type === "copyCsv") {
+        await vscode.env.clipboard.writeText(resultsToCsv(latest.table));
+        vscode.window.showInformationMessage("Results copied as CSV.");
+      } else if (message?.type === "copyJson") {
+        await vscode.env.clipboard.writeText(
+          JSON.stringify(
+            latest.table.rows.map((row) => row.raw),
+            undefined,
+            2,
+          ),
+        );
+        vscode.window.showInformationMessage("Results copied as JSON.");
+      } else if (message?.type === "copyXml") {
+        await vscode.env.clipboard.writeText(latest.xml);
+        vscode.window.showInformationMessage("FetchXML copied.");
+      }
+    });
+    panel.webview.html = html(panel.webview, context);
+  }
+
+  panel.title = `FetchXML results — ${payload.title}`;
+  void panel.webview.postMessage({ type: "results", payload: serializable(payload) });
+  panel.reveal(vscode.ViewColumn.Beside, true);
+}
+
+/** Show an error in the same place the rows would have appeared. */
+export function showResultsError(context: DataversePowerToolsContext, title: string, error: string): void {
+  showResults(context, { table: { columns: [], rows: [] }, context: { organizationUrl: "" }, xml: "", title });
+  void panel?.webview.postMessage({ type: "error", error, title });
+}
+
+/** Strip the raw records: they can be large, and the grid only renders the display cells. */
+function serializable(payload: ResultsPayload): unknown {
+  return {
+    columns: payload.table.columns,
+    rows: payload.table.rows.map((row) => row.cells),
+    totalRecordCount: payload.table.totalRecordCount,
+    moreRecords: payload.table.moreRecords,
+    context: payload.context,
+    title: payload.title,
+    xmlLength: payload.xml.length,
+  };
+}
+
+function html(webview: vscode.Webview, context: DataversePowerToolsContext): string {
+  const token = nonce();
+  const css = webview.asWebviewUri(vscode.Uri.joinPath(context.vscode.extensionUri, "media", "queryResults.css"));
+  const js = webview.asWebviewUri(vscode.Uri.joinPath(context.vscode.extensionUri, "media", "queryResults.js"));
+  return `<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta http-equiv="Content-Security-Policy" content="default-src 'none'; style-src ${webview.cspSource}; script-src 'nonce-${token}';">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <link href="${css}" rel="stylesheet">
+  <title>FetchXML results</title>
+</head>
+<body>
+  <header id="summary" aria-live="polite"></header>
+  <div id="error" role="alert" hidden></div>
+  <div id="grid" tabindex="0"></div>
+  <footer>
+    <button id="copyCsv" type="button">Copy as CSV</button>
+    <button id="copyJson" type="button">Copy as JSON</button>
+    <button id="copyXml" type="button">Copy FetchXML</button>
+  </footer>
+  <script nonce="${token}" src="${js}"></script>
+</body>
+</html>`;
+}

--- a/src/query/runQuery.ts
+++ b/src/query/runQuery.ts
@@ -1,0 +1,198 @@
+// Running a query against the live environment (#238).
+//
+// Gated on `canCallDataverseApi` and NEVER on `tenantId` — interactive (OAuth) connections don't have
+// one, and gating on it is the bug that shipped three times (#90/#91/#128).
+//
+// Two things the results view has to be told, because both silently change what a run means:
+//   * the query ran as the CONNECTED identity, not as the plugin's calling user, so row-level
+//     security and `eq-userid` resolve differently at runtime;
+//   * rows are capped, so an unbounded query over a big table can't pull the whole table.
+
+import fetch from "node-fetch";
+import DataversePowerToolsContext from "../context";
+import { DataverseContext, Options } from "../general/dataverse/dataverseContext";
+import { canCallDataverseApi } from "../general/dataverse/connectionReady";
+import { dataverseApiUrl, logDataverseHttpError } from "../general/dataverse/webApi";
+import { minifyFetchXml, parseFetchXml } from "./fetchXml";
+import { getMetadataCache } from "./metadataService";
+import { ResultTable, flattenResults } from "./results";
+import { QueryNode, attrBool, queryEntity } from "./queryModel";
+
+/** Default row cap for a test run. A query in a generator is being explored, not exported. */
+export const DEFAULT_ROW_CAP = 50;
+
+export interface RunContext {
+  organizationUrl: string;
+  identity?: string;
+  /** The cap actually applied, or undefined when the query set its own paging. */
+  rowCap?: number;
+}
+
+export type RunOutcome = { ok: true; table: ResultTable; context: RunContext } | { ok: false; error: string };
+
+/**
+ * Apply the row cap. Only when the query hasn't asked for its own paging: overriding an explicit
+ * `top`, `page` or `count` would change the query the user is actually testing.
+ */
+export function applyRowCap(root: QueryNode, cap: number): { root: QueryNode; applied?: number } {
+  if (root.tag !== "fetch" || root.attrs.top !== undefined || root.attrs.page !== undefined || root.attrs.count !== undefined) {
+    return { root };
+  }
+  const capped: QueryNode = { ...root, attrs: { ...root.attrs, top: String(cap) }, children: root.children };
+  return { root: capped, applied: cap };
+}
+
+/** Resolve the entity set name for the query's table, loading table metadata if needed. */
+async function entitySetFor(context: DataversePowerToolsContext, root: QueryNode): Promise<{ entitySet?: string; error?: string }> {
+  const entity = queryEntity(root);
+  const logicalName = entity?.attrs.name;
+  if (!logicalName) {
+    return { error: "The query has no <entity name='...'> to run against." };
+  }
+  if (logicalName.startsWith("@")) {
+    return { error: `The table name is still a parameter (${logicalName}). Replace it with a table before running.` };
+  }
+
+  const cache = getMetadataCache(context);
+  try {
+    await cache.getTables();
+  } catch (error) {
+    return { error: `Could not load table metadata: ${(error as Error).message}` };
+  }
+  const entitySet = cache.entitySetName(logicalName);
+  return entitySet ? { entitySet } : { error: `No table '${logicalName}' in this environment.` };
+}
+
+/**
+ * Run FetchXML and return a flattened result table. `xml` must already have its parameters
+ * substituted — this function does no token handling, so a token left in place is sent as a literal
+ * and the org reports it, which is the honest outcome.
+ */
+export async function runFetchXml(context: DataversePowerToolsContext, xml: string, rowCap = DEFAULT_ROW_CAP): Promise<RunOutcome> {
+  const parsed = parseFetchXml(xml);
+  if (!parsed.ok) {
+    return { ok: false, error: parsed.error };
+  }
+  if (parsed.root.tag !== "fetch") {
+    return { ok: false, error: "Only a whole <fetch> query can be run. A <filter> fragment has no table to run against." };
+  }
+
+  if (!context.dataverse) {
+    context.dataverse = new DataverseContext(context);
+  }
+  if (!context.dataverse.isValid) {
+    await context.dataverse.initialize();
+  }
+  if (!canCallDataverseApi({ organizationUrl: context.dataverse.organizationUrl, isValid: context.dataverse.isValid })) {
+    return { ok: false, error: "Connect to a Dataverse environment first." };
+  }
+
+  const { entitySet, error } = await entitySetFor(context, parsed.root);
+  if (!entitySet) {
+    return { ok: false, error: error ?? "Could not resolve the table." };
+  }
+
+  const { root, applied } = applyRowCap(parsed.root, rowCap);
+  const runnable = minifyFetchXml(root);
+
+  const token = await context.dataverse.getAuthorizationToken();
+  if (!token) {
+    return { ok: false, error: "No Dataverse token available." };
+  }
+
+  /* eslint-disable @typescript-eslint/naming-convention */
+  const options = {
+    method: "GET",
+    headers: {
+      Authorization: `Bearer ${token}`,
+      Accept: "application/json",
+      // Formatted values are what make the grid readable: without them an option set is an int and
+      // a lookup is a guid. maxpagesize is a second belt on the row cap.
+      Prefer: `odata.include-annotations="*"${applied === undefined ? "" : `,odata.maxpagesize=${applied}`}`,
+    },
+  } as Options;
+  /* eslint-enable @typescript-eslint/naming-convention */
+
+  const url = dataverseApiUrl(context.dataverse.organizationUrl, `${entitySet}?fetchXml=${encodeURIComponent(runnable)}`);
+  context.channel.appendLine(`[Query] GET ${entitySet} (${runnable.length} chars of FetchXML${applied === undefined ? "" : `, top ${applied}`})`);
+
+  try {
+    const response = await fetch(url, options);
+    if (!response.ok) {
+      const body = await logDataverseHttpError(context.channel, `run the query against ${entitySet}`, response);
+      return { ok: false, error: dataverseErrorMessage(body) ?? `The environment returned ${response.status}.` };
+    }
+    const table = flattenResults(await response.json());
+    context.channel.appendLine(`[Query] ${table.rows.length} row(s) returned`);
+    return {
+      ok: true,
+      table,
+      context: { organizationUrl: context.dataverse.organizationUrl, identity: await getConnectedIdentity(context), rowCap: applied },
+    };
+  } catch (caught) {
+    context.channel.appendLine(`[Query] Error: ${(caught as Error).message}`);
+    return { ok: false, error: (caught as Error).message };
+  }
+}
+
+/** Pull the human-readable message out of a Dataverse error body. */
+export function dataverseErrorMessage(body: string): string | undefined {
+  try {
+    const parsed = JSON.parse(body) as { error?: { message?: string } };
+    return parsed.error?.message;
+  } catch {
+    return body.length > 0 && body.length < 500 ? body : undefined;
+  }
+}
+
+let cachedIdentity: { organizationUrl: string; name: string } | undefined;
+
+/**
+ * Who the query runs as. Worth two calls once per session: a run under a service principal returns
+ * different rows than the user will see, and `eq-userid` resolves to THIS identity.
+ */
+export async function getConnectedIdentity(context: DataversePowerToolsContext): Promise<string | undefined> {
+  const organizationUrl = context.dataverse?.organizationUrl;
+  if (!organizationUrl) {
+    return undefined;
+  }
+  if (cachedIdentity?.organizationUrl === organizationUrl) {
+    return cachedIdentity.name;
+  }
+  try {
+    const token = await context.dataverse.getAuthorizationToken();
+    /* eslint-disable @typescript-eslint/naming-convention */
+    const options = { method: "GET", headers: { Authorization: `Bearer ${token}`, Accept: "application/json" } } as Options;
+    /* eslint-enable @typescript-eslint/naming-convention */
+    const who = await fetch(dataverseApiUrl(organizationUrl, "WhoAmI"), options);
+    if (!who.ok) {
+      return undefined;
+    }
+    // eslint-disable-next-line @typescript-eslint/naming-convention -- WhoAmI's own response shape.
+    const { UserId: userId } = (await who.json()) as { UserId?: string };
+    if (!userId) {
+      return undefined;
+    }
+    const user = await fetch(dataverseApiUrl(organizationUrl, `systemusers(${userId})?$select=fullname`), options);
+    if (!user.ok) {
+      return undefined;
+    }
+    const { fullname } = (await user.json()) as { fullname?: string };
+    if (fullname) {
+      cachedIdentity = { organizationUrl, name: fullname };
+    }
+    return fullname;
+  } catch {
+    return undefined;
+  }
+}
+
+/** Drop the cached identity — paired with clearing metadata when the connection changes. */
+export function forgetConnectedIdentity(): void {
+  cachedIdentity = undefined;
+}
+
+/** True when the query aggregates, which the results view labels differently. */
+export function isAggregateQuery(root: QueryNode): boolean {
+  return attrBool(root, "aggregate");
+}

--- a/src/query/writeBack.ts
+++ b/src/query/writeBack.ts
@@ -1,0 +1,80 @@
+// Turning an edited query back into source text (#238).
+//
+// This is the riskiest operation in the feature: a wrong write corrupts code the user has already
+// written, which is far worse than anything else here going wrong. So it is guarded, in order:
+//
+//   1. the edited XML must parse — a malformed query is never written;
+//   2. if the resulting code parts are identical to what is already there, report NO CHANGE, so
+//      opening the generator and closing it can never produce a diff;
+//   3. the literal we are about to emit is re-scanned with the same tokenizer that read it, and the
+//      write is REFUSED unless it decodes back to exactly the parts we meant to write.
+//
+// (3) is the important one. It catches any escaping bug in the encoders as a refusal instead of as
+// mangled source, and it costs one extra scan of a few hundred characters.
+//
+// Pure (no `vscode`) → unit-tested.
+
+import { DetectedQuery } from "./detect";
+import { detokenizeXml } from "./holes";
+import { Language, StringPart, chooseForm, encodeLiteral, scanLanguage } from "./literals";
+import { parseFetchXml } from "./fetchXml";
+
+export type WriteBack = { ok: true; changed: false } | { ok: true; changed: true; text: string } | { ok: false; reason: string };
+
+function partsEqual(a: readonly StringPart[], b: readonly StringPart[]): boolean {
+  return (
+    a.length === b.length &&
+    a.every(
+      (part, i) =>
+        part.kind === b[i].kind && (part.kind === "text" ? part.value === (b[i] as { value: string }).value : part.expression === (b[i] as { expression: string }).expression),
+    )
+  );
+}
+
+/**
+ * Compute the replacement source text for a detected query whose XML has been edited. `editedXml`
+ * still contains `@token` placeholders; known ones restore their original code expression and new
+ * ones become new interpolations.
+ */
+export function computeWriteBack(query: DetectedQuery, editedXml: string): WriteBack {
+  if (!query.writable) {
+    return { ok: false, reason: "This string can't be rewritten safely (a raw string literal), so it is read-only." };
+  }
+
+  const parsed = parseFetchXml(editedXml);
+  if (!parsed.ok) {
+    return { ok: false, reason: parsed.error };
+  }
+
+  const parts = detokenizeXml(editedXml, query.tokens);
+  if (partsEqual(parts, query.parts)) {
+    return { ok: true, changed: false };
+  }
+
+  const form = chooseForm(query.language, query.form, parts);
+  const text = encodeLiteral(query.language, parts, form);
+
+  const verified = verifyEncoding(text, parts, query.language);
+  if (!verified) {
+    return { ok: false, reason: "Refusing to write: the generated string did not read back identically. Please report this query on the issue tracker." };
+  }
+
+  return { ok: true, changed: true, text };
+}
+
+/** Re-scan an emitted literal and confirm it decodes to the parts we intended. */
+export function verifyEncoding(text: string, parts: readonly StringPart[], language: Language): boolean {
+  const rescanned = scanLanguage(text, language);
+  return rescanned.length === 1 && rescanned[0].start === 0 && rescanned[0].end === text.length && partsEqual(rescanned[0].parts, parts);
+}
+
+/**
+ * Build a literal for a brand-new query, for "insert at cursor". `indent` is the leading whitespace
+ * of the cursor's line so a multi-line query lines up with the code around it.
+ */
+export function buildInsertion(xml: string, language: Language, indent = ""): string {
+  const indented = indent.length === 0 ? xml : xml.split("\n").join(`\n${indent}`);
+  const parts: StringPart[] = [{ kind: "text", value: indented }];
+  const form = chooseForm(language, language === "csharp" ? "verbatim" : "template", parts);
+  return encodeLiteral(language, parts, form);
+}

--- a/src/test/suite/fetchXmlQueryTools.test.ts
+++ b/src/test/suite/fetchXmlQueryTools.test.ts
@@ -1,0 +1,194 @@
+import * as assert from "assert";
+import * as vscode from "vscode";
+import { PREVIEW_FEATURES } from "../../general/previewFeatures";
+
+// Integration test (real VS Code extension host) for the FetchXML query tools (#238). The pure
+// detection/write-back logic is unit-tested; what only a real host can prove is that the commands,
+// the CodeLens provider and the diagnostics are actually wired up — and that the preview gate really
+// suppresses them, which is the whole basis of shipping the feature disabled.
+
+const EXTENSION_ID = "dataversepowertools.dataverse-powertools";
+
+const QUERY_COMMANDS = ["dataverse-powertools.openFetchXmlGenerator", "dataverse-powertools.runFetchXml", "dataverse-powertools.clearQueryMetadataCache"];
+
+const CSHARP_WITH_QUERY = `using Microsoft.Xrm.Sdk;
+public class Demo
+{
+    public void Run(IOrganizationService service, System.Guid accountId)
+    {
+        var result = service.RetrieveMultiple(new Microsoft.Xrm.Sdk.Query.FetchExpression($@"<fetch top='50'>
+  <entity name='incident'>
+    <attribute name='title' />
+    <filter type='and'>
+      <condition attribute='customerid' operator='eq' value='{accountId}' />
+    </filter>
+  </entity>
+</fetch>"));
+    }
+}`;
+
+const TYPESCRIPT_WITH_QUERY = `export async function run(term: string): Promise<void> {
+  const fetchXml = \`<fetch top='50'>
+  <entity name='account'>
+    <attribute name='name' />
+    <filter type='and'>
+      <condition attribute='name' operator='like' value='%\${term}%' />
+    </filter>
+  </entity>
+</fetch>\`;
+  await Xrm.WebApi.retrieveMultipleRecords("account", "?fetchXml=" + encodeURIComponent(fetchXml));
+}`;
+
+/** Open an untitled document of a given language so the providers run against it. */
+async function openDocument(language: string, content: string): Promise<vscode.TextDocument> {
+  const document = await vscode.workspace.openTextDocument({ language, content });
+  await vscode.window.showTextDocument(document, { preview: false });
+  return document;
+}
+
+async function setPreviewFeatures(enabled: boolean): Promise<void> {
+  await vscode.workspace.getConfiguration().update("dataverse-powertools.previewFeatures", enabled, vscode.ConfigurationTarget.Global);
+}
+
+async function lensesFor(document: vscode.TextDocument): Promise<vscode.CodeLens[]> {
+  return (await vscode.commands.executeCommand<vscode.CodeLens[]>("vscode.executeCodeLensProvider", document.uri)) ?? [];
+}
+
+suite("FetchXML query tools (integration)", () => {
+  suiteSetup(async function () {
+    this.timeout(60000);
+    const ext = vscode.extensions.getExtension(EXTENSION_ID);
+    assert.ok(ext, `extension ${EXTENSION_ID} not found in the host`);
+    await ext.activate();
+  });
+
+  suiteTeardown(async () => {
+    await setPreviewFeatures(false);
+    await vscode.commands.executeCommand("workbench.action.closeAllEditors");
+  });
+
+  test("the three commands are registered globally at activation", async () => {
+    // Registered ONCE in activate(), never in a per-component initialise* — a second component of
+    // the same type would otherwise throw "command already exists" (#47).
+    const registered = new Set(await vscode.commands.getCommands(true));
+    const missing = QUERY_COMMANDS.filter((id) => !registered.has(id));
+    assert.deepStrictEqual(missing, [], `query commands not registered: ${missing.join(", ")}`);
+  });
+
+  test("the preview feature owns exactly those commands", () => {
+    const feature = PREVIEW_FEATURES.find((candidate) => candidate.id === "fetchXmlQueries");
+    assert.ok(feature, "the fetchXmlQueries preview feature should exist");
+    assert.deepStrictEqual([...feature.commands].sort(), [...QUERY_COMMANDS].sort());
+    assert.ok(feature.manualTestIssue > 0, "it needs a manual-test sign-off issue");
+  });
+
+  test("no CodeLens appears while preview features are off", async function () {
+    this.timeout(30000);
+    await setPreviewFeatures(false);
+    const document = await openDocument("csharp", CSHARP_WITH_QUERY);
+    assert.deepStrictEqual(await lensesFor(document), [], "the gate must suppress the lens entirely");
+  });
+
+  test("the lens appears on a C# query once preview features are on", async function () {
+    this.timeout(30000);
+    await setPreviewFeatures(true);
+    const document = await openDocument("csharp", CSHARP_WITH_QUERY);
+    const lenses = await lensesFor(document);
+    const titles = lenses.map((lens) => lens.command?.title ?? "");
+    assert.ok(
+      titles.some((title) => title.includes("Run")),
+      `expected a Run lens, got: ${titles.join(" | ")}`,
+    );
+    assert.ok(
+      titles.some((title) => title.includes("generator")),
+      `expected a generator lens, got: ${titles.join(" | ")}`,
+    );
+    // Every lens sits on the line the literal starts on.
+    const literalLine = document.positionAt(document.getText().indexOf('$@"<fetch')).line;
+    for (const lens of lenses) {
+      assert.strictEqual(lens.range.start.line, literalLine, "the lens should sit on the line the query starts on");
+    }
+  });
+
+  test("the lens appears on a TypeScript query too", async function () {
+    this.timeout(30000);
+    await setPreviewFeatures(true);
+    const document = await openDocument("typescript", TYPESCRIPT_WITH_QUERY);
+    const titles = (await lensesFor(document)).map((lens) => lens.command?.title ?? "");
+    assert.ok(
+      titles.some((title) => title.includes("Run")),
+      `expected a Run lens in TypeScript, got: ${titles.join(" | ")}`,
+    );
+  });
+
+  test("a file with no FetchXML gets no lens", async function () {
+    this.timeout(30000);
+    await setPreviewFeatures(true);
+    const document = await openDocument("csharp", 'public class Empty { public string Name => "nothing here"; }');
+    assert.deepStrictEqual(await lensesFor(document), []);
+  });
+
+  test("the unescaped-value warning is published as a diagnostic with a quick fix", async function () {
+    this.timeout(30000);
+    await setPreviewFeatures(true);
+    // A string value interpolated raw into an attribute — the finding that pays for itself.
+    const document = await openDocument(
+      "csharp",
+      `public class Demo { public void Run(string term) { var x = new FetchExpression($@"<fetch><entity name='account'><filter><condition attribute='name' operator='like' value='%{term}%' /></filter></entity></fetch>"); } }`,
+    );
+
+    // Diagnostics are published on open/change; give the provider a turn of the event loop.
+    const diagnostics = await waitFor(() => {
+      const found = vscode.languages.getDiagnostics(document.uri).filter((diagnostic) => diagnostic.source === "Dataverse PowerTools");
+      return found.length > 0 ? found : undefined;
+    });
+    assert.ok(diagnostics, "expected a Dataverse PowerTools diagnostic on the unescaped value");
+    assert.ok(
+      diagnostics.some((diagnostic) => diagnostic.code === "unescapedValue"),
+      `expected an unescapedValue diagnostic, got: ${diagnostics.map((d) => String(d.code)).join(", ")}`,
+    );
+
+    const target = diagnostics.find((diagnostic) => diagnostic.code === "unescapedValue") as vscode.Diagnostic;
+    const actions = (await vscode.commands.executeCommand<vscode.CodeAction[]>("vscode.executeCodeActionProvider", document.uri, target.range)) ?? [];
+    assert.ok(
+      actions.some((action) => action.title.includes("SecurityElement.Escape")),
+      `expected an escaping quick fix, got: ${actions.map((action) => action.title).join(" | ")}`,
+    );
+  });
+
+  test("diagnostics are withdrawn when the preview flag goes off", async function () {
+    this.timeout(30000);
+    await setPreviewFeatures(true);
+    const document = await openDocument("csharp", CSHARP_WITH_QUERY);
+    await waitFor(() => (vscode.languages.getDiagnostics(document.uri).length >= 0 ? true : undefined));
+
+    await setPreviewFeatures(false);
+    const cleared = await waitFor(() => (vscode.languages.getDiagnostics(document.uri).filter((d) => d.source === "Dataverse PowerTools").length === 0 ? true : undefined));
+    assert.ok(cleared, "the gate must withdraw the diagnostics too");
+  });
+
+  test("running with no FetchXML at the cursor reports it instead of throwing", async function () {
+    this.timeout(30000);
+    await setPreviewFeatures(true);
+    await openDocument("csharp", "public class Empty { }");
+    // Resolves rather than rejecting: the command tells the user and returns.
+    await vscode.commands.executeCommand("dataverse-powertools.runFetchXml");
+  });
+
+  test("clearing the metadata cache works without a connection", async function () {
+    this.timeout(30000);
+    await vscode.commands.executeCommand("dataverse-powertools.clearQueryMetadataCache");
+  });
+});
+
+/** Poll a condition for up to ~5s — provider results arrive asynchronously. */
+async function waitFor<T>(check: () => T | undefined, attempts = 50): Promise<T | undefined> {
+  for (let i = 0; i < attempts; i++) {
+    const result = check();
+    if (result !== undefined) {
+      return result;
+    }
+    await new Promise((resolve) => setTimeout(resolve, 100));
+  }
+  return undefined;
+}

--- a/src/ui-test/e2e/fetchXmlQuery.e2e.ts
+++ b/src/ui-test/e2e/fetchXmlQuery.e2e.ts
@@ -1,0 +1,379 @@
+import * as path from "path";
+import * as fs from "fs";
+import { expect } from "chai";
+import { By, Key, TextEditor, VSBrowser, WebElement, WebView } from "vscode-extension-tester";
+import {
+  loadE2EEnv,
+  freshWorkspace,
+  answerText,
+  answerFlexible,
+  pickByLabel,
+  runCommand,
+  waitForFile,
+  dismissOverlays,
+  sleep,
+  expectOutput,
+  clearOutput,
+  E2EClient,
+  resetAllCredentials,
+} from "./lib";
+
+// End-to-end for the FetchXML query tools (#238), driving the LITERAL VS Code UI.
+//
+// What only this layer can prove: the CodeLens really appears on FetchXML in the user's own file,
+// the run really reaches the environment and returns rows, the generator webview really loads under its
+// CSP and its edits really reach the host — and, the one that matters most, that saving really
+// rewrites the source file and leaves the rest of it alone.
+//
+// Every step is gated on the extension's own FINAL log line via expectOutput, never on a sleep or an
+// intermediate artifact, so a step cannot start while the previous command is still running.
+// Quick picks are answered by keyboard (type-to-filter + Enter), never by clicking a row: closing all
+// editors reveals the watermark whose hints sit over the quick-pick rows and intercept clicks.
+//
+// Self-skips without sandbox/.env.
+describe("FetchXML query tools (e2e)", function () {
+  this.timeout(900000);
+  const env = loadE2EEnv();
+  let workspace: string;
+  let solutionFriendlyName: string;
+
+  /** A plugin-style C# file: verbatim FetchXML, one interpolated GUID, handed to FetchExpression. */
+  const CSHARP_FILE = "QueryProbe.cs";
+  const CSHARP_SOURCE = `using System;
+using Microsoft.Xrm.Sdk;
+using Microsoft.Xrm.Sdk.Query;
+
+namespace DvptQueryProbe
+{
+    public class QueryProbe
+    {
+        // A marker the write-back test asserts is still present afterwards.
+        public const string Marker = "DO-NOT-TOUCH";
+
+        public EntityCollection OpenCasesFor(IOrganizationService service, Guid accountId)
+        {
+            var fetchXml = $@"<fetch top='50'>
+  <entity name='account'>
+    <attribute name='name' />
+    <filter type='and'>
+      <condition attribute='accountid' operator='eq' value='{accountId}' />
+    </filter>
+  </entity>
+</fetch>";
+            return service.RetrieveMultiple(new FetchExpression(fetchXml));
+        }
+    }
+}
+`;
+
+  /** A web-resource-style TS file: a template literal with an UNESCAPED string interpolation. */
+  const TS_FILE = "queryProbe.ts";
+  const TS_SOURCE = `export async function findAccounts(term: string): Promise<void> {
+  const fetchXml = \`<fetch top='25'>
+  <entity name='account'>
+    <attribute name='name' />
+    <filter type='and'>
+      <condition attribute='name' operator='like' value='%\${term}%' />
+    </filter>
+  </entity>
+</fetch>\`;
+  await Xrm.WebApi.retrieveMultipleRecords("account", "?fetchXml=" + encodeURIComponent(fetchXml));
+}
+`;
+
+  const csharpPath = (): string => path.join(workspace, CSHARP_FILE);
+  const tsPath = (): string => path.join(workspace, TS_FILE);
+
+  afterEach(async function () {
+    if (this.currentTest?.state === "failed") {
+      try {
+        const dir = path.resolve(__dirname, "..", "..", "..", "sandbox", "screenshots-out");
+        fs.mkdirSync(dir, { recursive: true });
+        const img = await VSBrowser.instance.driver.takeScreenshot();
+        const name = (this.currentTest?.title || "step").replace(/[^a-z0-9]+/gi, "-").slice(0, 40);
+        fs.writeFileSync(path.join(dir, `e2e-fail-fetchxml-${name}.png`), img, "base64");
+      } catch {
+        /* ignore */
+      }
+    }
+  });
+
+  /** Read visible notification text BEFORE dismissing overlays, so a command error can be asserted.
+   * File asserts alone are not enough: a command can error AFTER writing (see CLAUDE.md). */
+  async function assertCommandDidNotError(context: string): Promise<void> {
+    await sleep(3000);
+    let text = "";
+    try {
+      text = String(
+        (await VSBrowser.instance.driver.executeScript(
+          "return Array.from(document.querySelectorAll('.notification-list-item-message, .notification-toast, .monaco-dialog-box')).map(function(e){return e.textContent || '';}).join(' ||| ');",
+        )) ?? "",
+      );
+    } catch {
+      /* no readable notifications */
+    }
+    expect(/resulted in an error/i.test(text), `${context}: a command surfaced an error notification — "${text.slice(0, 300)}"`).to.equal(false);
+  }
+
+  /** Open a workspace file and settle. */
+  async function openFile(file: string): Promise<void> {
+    await VSBrowser.instance.openResources(file);
+    await sleep(2500);
+    await dismissOverlays();
+  }
+
+  /** The titles of the CodeLenses currently shown in the active editor. */
+  async function lensTitles(): Promise<string[]> {
+    const deadline = Date.now() + 30000;
+    let titles: string[] = [];
+    while (Date.now() < deadline) {
+      try {
+        const editor = new TextEditor();
+        const lenses = await editor.getCodeLenses();
+        titles = await Promise.all(lenses.map((lens) => lens.getText()));
+        if (titles.some((title) => title.includes("Run"))) {
+          return titles;
+        }
+      } catch {
+        /* lenses resolve asynchronously — retry */
+      }
+      await sleep(2000);
+    }
+    return titles;
+  }
+
+  /** Click a CodeLens by (partial) title. */
+  async function clickLens(match: string): Promise<void> {
+    const editor = new TextEditor();
+    const lenses = await editor.getCodeLenses();
+    for (const lens of lenses) {
+      if ((await lens.getText()).includes(match)) {
+        await lens.click();
+        return;
+      }
+    }
+    throw new Error(`no CodeLens matching "${match}" — saw: ${(await Promise.all(lenses.map((l) => l.getText()))).join(" | ")}`);
+  }
+
+  /**
+   * Interact with an element inside the webview, re-finding it and retrying on staleness.
+   *
+   * The generator's renderer replaces its children wholesale on every state push, so any element
+   * reference held across an edit round trip goes stale. This is why the value is typed in ONE
+   * sendKeys ending in TAB below — a `clear()` first would fire its own `change`, trigger a
+   * re-render, and invalidate the very element being typed into (which is exactly how this step
+   * failed the first time it ran).
+   */
+  async function inFrame<T>(webview: WebView, selector: string, action: (element: WebElement) => Promise<T>): Promise<T> {
+    for (let attempt = 0; ; attempt++) {
+      try {
+        return await action(await webview.findWebElement(By.css(selector)));
+      } catch (error) {
+        if (attempt >= 3 || !/stale element/i.test(String(error))) {
+          throw error;
+        }
+        await sleep(1000);
+      }
+    }
+  }
+
+  /** Switch into the generator webview, verified by its own #tree marker. */
+  async function openGeneratorFrame(): Promise<WebView> {
+    for (let attempt = 0; attempt < 10; attempt++) {
+      const webview = new WebView();
+      try {
+        await webview.switchToFrame(5000);
+        if ((await webview.findWebElements(By.css("#tree .row"))).length > 0) {
+          return webview;
+        }
+        await webview.switchBack();
+      } catch {
+        try {
+          await webview.switchBack();
+        } catch {
+          /* not in a frame */
+        }
+      }
+      await sleep(2000);
+    }
+    throw new Error("could not switch into the FetchXML Generator webview (no #tree rows found)");
+  }
+
+  before(async function () {
+    if (!env) {
+      this.skip();
+    }
+    const client = new E2EClient(env!);
+    await client.connect();
+    solutionFriendlyName = (await client.getSolutionFriendlyName(env!.solutionName)) ?? env!.solutionName;
+
+    workspace = freshWorkspace("fetchxml");
+    // The probe files exist before the workspace opens, so the CodeLens provider sees them
+    // immediately — this suite tests the query tools, not scaffolding.
+    fs.writeFileSync(csharpPath(), CSHARP_SOURCE, "utf8");
+    fs.writeFileSync(tsPath(), TS_SOURCE, "utf8");
+
+    await VSBrowser.instance.openResources(workspace);
+    await VSBrowser.instance.waitForWorkbench();
+    await sleep(3500);
+    await dismissOverlays();
+    try {
+      await runCommand("Dataverse PowerTools: Show Log");
+    } catch {
+      /* the command may not be registered until the extension activates */
+    }
+  });
+
+  it("connects the workspace with a connection-only root", async () => {
+    const log = (m: string) => console.log(`    [e2e] ${m}`);
+    log("running Initialise Project");
+    // Fresh-credential isolation: this suite proves its own auth path from zero.
+    await resetAllCredentials(log);
+    await runCommand("Dataverse PowerTools: Initialise Project");
+    // A connection-only root: this suite needs a live connection, not a scaffolded component.
+    await pickByLabel("Multi-component project (two or more types)");
+    await pickByLabel("Service principal (client secret)");
+    await answerText(env!.tenantId);
+    await answerText(env!.clientId);
+    await answerText(env!.clientSecret);
+    await answerFlexible(env!.url);
+    await pickByLabel(solutionFriendlyName);
+    await sleep(5000);
+    await dismissOverlays();
+
+    expect(await waitForFile(path.join(workspace, "dataverse-powertools.json"), 120000), "root dataverse-powertools.json").to.equal(true);
+    const settings = JSON.parse(fs.readFileSync(path.join(workspace, "dataverse-powertools.json"), "utf8"));
+    expect(settings.connectionString, "the root carries the connection").to.be.a("string").and.not.equal("");
+  });
+
+  it("shows the Run and generator CodeLens on FetchXML in a C# file", async () => {
+    await openFile(csharpPath());
+    const titles = await lensTitles();
+    expect(
+      titles.some((title) => title.includes("Run")),
+      `expected a Run lens on the C# query — saw: ${titles.join(" | ")}`,
+    ).to.equal(true);
+    expect(
+      titles.some((title) => title.includes("generator")),
+      `expected an "Edit in generator" lens — saw: ${titles.join(" | ")}`,
+    ).to.equal(true);
+  });
+
+  it("shows the CodeLens on a TypeScript template-literal query, and flags the unescaped value", async () => {
+    await openFile(tsPath());
+    const titles = await lensTitles();
+    expect(
+      titles.some((title) => title.includes("Run")),
+      `expected a Run lens on the TypeScript query — saw: ${titles.join(" | ")}`,
+    ).to.equal(true);
+    // `${term}` is a raw string interpolated into an XML attribute — the diagnostic that pays for
+    // itself, surfaced as the "N issues" lens.
+    expect(
+      titles.some((title) => title.includes("issue")),
+      `expected an issues lens for the unescaped value — saw: ${titles.join(" | ")}`,
+    ).to.equal(true);
+  });
+
+  it("runs the C# query against the environment and returns rows", async () => {
+    await clearOutput();
+    await openFile(csharpPath());
+    await lensTitles(); // wait for the lenses to resolve before clicking one
+    await clickLens("Run");
+
+    // One parameter (accountId, inferred Uniqueidentifier from the column) — the prompt validates it,
+    // so an all-zero GUID is accepted and simply matches nothing.
+    await answerText("00000000-0000-0000-0000-000000000000");
+
+    // Gate on the run's FINAL line. Metadata has to load first (the entity SET name comes from it),
+    // so allow for that round trip.
+    const text = await expectOutput(["[Query] GET accounts", "row(s) returned"], { step: "run C# query", timeoutMs: 240000 });
+    expect(/\[Query\] \d+ row\(s\) returned/.test(text), "the run logged a row count").to.equal(true);
+    await assertCommandDidNotError("run C# query");
+  });
+
+  it("opens the generator on the C# query with the parameter bound to the code expression", async () => {
+    await openFile(csharpPath());
+    await lensTitles();
+    await clickLens("generator");
+    // FINAL signal for the open: state rendered. 5 elements = fetch/entity/attribute/filter/condition.
+    await expectOutput(["[Query] Generator ready for QueryProbe.cs", "5 elements"], { step: "open generator", timeoutMs: 120000 });
+
+    const webview = await openGeneratorFrame();
+    try {
+      const rows = await webview.findWebElements(By.css("#tree .row"));
+      expect(rows.length, "the tree renders one row per element").to.equal(5);
+      const labels = await Promise.all(rows.map((row) => row.getText()));
+      expect(labels.join(" | "), "the tree reads like the query").to.contain("account");
+
+      // The parameter is bound to the code expression, not invented by the generator.
+      const parameterInputs = await webview.findWebElements(By.css("#parameters input"));
+      expect(parameterInputs.length, "one parameter row for {accountId}").to.equal(1);
+      const parameterText = await (await webview.findWebElement(By.css("#parameters"))).getText();
+      expect(parameterText, "the parameter names itself after the variable").to.contain("accountId");
+    } finally {
+      await webview.switchBack();
+    }
+  });
+
+  it("writes an edit from the generator back into the C# file, leaving the rest of it untouched", async () => {
+    await clearOutput();
+    const before = fs.readFileSync(csharpPath(), "utf8");
+    expect(before, "starts at top='50'").to.contain("top='50'");
+
+    await openFile(csharpPath());
+    await lensTitles();
+    await clickLens("generator");
+    await expectOutput(["[Query] Generator ready for QueryProbe.cs"], { step: "open generator for edit", timeoutMs: 120000 });
+
+    const webview = await openGeneratorFrame();
+    try {
+      // The root <fetch> is selected by default, so its Top field is on screen. Select-all, type the
+      // new value and TAB out in one go: the field commits on `change`, i.e. once, at blur.
+      await inFrame(webview, "#field-top", (element) => element.sendKeys(Key.chord(Key.CONTROL, "a"), "7", Key.TAB));
+      await sleep(2500); // the host applies the edit and pushes fresh state
+
+      expect(await inFrame(webview, "#save", (element) => element.isEnabled()), "Save enables once there are unsaved changes").to.equal(true);
+      await inFrame(webview, "#save", (element) => element.click());
+    } finally {
+      await webview.switchBack();
+    }
+
+    await expectOutput(["[Query] Wrote the edited query back to"], { step: "save to code", timeoutMs: 120000 });
+    await assertCommandDidNotError("save to code");
+
+    // The file really changed...
+    const after = await (async () => {
+      const deadline = Date.now() + 30000;
+      for (;;) {
+        const text = fs.readFileSync(csharpPath(), "utf8");
+        if (text.includes("top='7'") || Date.now() > deadline) {
+          return text;
+        }
+        await sleep(2000);
+      }
+    })();
+    expect(after, "the edit landed in the source file").to.contain("top='7'");
+    expect(after, "the old value is gone").to.not.contain("top='50'");
+    // ...and nothing else did: the surrounding code, the interpolation, and the literal's form.
+    expect(after, "the interpolated expression is preserved verbatim").to.contain("{accountId}");
+    expect(after, "the literal stays an interpolated verbatim string").to.contain('$@"<fetch');
+    expect(after, "surrounding code is untouched").to.contain('public const string Marker = "DO-NOT-TOUCH";');
+    expect(after, "the method signature is untouched").to.contain("public EntityCollection OpenCasesFor(IOrganizationService service, Guid accountId)");
+  });
+
+  it("re-detects the edited query, so the round trip is stable", async () => {
+    await openFile(csharpPath());
+    const titles = await lensTitles();
+    expect(
+      titles.some((title) => title.includes("Run")),
+      `the rewritten query is still detected — saw: ${titles.join(" | ")}`,
+    ).to.equal(true);
+  });
+
+  it("clears the metadata cache", async () => {
+    await clearOutput();
+    await runCommand("Dataverse PowerTools: Clear Dataverse Metadata Cache");
+    await expectOutput(["[Query] Metadata cache cleared."], { step: "clear metadata cache", timeoutMs: 60000 });
+    await assertCommandDidNotError("clear metadata cache");
+  });
+});

--- a/test/live/pluginProfilerCaptureLifecycle.spec.ts
+++ b/test/live/pluginProfilerCaptureLifecycle.spec.ts
@@ -216,10 +216,14 @@ live("plugin profiler capture -> download -> replay (headless, Windows)", () => 
     fs.writeFileSync(profilePath, report, "utf8");
 
     // Sanity-check the extension's replay-test GENERATION against the real inputs (it is
-    // added to the user's DataverseUnitTest project, which resolves the deps). Its exact
-    // Replay(...) call is what we run below.
+    // added to the user's DataverseUnitTest project, which resolves the deps).
+    // 0.14.44 (#210) moved generation from PRT's ProfilerExecutionUtility/AppDomain to the
+    // IN-PROCESS shape — decode the profile, deserialise the context, invoke the plugin — so
+    // assert that shape here, matching src/plugins/replayTest.spec.ts.
     const generated = replayTestSource({ framework: "xunit", namespaceName: "ReplayTest", className: "ReplayProbeTest", pluginTypeName: PROBE_TYPE, pluginAssemblyFileName: "DvptProbe.dll", profileFileName: profileName });
-    expect(generated).toContain("ProfilerExecutionUtility.Replay(");
+    expect(generated).toContain("ProfileReplay.LoadContext(");
+    expect(generated).toContain("plugin.Execute(ProfileReplay.CreateServiceProvider(context));");
+    expect(generated).not.toContain("ProfilerExecutionUtility");
     expect(generated).toContain(PROBE_TYPE);
 
     // Execute the replay for real via the same PluginProfiler API the generated test uses,

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -18,11 +18,13 @@ export default defineConfig({
       // Global unit coverage is low by design: most of src is tangled with the vscode API
       // and is covered by the integration + ExTester UI suites, not unit tests. Ratchet
       // these up as vscode-free logic is extracted and unit-tested (see #80).
+      // Regression guard, kept a couple of points below the actual so it isn't brittle. Ratchet UP
+      // as pure modules are extracted (#238 added src/query, which is ~all pure) — never down.
       thresholds: {
-        statements: 10,
-        branches: 11,
-        functions: 15,
-        lines: 10,
+        statements: 30,
+        branches: 34,
+        functions: 37,
+        lines: 30,
       },
     },
   },


### PR DESCRIPTION
Closes #238. Sign-off checklist: #239.

## What this is

Finds the FetchXML developers **already have** in their C#/TypeScript and makes it actionable in
place: a CodeLens to run it, edit it in a generator, or see what's wrong with it.

The first design (rejected, see #238) was `queries/*.fetchxml` source files compiled into generated
C#/TS. That needed a code generator, a committed-generated-file drift guard, and placement rules for
both the plugin `csproj` glob and the webpack per-file entry glob — and it only helped queries authored
with the tool. Detecting queries in code needs none of that and works on every existing codebase from
the first install. The XML is already in the compiled output because it is already in the source.

Named **FetchXML Generator** rather than "builder", so it doesn't read as a straight copy of
XrmToolBox's FetchXML Builder.

## The core mechanic

Real FetchXML in code is parameterised, so it isn't valid XML. Each interpolation becomes a **hole**,
swapped for an `@token` placeholder so the query parses, with the original expression text remembered
verbatim and restored on write-back. One concept covers all three shapes people actually write:

| Shape | Example |
| --- | --- |
| C# interpolation | `$"…value='{accountId}'…"` |
| TS template literal | `` `…value='${accountId}'…` `` |
| `+` concatenation | `"…value='" + accountId + "'…"` |

A parameter's **type is inferred from the column its condition compares against**, so a test run
prompts and validates without anything being declared. A query assembled with a `StringBuilder` never
yields a complete `<fetch>…</fetch>` in one span, so it is simply not offered — the honest failure mode.

## Write-back is the risk, so it is guarded

1. The edited XML must parse.
2. If the resulting code parts are identical, report **no change** — opening the generator can never
   produce a diff.
3. The literal about to be written is **re-read with the same tokenizer that parsed it**, and the write
   is REFUSED unless it decodes back identically.
4. Applied as one `WorkspaceEdit` (single undo), preserving the literal's original form and quote style.

## Testing

- **213 unit tests** over the pure core: FetchXML parse/serialize round trip, the per-language literal
  tokenizers, hole mapping, consumer detection, diagnostics, parameters, edits, view-model, result
  flattening, metadata cache — plus **jsdom DOM specs that load both shipping webview scripts
  unchanged** (following `menuPanel.dom.spec.ts`), asserting among other things that a hostile column
  name or cell value cannot become markup.
- **10 integration tests** in a real extension host: command registration, the lens in both languages,
  diagnostics + quick fix, and that the preview gate really suppresses all of it.
- **8-step e2e** (`src/ui-test/e2e/fetchXmlQuery.e2e.ts`) driving the literal VS Code UI against the
  live test environment, every step gated on the extension's own final log line.
- `npm run test:live` is green (12 files) — it was **red before this branch**; see below.

## Two real bugs the tests found

1. **Untitled buffers got nothing.** The providers were registered with `scheme: "file"`, so a query
   pasted into a scratch buffer had no lens and no quick fix. Now includes `untitled`.
2. **"Save to code" saved nothing.** `workspace.applyEdit` only mutates the in-memory document, so the
   buffer went dirty and the file on disk — the one that compiles and deploys — still held the old
   query. Every other layer passed because the in-memory text was correct; only the e2e, which asserts
   the file, caught it. `document.save()` now follows the edit.

## Release

1.0.1, shipping **behind `previewFeatures`** (off by default) per the convention in
`src/general/previewFeatures.ts`, with the manual-test checklist in #239.

## Also in here

- **Coverage floor ratcheted up**: statements 10→30, branches 11→34, functions 15→37, lines 10→30, now
  that `src/query` adds a large pure surface. (Guideline is ratchet up, never down.)
- **Fixed a pre-existing red live test**: the live plugin-profiler spec still asserted the pre-0.14.44
  `ProfilerExecutionUtility.Replay(...)` generation, while `replayTest.spec.ts` asserts the generated
  code must *not* contain it. The generator changed in #210 on 2026-07-20; that spec was last touched
  2026-07-12, so it had been failing since. One-line assertion fix.
- `package-lock.json`'s self-version bumped to 1.0.1 alongside `package.json` (1.0.0's release commit
  bumped both; mine had only done one).
- CLAUDE.md: documented that `test:integration` does **not** rebuild `dist/`, so after changing
  extension source you must `npm run compile` or the host under test is your previous build. This cost
  a debugging cycle here.

## Full e2e status — read before merging

`npm run test:e2e` on this branch: **69 passing, 6 failing**. My suite passes, and so does every suite
that would catch a regression from this change: two-of-each components (#47), both interactive-auth
suites, comprehensive web-resource, plugin lifecycle, per-file, config refresh.

The 6 failures were investigated rather than waved through:

- `pcfAcceptance` (1) — **environmental**. Passed on a re-run once orphaned `Code.exe`/webpack
  processes were reaped; the 8 GB box was starved during the 1-hour run.
- `solutionAcceptance` Deploy (1) and `pluginProfilerReplay` (4) — **pre-existing on `main`**.
  Reproduced byte-identically on a clean `main` @ `1dcbb2f` (1.0.0) whose build contains no `src/query`
  at all. Filed as #240 and #241 with the evidence; neither is a regression from this PR.
