### PR TITLE
chore(deps): bump js-yaml to 3.15.1 / 4.3.1 (two high-severity advisories)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1413,9 +1413,9 @@
       }
     },
     "node_modules/@istanbuljs/load-nyc-config/node_modules/js-yaml": {
-      "version": "3.15.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.15.0.tgz",
-      "integrity": "sha512-ttBQIIQPDeLjpPOohtUdXuXUVoA2uIB6fEH9HyJ7234s5mBJ5wTx20njxplLZQgLaOfpmPQA7X2t5AX6tIPbog==",
+      "version": "3.15.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.15.1.tgz",
+      "integrity": "sha512-S99WuO3HlhO3XN41EtYUNl9zzXjoJx7QvmipxsJVxtCBT0YHEFy+iOJhjSvrmV12nYhWpZaM8lPHkJm0yUMbag==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -9228,9 +9228,9 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
-      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.1.tgz",
+      "integrity": "sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==",
       "dev": true,
       "funding": [
         {


### PR DESCRIPTION
Clears Dependabot alerts **#118** and **#122** — *JS-YAML: Quadratic CPU consumption in `!!omap` resolution*, **high** severity, affecting `>= 3.0.0 < 3.15.1` and `>= 4.0.0 < 4.3.1`. Both were installed transitively: 4.3.0 across the dev toolchain and 3.15.0 nested under it.

**No exposure in the published VSIX.** Both alerts are `scope: development`; webpack bundles only what `src` imports and js-yaml is not a runtime dependency. Clearing them regardless, rather than leaving two high-severity alerts open on a just-published repo.

**Lockfile only** — `npm update js-yaml` resolved both inside the existing ranges, so `package.json` is untouched (6 lines).

Verified locally: lint clean, compile clean, **1050 unit tests**, **22 integration tests** — js-yaml sits under the test tooling, so that last layer is the one that would notice.

Found while confirming there were no open PRs left: Dependabot had started a run for this (`npm_and_yarn in /. for js-yaml`) but never landed a PR, so the alerts were sitting open with a fix available.