### PR TITLE
fix: root-cause the two red e2e suites (#240, #241) — one broken gate, one self-poisoning test

### DIFF
--- a/src/general/dataverse/pluginProfiles.spec.ts
+++ b/src/general/dataverse/pluginProfiles.spec.ts
@@ -9,6 +9,8 @@ import {
   findMatchingStep,
   buildProfilableStepsResource,
   pluginAssemblyProfilingQuery,
+  buildAssemblyStepsAnyStateResource,
+  noProfilableStepsMessage,
 } from "./pluginProfiles";
 
 describe("plugin profile queries", () => {
@@ -109,5 +111,46 @@ describe("active plugin profiles (#139)", () => {
     expect(findMatchingStep(steps, { message: "Create", primaryEntity: "contact" })?.typeName).toBe("Acme.ContactPlugin");
     expect(findMatchingStep(steps, { message: "Update", primaryEntity: "account", typeName: "OtherPlugin" })?.typeName).toBe("Acme.OtherPlugin");
     expect(findMatchingStep(steps, { message: "Delete", primaryEntity: "account" })).toBeUndefined();
+  });
+});
+
+// #241: a step the profiler is profiling stays DISABLED, so the profilable query correctly returns
+// nothing. The old dead end told the user to "deploy and register a step" they already had, and
+// logged nothing at all when the assembly-filtered query came back empty.
+describe("no-profilable-steps diagnosis (#241)", () => {
+  it("filters by assembly WITHOUT the active-state clause, so disabled steps are visible", () => {
+    const resource = buildAssemblyStepsAnyStateResource("ProfilerE2E");
+    expect(resource).toContain("plugintypeid/pluginassemblyid/name eq 'ProfilerE2E'");
+    expect(resource).not.toContain("statecode eq 0");
+    expect(resource).toContain("$select=name,statecode");
+  });
+
+  it("escapes a quote in the assembly name", () => {
+    expect(buildAssemblyStepsAnyStateResource("O'Brien.Plugins")).toContain("name eq 'O''Brien.Plugins'");
+  });
+
+  it("names the disabled-step cause instead of telling the user to register a step", () => {
+    const message = noProfilableStepsMessage("ProfilerE2E", { active: 0, inactive: ["Create territory (DVPT profiler e2e)"] });
+    expect(message).toContain("DISABLED");
+    expect(message).toContain("ProfilerE2E");
+    expect(message).toContain("Create territory (DVPT profiler e2e)");
+    expect(message).toContain("stop profiling");
+    expect(message).not.toContain("Deploy your plugin and register a step");
+  });
+
+  it("truncates a long disabled list", () => {
+    const message = noProfilableStepsMessage("A", { active: 0, inactive: ["s1", "s2", "s3", "s4", "s5"] });
+    expect(message).toContain("5 step(s)");
+    expect(message).toContain("s1, s2, s3, …");
+    expect(message).not.toContain("s4");
+  });
+
+  it("keeps the generic advice when there genuinely are no steps", () => {
+    expect(noProfilableStepsMessage("A", { active: 0, inactive: [] })).toContain("Deploy your plugin and register a step");
+    expect(noProfilableStepsMessage(undefined, undefined)).toContain("Deploy your plugin and register a step");
+  });
+
+  it("keeps the generic advice when active steps exist (a different problem)", () => {
+    expect(noProfilableStepsMessage("A", { active: 2, inactive: ["s1"] })).toContain("Deploy your plugin and register a step");
   });
 });

--- a/src/general/dataverse/pluginProfiles.ts
+++ b/src/general/dataverse/pluginProfiles.ts
@@ -124,6 +124,46 @@ export async function setPluginAssemblyContent(context: DataversePowerToolsConte
  * capture dead-ended with "No registered plugin steps to profile". The assembly filter returns
  * only the user's own steps regardless of how many system steps exist.
  */
+export function buildAssemblyStepsAnyStateResource(assemblyName: string): string {
+  // Same assembly join, WITHOUT `statecode eq 0`. Used only to explain an empty profilable result:
+  // a step the Plugin Profiler is profiling is left DISABLED (the profiler clones it and deactivates
+  // the original), and if profiling is never stopped the step stays disabled. The profilable query
+  // then correctly returns nothing, and the user saw "No registered plugin steps to profile. Deploy
+  // your plugin and register a step first" — advice that cannot help, for a step they already
+  // deployed and registered. This lets us say what is actually wrong.
+  return `sdkmessageprocessingsteps?$select=name,statecode&$filter=plugintypeid/pluginassemblyid/name eq '${assemblyName.replace(/'/g, "''")}'&$top=50`;
+}
+
+/** Steps of one assembly regardless of state, with their active/inactive split. Undefined on failure. */
+export async function getAssemblyStepStates(context: DataversePowerToolsContext, assemblyName: string): Promise<{ active: number; inactive: string[] } | undefined> {
+  const body = await getJson(context, `List all steps for assembly '${assemblyName}'`, buildAssemblyStepsAnyStateResource(assemblyName));
+  if (!body || !Array.isArray(body.value)) {
+    return undefined;
+  }
+  const rows = body.value as { name?: string; statecode?: number }[];
+  return {
+    active: rows.filter((row) => row.statecode === 0).length,
+    inactive: rows.filter((row) => row.statecode !== 0).map((row) => row.name ?? "(unnamed)"),
+  };
+}
+
+/**
+ * The message to show when nothing is profilable (pure, unit-tested).
+ *
+ * The disabled-step case is the one worth naming: it is what a user hits after leaving profiling on,
+ * and the generic "deploy and register a step" advice actively misleads them.
+ */
+export function noProfilableStepsMessage(assemblyName: string | undefined, states: { active: number; inactive: string[] } | undefined): string {
+  if (assemblyName && states && states.inactive.length > 0 && states.active === 0) {
+    const names = states.inactive.slice(0, 3).join(", ");
+    return (
+      `${states.inactive.length} step(s) are registered for '${assemblyName}' but all are DISABLED (${names}${states.inactive.length > 3 ? ", …" : ""}), ` +
+      `so there is nothing to profile. The Plugin Profiler disables a step while it profiles it — stop profiling that step (or re-enable it) and try again.`
+    );
+  }
+  return "No registered plugin steps to profile. Deploy your plugin and register a step (CodeLens) first.";
+}
+
 export function buildProfilableStepsResource(assemblyName?: string): string {
   // #135: expand the DEDICATED `plugintypeid` lookup — NOT the polymorphic `eventhandler`
   // (which targets plugintype OR serviceendpoint and doesn't populate `typename` for a
@@ -149,6 +189,16 @@ export async function getProfilableSteps(context: DataversePowerToolsContext, as
     return undefined;
   }
   const steps = parseProfilableSteps(body, assemblyName);
+  // The assembly-filtered query returning ZERO ROWS used to log nothing at all — a silent dead end.
+  // Name the most likely cause (every step disabled, typically by profiling left on).
+  if (steps.length === 0 && (body?.value?.length ?? 0) === 0 && assemblyName) {
+    const states = await getAssemblyStepStates(context, assemblyName);
+    context.channel.appendLine(
+      states && states.inactive.length > 0
+        ? `[Profiler] No ACTIVE steps for assembly "${assemblyName}": ${states.inactive.length} registered but disabled (${states.inactive.slice(0, 3).join(", ")}). The profiler disables a step while profiling it — stop profiling to re-enable it.`
+        : `[Profiler] No steps registered for assembly "${assemblyName}" — register a step (CodeLens on the [CrmPluginRegistration] attribute) and deploy.`,
+    );
+  }
   // #135: the query succeeded but every step was filtered out — log WHY so a "No registered
   // plugin steps" dead-end is diagnosable (which bucket the user's live step fell into).
   if (steps.length === 0 && (body?.value?.length ?? 0) > 0) {

--- a/src/plugins/profilerCapture.ts
+++ b/src/plugins/profilerCapture.ts
@@ -10,6 +10,8 @@ import {
   getPluginAssemblyProfilingInfo,
   setPluginAssemblyContent,
   ProfilableStep,
+  getAssemblyStepStates,
+  noProfilableStepsMessage,
 } from "../general/dataverse/pluginProfiles";
 import { getOrganizationUrl } from "../general/connectionString";
 import { isCaptureSupported, buildEnableArgs, buildDisableArgs, runProfilerTool } from "./profilerCaptureTool";
@@ -151,7 +153,10 @@ export async function capturePluginRun(context: DataversePowerToolsContext): Pro
     return;
   }
   if (steps.length === 0) {
-    vscode.window.showInformationMessage("No registered plugin steps to profile. Deploy your plugin and register a step (CodeLens) first.");
+    // Say what is actually wrong. The common case is a step left DISABLED by profiling that was
+    // never stopped, where "deploy and register a step" is advice the user cannot act on.
+    const states = assemblyName ? await getAssemblyStepStates(context, assemblyName) : undefined;
+    vscode.window.showInformationMessage(noProfilableStepsMessage(assemblyName, states));
     return;
   }
 

--- a/src/plugins/profilerToggle.ts
+++ b/src/plugins/profilerToggle.ts
@@ -4,7 +4,15 @@ import { runForComponent } from "../components/componentDiscovery";
 import { ProjectTypes } from "../projectTypes/registry";
 import { getOrganizationUrl } from "../general/connectionString";
 import { canCallDataverseApi } from "../general/dataverse/connectionReady";
-import { ActiveProfileStep, RegistrationKey, getProfilableSteps, findMatchingStep, deleteProfilerStep } from "../general/dataverse/pluginProfiles";
+import {
+  ActiveProfileStep,
+  RegistrationKey,
+  getProfilableSteps,
+  findMatchingStep,
+  deleteProfilerStep,
+  getAssemblyStepStates,
+  noProfilableStepsMessage,
+} from "../general/dataverse/pluginProfiles";
 import { parseRegistrationArgs } from "./registrationAttribute";
 import { findPluginClasses } from "./profilerCodeLens";
 import { isCaptureSupported, buildEnableArgs, buildDisableArgs, runProfilerTool } from "./profilerCaptureTool";

--- a/src/ui-test/e2e/lib.ts
+++ b/src/ui-test/e2e/lib.ts
@@ -438,6 +438,14 @@ export async function runCommandResilient(title: string, attempts = 4): Promise<
  * next — so the test only proceeds once the extension reports the step actually succeeded.
  * Returns the channel text on success, or undefined on timeout.
  */
+/**
+ * Wait until the output channel contains EVERY string in `expected` (they are ANDed, not ORed).
+ *
+ * Passing alternatives here is a trap that cost a daily-failing suite: an array of four different
+ * phrasings of "the import finished" can never all appear, so the wait burns its whole timeout and
+ * the step fails while the command it is watching actually succeeded (#240). Pass the lines that
+ * genuinely co-occur — ideally the command's FINAL signal — or a single string.
+ */
 export async function waitForOutput(expected: string | string[], timeoutMs = 120000, channel = "dataverse-powertools"): Promise<string | undefined> {
   const wants = Array.isArray(expected) ? expected : [expected];
   let view;
@@ -744,6 +752,36 @@ export class E2EClient {
    * Exception in the Plug-in Profiler" (its target assembly may already be gone). Cleanup calls this
    * so a failed run never leaves the shared org broken. Returns the number of steps deleted.
    */
+  /**
+   * Re-activate the ORIGINAL steps of an assembly that profiling left disabled (#241).
+   *
+   * The Plugin Profiler clones a step and DEACTIVATES the original while profiling it. If a run never
+   * reaches "Stop Profiling", the original stays disabled — and because the deploy's step sync reports
+   * it "Unchanged" without touching `statecode`, the profilable query correctly finds nothing forever
+   * after. One failed run therefore poisoned every later run of this suite. Returns how many it
+   * re-enabled.
+   */
+  async reactivateAssemblySteps(assemblyName: string): Promise<number> {
+    const filter = `plugintypeid/pluginassemblyid/name eq '${assemblyName.replace(/'/g, "''")}'`;
+    const res = await this.request("GET", `sdkmessageprocessingsteps?$select=name,statecode,sdkmessageprocessingstepid&$filter=${filter}&$top=50`);
+    if (!res.ok) {
+      return 0;
+    }
+    const rows: any[] = ((await res.json()) as any).value ?? [];
+    let reactivated = 0;
+    for (const step of rows) {
+      // Never touch the profiler's own clones — those get deleted, not re-enabled.
+      if (step.statecode === 0 || /\((Profiler|Profiled)\)\s*$/.test(String(step.name ?? ""))) {
+        continue;
+      }
+      const patch = await this.request("PATCH", `sdkmessageprocessingsteps(${step.sdkmessageprocessingstepid})`, { statecode: 0, statuscode: 1 });
+      if (patch.ok || patch.status === 204) {
+        reactivated++;
+      }
+    }
+    return reactivated;
+  }
+
   async cleanupProfilerSteps(entityLogicalName: string): Promise<number> {
     const filter = `sdkmessagefilterid/primaryobjecttypecode eq '${entityLogicalName.replace(/'/g, "''")}'`;
     const res = await this.request("GET", `sdkmessageprocessingsteps?$select=name,sdkmessageprocessingstepid&$expand=plugintypeid($select=typename)&$filter=${filter}`);

--- a/src/ui-test/e2e/pluginProfilerReplay.e2e.ts
+++ b/src/ui-test/e2e/pluginProfilerReplay.e2e.ts
@@ -205,6 +205,16 @@ describe("DEBUGGING: Plugin — profile capture → replay → execute via panel
       // The extension's capture uses a server-side assembly filter now, so a freshly-registered step
       // is found even though this org has 200+ active system (Microsoft.*) steps. Assert it live —
       // this is the reliable heart of the debugging loop (before the modal that the VM can't drive).
+      //
+      // SELF-HEAL first (#241): profiling DEACTIVATES the step it profiles, and a run that never
+      // reached "Stop Profiling" leaves it that way. The deploy above reports such a step "Unchanged"
+      // without touching `statecode`, so the profilable query then correctly finds nothing — one
+      // failed run used to poison every later run permanently. Re-enable before asserting.
+      const reactivated = await client.reactivateAssemblySteps(projectName).catch(() => 0);
+      if (reactivated > 0) {
+        console.log(`    [e2e] re-enabled ${reactivated} step(s) left disabled by an earlier profiling run`);
+      }
+
       let count = 0;
       const deadline = Date.now() + 120000;
       do {
@@ -320,6 +330,16 @@ describe("DEBUGGING: Plugin — profile capture → replay → execute via panel
       const removed = await client.cleanupProfilerSteps("territory");
       if (removed > 0) {
         console.log(`[cleanup] removed ${removed} leftover profiler step(s) on territory`);
+      }
+    } catch {
+      /* best-effort */
+    }
+    // Then RE-ENABLE the original the profiler deactivated (#241). Deleting the clone was never
+    // enough: leaving the original disabled is what made one failed run break every run after it.
+    try {
+      const reactivated = await client.reactivateAssemblySteps(projectName);
+      if (reactivated > 0) {
+        console.log(`[cleanup] re-enabled ${reactivated} original step(s) the profiler had disabled`);
       }
     } catch {
       /* best-effort */

--- a/src/ui-test/e2e/solutionAcceptance.e2e.ts
+++ b/src/ui-test/e2e/solutionAcceptance.e2e.ts
@@ -112,7 +112,14 @@ describe("ACCEPTANCE: Solution — extract, pack, deploy via panel buttons", fun
       await clickPanelButton("Deploy to", { timeoutMs: 30000, contains: true }); // primary "▶ Deploy to {environment}"
       // Deploy re-packs (managed + unmanaged) THEN imports + publishes — slow, so allow a generous
       // window before gating on the import-completion signal in the output channel.
-      const done = await waitForOutput(["Solution Imported successfully", "Published All Customizations", "imported successfully", "Import complete"], 900000);
+      // Gate on the two lines the import path REALLY logs, in order: the import result, then the
+      // publish that follows it (the command's final signal). These are ANDed — see waitForOutput.
+      //
+      // This previously passed four ALTERNATIVE phrasings to an all-must-match helper, two of which
+      // ("imported successfully" lower-case, "Import complete") the extension never logs at all. The
+      // condition was therefore unsatisfiable, so this step burned its full 900s and failed on every
+      // run while the import itself was succeeding (#240).
+      const done = await waitForOutput(["Solution Imported successfully", "Published All Customizations"], 900000);
       if (!done) {
         throw new Error("solution import did not report completion in the output channel");
       }


### PR DESCRIPTION
Closes #240. Closes #241. **11/11 pass** across both suites (7m), including the full capture → replay → `dotnet test` chain those failures had been hiding.

Both were investigated to a proven cause rather than quarantined or retried.

## #240 `solutionAcceptance` Deploy — broken test, unsatisfiable by construction

The import was succeeding **every run**. The extension logged exactly what the test wanted:

```
Solution Importing...
Solution Imported successfully.
Publishing All Customizations...
Published All Customizations.
```

The test passed **four alternative phrasings** to `waitForOutput`, which **ANDs** them — and two of those strings (`"imported successfully"` lower-case, `"Import complete"`) are logged nowhere in the codebase. The condition could never be satisfied, so the step burned its full 900 s and reported *"solution import did not report completion"* about an import that had completed.

Now gates on the two lines that genuinely co-occur, ending on the command's **final** signal (the publish). Deploy confirms in **68 s** where it previously timed out at 900 s.

`waitForOutput`'s AND semantics are now documented — "pass a list of alternatives" is the natural misreading and it silently produces a permanently-red test. I checked every other array-form gate in the repo; no others have this defect.

## #241 `pluginProfilerReplay` — self-poisoning test, hiding a real product bug

**The extension's query was correct.** I verified against the live org that the two-level filter `plugintypeid/pluginassemblyid/name` genuinely filters (200 rows for a known assembly), so the 0.14.40 `$top=200` fix had **not** regressed. The org state was the problem:

```
ALL ProfilerE2E steps (any statecode): 1
   statecode=1 statuscode=2  Create territory (DVPT profiler e2e)
extension's profilable query: rows: 0
```

The Plugin Profiler **deactivates the original step** while profiling it. Teardown deleted the profiler's clone but never re-enabled the original, and the deploy's step sync reports such a step `Unchanged` without touching `statecode`. So the first failed run disabled the step permanently and every later run failed at the same assertion — which is exactly why it reproduced identically on `main`.

**Test fix:** `reactivateAssemblySteps()` re-enables originals (never the `(Profiled)` clones) in teardown **and** defensively before the assertion, so an already-poisoned org self-heals rather than failing forever. It fired in the verification run:

```
[e2e] re-enabled 1 step(s) left disabled by an earlier profiling run
```

**Product fix — the real bug this exposed.** A user in the same state (steps registered but disabled, which is what leaving profiling on gives you) was told:

> No registered plugin steps to profile. Deploy your plugin and register a step (CodeLens) first.

Advice they cannot act on, for a step they already deployed. And **nothing was logged at all** — the diagnostic only fired when the query returned rows, and the assembly-filtered query returns *zero* rows in this case. A silent dead end. Both the message and the log now name the real cause and the remedy (*"the profiler disables a step while profiling it — stop profiling"*), on both the capture and CodeLens paths.

## Verification

| | |
| --- | --- |
| e2e, both suites | **11/11 passing** (7m), log audit clean |
| unit | 1056 passing (**6 new** over the pure message/query builders) |
| lint / tsc | clean |

Also relevant to #224: the profiler chain now demonstrably runs end to end — capture → replay → `dotnet test` green — which the cascade had been masking.