### PR TITLE
chore: sync package-lock's self-version to 1.0.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "dataverse-powertools",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "dataverse-powertools",
-      "version": "1.0.0",
+      "version": "1.0.1",
       "hasInstallScript": true,
       "dependencies": {
         "@azure/msal-node": "^5.4.0",


### PR DESCRIPTION
The four Dependabot PRs (#218, #220, #222, #235) were branched from a 1.0.0 base, so merging them after the 1.0.1 release regenerated `package-lock.json` with `"version": "1.0.0"` and reverted the bump that shipped with the release. `main` is currently `package.json` 1.0.1 against a lockfile claiming 1.0.0.

Harmless to `npm ci` (verified: still resolves cleanly, 213 query tests pass), but the next `npm install` would silently rewrite it and drop an unrelated diff into someone's PR. 1.0.0's own release commit bumped both files, so this just restores the convention.

Two lines, no dependency changes. `Version changed?` sees no version change, so this does not republish.