### PR TITLE
fix(test): live specs must collect without credentials (fixes the daily-red nightly)

### DIFF
--- a/test/live/debugBrowsersMatrix.spec.ts
+++ b/test/live/debugBrowsersMatrix.spec.ts
@@ -5,7 +5,7 @@ import * as fs from "fs";
 import * as path from "path";
 import * as vscode from "vscode"; // aliased to test/vscode.mock.ts
 import CDP = require("chrome-remote-interface");
-import { loadLiveEnv, loadInteractiveTestUser, LiveEnv, testSolutionConfig } from "../liveEnv";
+import { loadLiveEnv, loadInteractiveTestUser, LiveEnv, testSolutionConfig, liveEnvOrPlaceholder } from "../liveEnv";
 import { LiveDataverseClient } from "./dataverseClient";
 import { DataverseWebresource } from "../../src/general/dataverse/DataverseWebresource";
 import { DataverseForm } from "../../src/general/dataverse/DataverseForm";
@@ -45,7 +45,7 @@ function log(m: string): void {
 
 function makeContext(url: string, token: string, workspacePath: string, globalStorage: string, browser: string): DataversePowerToolsContext {
   return {
-    projectSettings: { prefix: "dvpt", tenantId: (env as LiveEnv).tenantId },
+    projectSettings: { prefix: "dvpt", tenantId: liveEnvOrPlaceholder(env).tenantId },
     dataverse: { organizationUrl: url, isValid: true, authorizationToken: token, getAuthorizationToken: async () => token, initialize: async () => true },
     channel: { appendLine: (m: string) => log(`[${browser}] ${m}`), show: () => undefined },
     vscode: { globalStorageUri: { fsPath: globalStorage }, subscriptions: [] as unknown[] },
@@ -162,7 +162,7 @@ async function reloadedBanner(port: number): Promise<string> {
 }
 
 suite("Debug Web Resources — Edge + Chrome unattended (#64)", () => {
-  const e = env as LiveEnv;
+  const e = liveEnvOrPlaceholder(env);
   const u = user!;
   const client = new LiveDataverseClient(e);
   const orgHost = new URL(e.url).host;

--- a/test/live/formEventRoundtrip.spec.ts
+++ b/test/live/formEventRoundtrip.spec.ts
@@ -64,7 +64,7 @@ function decorate(form: DataverseForm, libraryName: string, functionName: string
 
 live("form read + decoration logic + webresource lifecycle (extension code vs real env)", () => {
   const client = new LiveDataverseClient(env as LiveEnv);
-  const prefix = testSolutionConfig(env as LiveEnv).prefix;
+  const prefix = testSolutionConfig(env).prefix;
   const stamp = Date.now();
   const libraryName = `${prefix}_dvpttestlib_${stamp}.js`;
   const testFunctionName = `dvpt_test_OnLoad_${stamp}`;

--- a/test/live/liveOperationsLog.spec.ts
+++ b/test/live/liveOperationsLog.spec.ts
@@ -3,7 +3,7 @@ import * as fs from "fs";
 import * as os from "os";
 import * as path from "path";
 import * as cp from "child_process";
-import { loadLiveEnv, LiveEnv, testSolutionConfig } from "../liveEnv";
+import { loadLiveEnv, LiveEnv, testSolutionConfig, liveEnvOrPlaceholder } from "../liveEnv";
 import { LiveDataverseClient } from "./dataverseClient";
 import { DataverseContext } from "../../src/general/dataverse/dataverseContext";
 import { DataverseWebresource } from "../../src/general/dataverse/DataverseWebresource";
@@ -32,7 +32,7 @@ it(env && toolchain ? "live env + pac/dotnet available for operations log" : "op
 const live = env && toolchain ? describe : describe.skip;
 
 live("live operations log (real connect + webresource push + plugin push, captured channel)", () => {
-  const e = env as LiveEnv;
+  const e = liveEnvOrPlaceholder(env);
   const client = new LiveDataverseClient(e);
   const cfg = testSolutionConfig(e);
   const stamp = Date.now();

--- a/test/live/pcfLiveFormDebug.spec.ts
+++ b/test/live/pcfLiveFormDebug.spec.ts
@@ -5,7 +5,7 @@ import * as path from "path";
 import * as net from "net";
 import * as cp from "child_process";
 import CDP = require("chrome-remote-interface");
-import { loadLiveEnv } from "../liveEnv";
+import { loadLiveEnv, liveOrgUrl } from "../liveEnv";
 import { isPcfBundleUrl, pcfBundleCdpPattern, pcfBundleContentType } from "../../src/pcf/debug/pcfBundleUrl";
 import { resolveBrowser } from "../../src/webresources/debug/browserResolver";
 import { buildBrowserArgs } from "../../src/webresources/debug/browserArgs";
@@ -47,7 +47,7 @@ it(env && browserPath ? "live env + a browser available for the PCF debug e2e" :
 });
 
 gate("PCF live-form debug — interception serves the local bundle (live)", () => {
-  const orgUrl = env!.url.replace(/\/$/, "");
+  const orgUrl = liveOrgUrl(env).replace(/\/$/, "");
   const bundleUrl = `${orgUrl}/WebResources/cc_${NS}.${CTOR}/bundle.js`;
   const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "dvpt-pcf-debug-"));
   const localBundle = path.join(tmpDir, "bundle.js");

--- a/test/live/pluginPackageRoundtrip.spec.ts
+++ b/test/live/pluginPackageRoundtrip.spec.ts
@@ -40,7 +40,7 @@ function fakeContext(url: string, token: string): DataversePowerToolsContext {
 
 live("plugin build + package push round-trip (pac init + dotnet build -> extension push -> verify -> delete)", () => {
   const client = new LiveDataverseClient(env as LiveEnv);
-  const prefix = testSolutionConfig(env as LiveEnv).prefix;
+  const prefix = testSolutionConfig(env).prefix;
   const stamp = Date.now();
   const projectName = `${prefix}_testplugin${stamp}`;
   const uniqueName = `${prefix}_testpkg${stamp}`;

--- a/test/live/webresourceRoundtrip.spec.ts
+++ b/test/live/webresourceRoundtrip.spec.ts
@@ -25,7 +25,7 @@ function fakeContext(url: string, token: string): DataversePowerToolsContext {
 
 live("webresource deploy round-trip (extension code → test solution → verify)", () => {
   const client = new LiveDataverseClient(env as LiveEnv);
-  const solutionCfg = testSolutionConfig(env as LiveEnv);
+  const solutionCfg = testSolutionConfig(env);
   let solutionUniqueName = "";
   let solutionId = "";
   let webresourceName = "";

--- a/test/live/webresourceScaffoldLifecycle.spec.ts
+++ b/test/live/webresourceScaffoldLifecycle.spec.ts
@@ -3,7 +3,7 @@ import * as fs from "fs";
 import * as os from "os";
 import * as path from "path";
 import * as cp from "child_process";
-import { loadLiveEnv, LiveEnv, testSolutionConfig } from "../liveEnv";
+import { loadLiveEnv, LiveEnv, testSolutionConfig, liveEnvOrPlaceholder } from "../liveEnv";
 import { LiveDataverseClient } from "./dataverseClient";
 import { DataverseContext } from "../../src/general/dataverse/dataverseContext";
 import { DataverseWebresource } from "../../src/general/dataverse/DataverseWebresource";
@@ -62,7 +62,7 @@ function restoreCommands(): string[] {
 }
 
 live("web resources scaffold -> restore -> build -> deploy (command level)", () => {
-  const e = env as LiveEnv;
+  const e = liveEnvOrPlaceholder(env);
   const client = new LiveDataverseClient(e);
   const cfg = testSolutionConfig(e);
   const libraryName = `${cfg.prefix}_library.js`;

--- a/test/liveEnv.ts
+++ b/test/liveEnv.ts
@@ -98,14 +98,47 @@ export interface TestSolutionConfig {
  * The dedicated test solution/publisher config. Live tests ensure this exists and
  * add anything they create to it, so test artifacts are easy to find (and the
  * solution can be deleted wholesale) instead of scattered in the Default layer.
+ *
+ * `env` is OPTIONAL on purpose. Vitest's `describe.skip` still INVOKES its callback to
+ * collect the suite, so a spec that calls this at describe scope (the common shape here)
+ * evaluates it even when the suite is skipped for want of credentials. Taking
+ * `LiveEnv | undefined` and falling back to the same defaults keeps collection safe; a
+ * skipped suite never runs a test, so these defaults are never used against a real org.
  */
-export function testSolutionConfig(env: LiveEnv): TestSolutionConfig {
+export function testSolutionConfig(env?: LiveEnv): TestSolutionConfig {
   return {
-    solutionUniqueName: env.solutionName || "dvpttests",
+    solutionUniqueName: env?.solutionName || "dvpttests",
     solutionFriendlyName: "Dataverse PowerTools Tests",
     publisherUniqueName: "dataversepowertoolstests",
     publisherFriendlyName: "Dataverse PowerTools Tests",
-    prefix: env.publisherPrefix || "dvpt",
+    prefix: env?.publisherPrefix || "dvpt",
     optionValuePrefix: 65200,
   };
+}
+
+/**
+ * A placeholder org URL for collection-time expressions in suites that are about to be
+ * skipped (see `testSolutionConfig` for why collection still happens). Parsing or string
+ * -munging this is harmless; it is never fetched, because the suite does not run.
+ */
+export const PLACEHOLDER_ORG_URL = "https://placeholder.crm.dynamics.com";
+
+/** The org URL for collection-time use: the real one, or a parseable placeholder when
+ * credentials are absent and the suite is therefore skipped. */
+export function liveOrgUrl(env?: LiveEnv): string {
+  return env?.url || PLACEHOLDER_ORG_URL;
+}
+
+/** A complete `LiveEnv` of harmless placeholders. Empty credentials cannot authenticate against
+ * anything, and the URL is only ever parsed or interpolated during collection. */
+const PLACEHOLDER_LIVE_ENV: LiveEnv = { url: PLACEHOLDER_ORG_URL, clientId: "", clientSecret: "", tenantId: "" };
+
+/**
+ * The env for collection-time use. Use this instead of `env as LiveEnv` / `env!` at describe scope:
+ * the cast satisfies the compiler but still dereferences `undefined` at runtime, which is what made
+ * nine live spec FILES fail to load (and the nightly workflow red every day) whenever credentials
+ * were absent. A suite whose gate is false never runs a test, so placeholders never reach an org.
+ */
+export function liveEnvOrPlaceholder(env?: LiveEnv): LiveEnv {
+  return env ?? PLACEHOLDER_LIVE_ENV;
 }


### PR DESCRIPTION
## Why the nightly has failed every day

`Nightly live tests` has been red on every scheduled run for at least 12 days. `nightly.yml`'s own comment says:

> Every live spec self-skips when its inputs are absent … so with NO repository secrets this job is a clean no-op

That has never been true. **9 of the 15 live spec files fail to load** without credentials:

```
Test Files  9 failed | 4 passed | 2 skipped (15)
TypeError: Cannot read properties of undefined (reading 'solutionName')   ×7
TypeError: Cannot read properties of undefined (reading 'url')            ×2
```

So no live test has ever executed on the schedule — the job produced zero signal while emitting a failure notification daily. Reproduced locally by temporarily withholding `sandbox/.env`.

## Cause

Vitest's `describe.skip` **still invokes its callback** to collect the suite. The shape used throughout is:

```ts
const live = env ? describe : describe.skip;
live("…", () => {
  const e = env as LiveEnv;                 // cast satisfies tsc, still undefined at runtime
  const cfg = testSolutionConfig(env as LiveEnv);
  const host = new URL(e.url).host;         // throws during collection
```

The `as LiveEnv` / `env!` casts are what hid this: they silence the compiler while doing nothing at runtime, so the guard *looks* airtight.

## Fix

All in `test/liveEnv.ts`, so the specs change by one line each:

- `testSolutionConfig(env?)` takes an optional env and falls back to the same defaults — repairs 7 files in one place.
- New `liveEnvOrPlaceholder(env)` and `liveOrgUrl(env)` for describe-scope use, with a comment explaining why the cast was wrong so the pattern isn't reintroduced.

A suite whose gate is false never runs a test, so the placeholders (empty credentials, a parseable placeholder URL) can never reach a real org.

## Verified both directions

| | Result |
| --- | --- |
| **Without** creds (the nightly's situation) | 12 passed \| 3 skipped, **0 failed**, exit 0 |
| **With** creds (the VM / local) | 12 passed \| 3 skipped, **30 tests passed** — unchanged |
| lint / unit | clean / 1050 passing |

8 files, +48/-15.

## Separate question for you

This makes the nightly *honest*, not *useful*: with no `DVPT_TEST_*` repository secrets it is now a green ~1-minute no-op. Whether it earns its keep depends on whether those secrets get added — see my comment below.