### PR TITLE
fix: Custom API handlers were generated where they could never compile (#225)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,29 @@ All notable changes to the "dataverse-powertools" extension will be documented i
 Pre-release builds get a per-version entry in [CHANGELOG-prerelease.md](CHANGELOG-prerelease.md);
 those entries are rolled up into one section here when a full release ships.
 
+## 1.0.4
+
+**Custom APIs work.** They could not before: the generated C# handler was written where the plug-in
+project never compiled it.
+
+**Generated handlers land in your plug-in project**
+
+*Generate Custom API handlers* wrote the handler one folder above your plug-in project, and a .NET
+project only compiles the C# files inside its own folder. So the handler never made it into the
+assembly, the plug-in type it declares never existed, and *Deploy Custom APIs* always ended with
+*"plugin type '…' not found in the environment — deploy & register the plugin first."*
+
+Handlers now go to `<YourPluginProject>/CustomApi/<Class>.generated.cs`, and the output names the path
+so you can see which project builds it. If you hit that error before, regenerate the handler, deploy the
+package, then deploy the API.
+
+The whole loop is now covered end to end against a real environment — define, generate, deploy the
+package, deploy the API, then call it and check the response — so this stays fixed. Two things to know
+while Custom APIs are still a preview feature: **regenerating a handler overwrites the file, including
+the code you wrote in `Execute`** ([#254](https://github.com/pete-mc/dataverse-powertools/issues/254)),
+and *Run Custom API…* calls Global (unbound) APIs only — use the generated TypeScript client for
+table-bound ones.
+
 ## 1.0.3
 
 **Replay & debug** now does what it says: it replays a captured plug-in run **under the debugger**, so

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "dataverse-powertools",
-  "version": "1.0.2",
+  "version": "1.0.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "dataverse-powertools",
-      "version": "1.0.2",
+      "version": "1.0.4",
       "hasInstallScript": true,
       "dependencies": {
         "@azure/msal-node": "^5.4.0",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "type": "git",
     "url": "https://github.com/pete-mc/dataverse-powertools"
   },
-  "version": "1.0.3",
+  "version": "1.0.4",
   "engines": {
     "vscode": "^1.95.0"
   },

--- a/src/customapi/customApiCommands.ts
+++ b/src/customapi/customApiCommands.ts
@@ -13,6 +13,7 @@ import { CUSTOM_API_FILE_SUFFIX, CustomApiDefinition, newCustomApiDefinition } f
 import { validateCustomApiDefinition } from "./validate";
 import { generateCustomApiHandler, customApiHandlerFileName } from "./generateHandler";
 import { generateTypedClient, customApiClientFileName } from "./generateTypedClient";
+import { findPrimaryPluginCsproj } from "../plugins/projectPaths";
 
 /** All `*.customapi.json` files directly under a component root. */
 export function findCustomApiDefinitionFiles(root: string): string[] {
@@ -24,6 +25,16 @@ export function findCustomApiDefinitionFiles(root: string): string[] {
   } catch {
     return [];
   }
+}
+
+/**
+ * Where a generated C# handler belongs: the directory of the component's plug-in `.csproj`, falling back
+ * to the component root when there is no project to put it in (the file is then at least visible, and
+ * the deploy will say the type is missing rather than silently pointing at nothing).
+ */
+export async function customApiHandlerDirectory(root: string, preferredProjectName?: string): Promise<string> {
+  const csproj = await findPrimaryPluginCsproj(root, preferredProjectName);
+  return csproj ? path.dirname(csproj) : root;
 }
 
 /** Scaffold a new sample `*.customapi.json` in the active plugin component. */
@@ -78,7 +89,12 @@ export async function generateCustomApiHandlers(context: DataversePowerToolsCont
     return;
   }
 
-  const outDir = path.join(root, "CustomApi");
+  // Into the PLUG-IN PROJECT, not the component root. The handler declares the plug-in type the Custom
+  // API points at, so it has to be inside the folder the .csproj compiles — an SDK-style project globs
+  // `**/*.cs` under its own directory and nothing above it. Written to the component root it never
+  // reached the assembly, the plug-in type never existed, and every Deploy Custom APIs ended in
+  // "plugin type '…' not found in the environment". Same resolution the New plugin class command uses.
+  const outDir = path.join(await customApiHandlerDirectory(root, context.projectSettings.pluginProjectName), "CustomApi");
   let generated = 0;
   let failed = 0;
 
@@ -104,7 +120,9 @@ export async function generateCustomApiHandlers(context: DataversePowerToolsCont
     fs.mkdirSync(outDir, { recursive: true });
     const outPath = path.join(outDir, customApiHandlerFileName(definition));
     fs.writeFileSync(outPath, generateCustomApiHandler(definition), "utf8");
-    context.channel.appendLine(`✓ ${name} → CustomApi/${path.basename(outPath)}`);
+    // Say WHERE it landed relative to the component, so "which project is this compiled into?" is
+    // answerable from the log.
+    context.channel.appendLine(`✓ ${name} → ${path.relative(root, outPath).replace(/\\/g, "/")}`);
     generated++;
   }
 

--- a/src/customapi/handlerLocation.spec.ts
+++ b/src/customapi/handlerLocation.spec.ts
@@ -1,0 +1,37 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+vi.mock("../plugins/projectPaths", () => ({ findPrimaryPluginCsproj: vi.fn() }));
+import { findPrimaryPluginCsproj } from "../plugins/projectPaths";
+import { customApiHandlerDirectory } from "./customApiCommands";
+
+// The generated C# handler declares the plug-in type the Custom API points at, so it has to live inside
+// the folder the .csproj compiles. It was written to the COMPONENT ROOT instead — one level above the
+// project — where an SDK-style project's `**/*.cs` glob never sees it. The consequences were invisible
+// until a live run: the type never reached the assembly, so every Deploy Custom APIs ended in
+// "plugin type '…' not found in the environment". These tests pin the location.
+
+const csprojMock = findPrimaryPluginCsproj as unknown as ReturnType<typeof vi.fn>;
+beforeEach(() => csprojMock.mockReset());
+
+describe("customApiHandlerDirectory", () => {
+  it("puts the handler in the plug-in project's directory, not the component root", async () => {
+    csprojMock.mockResolvedValue("C:/ws/MyPlugins/MyPlugins.csproj");
+    expect(await customApiHandlerDirectory("C:/ws")).toBe("C:/ws/MyPlugins");
+  });
+
+  it("prefers the configured plug-in project when several exist", async () => {
+    csprojMock.mockResolvedValue("C:/ws/Chosen/Chosen.csproj");
+    expect(await customApiHandlerDirectory("C:/ws", "Chosen")).toBe("C:/ws/Chosen");
+    expect(csprojMock).toHaveBeenCalledWith("C:/ws", "Chosen");
+  });
+
+  it("handles a project that IS the component root", async () => {
+    csprojMock.mockResolvedValue("C:/ws/MyPlugins.csproj");
+    expect(await customApiHandlerDirectory("C:/ws")).toBe("C:/ws");
+  });
+
+  it("falls back to the component root when there is no plug-in project", async () => {
+    csprojMock.mockResolvedValue(undefined);
+    expect(await customApiHandlerDirectory("C:/ws")).toBe("C:/ws");
+  });
+});

--- a/src/ui-test/e2e/customApiLifecycle.e2e.ts
+++ b/src/ui-test/e2e/customApiLifecycle.e2e.ts
@@ -1,0 +1,295 @@
+import * as path from "path";
+import * as fs from "fs";
+import { expect } from "chai";
+import { Key, VSBrowser } from "vscode-extension-tester";
+import { loadE2EEnv, freshWorkspace, answerText, pickByLabel, waitForFile, dismissOverlays, sleep, expectOutput, clearOutput, E2EClient } from "./lib";
+import { clickPanelButton, clickOverflowItem, expandComponentCards } from "../supervised/supervisedLib";
+import { initProject, step, showLog } from "./acceptanceLib";
+
+// ACCEPTANCE (button-driven, live Dataverse): the Custom API loop, end to end — define, generate the
+// handler and the typed client, deploy the plug-in package, deploy the API, then CALL IT and check the
+// response.
+//
+// This suite exists because nothing had ever exercised those wire calls (#225). Both files said so in
+// their own source: deployCustomApi's create/update/delete "have not yet been run against a live
+// environment", and invokeCustomApi's HTTP call likewise. Six unit specs cover the pure parts — the
+// definition format, the payload shapes, the reconcile plan, the generated code — none of which can
+// catch a 400 from Dataverse or a swallowed failure, the exact shape of #129 (early-bound reporting
+// success with zero files written because pac exits 0 on failure).
+//
+// What only this layer can prove:
+//   * the customapi row, its request parameters and its response properties really land, with the
+//     values the definition asked for;
+//   * the deploy finds the plug-in type it needs (the package import has to have created it);
+//   * invoking the message actually returns the handler's output, so the whole path — request wrapper,
+//     InputParameters, the plug-in, OutputParameters, response wrapper — is connected.
+//
+// The generated handler is a stub with a TODO, so the test writes one line of real implementation into
+// it (echo the input) before deploying: without that the call would return 200 and nothing, which would
+// prove the plumbing while proving nothing about the data.
+const COMPONENT = "Custom API";
+
+/**
+ * Close a panel overflow menu left open by an earlier step.
+ *
+ * The menu lives inside the panel's webview, so `dismissOverlays` (which works on the main document)
+ * cannot reach it — and while it is open the panel's own buttons are unreachable, which turned one failed
+ * step into a cascade of "button not found".
+ */
+const escapeKey = Key.ESCAPE;
+
+async function closeAnyOpenMenu(): Promise<void> {
+  try {
+    await VSBrowser.instance.driver.actions().sendKeys(escapeKey).perform();
+    await sleep(500);
+    await VSBrowser.instance.driver.actions().sendKeys(escapeKey).perform();
+  } catch {
+    /* best-effort */
+  }
+  await dismissOverlays();
+  await sleep(500);
+}
+
+describe("ACCEPTANCE: Custom API — define, deploy and execute via panel buttons", function () {
+  this.timeout(3600000);
+  const env = loadE2EEnv();
+  let workspace: string;
+  let solutionFriendlyName: string;
+  let client: E2EClient;
+  const projectName = "CustomApiE2E";
+  const packageName = "CustomApiE2E";
+  /** Unique per run: a leftover row from an earlier run would make "created" un-provable. */
+  const apiUniqueName = `dvpt_Echo${Date.now().toString().slice(-6)}`;
+  const className = `Echo${Date.now().toString().slice(-6)}`;
+  let pluginTypeName = "";
+  let handlerPath = "";
+  const isWindows = process.platform === "win32";
+
+  function pkgUnique(): string {
+    const settings = JSON.parse(fs.readFileSync(path.join(workspace, "dataverse-powertools.json"), "utf8"));
+    return `${settings.prefix ?? env?.prefix}_${packageName}`;
+  }
+
+  before(async function () {
+    if (!env || !isWindows) {
+      this.skip();
+    }
+    client = new E2EClient(env!);
+    await client.connect();
+    solutionFriendlyName = (await client.getSolutionFriendlyName(env!.solutionName)) ?? env!.solutionName;
+    workspace = freshWorkspace("acc-customapi");
+    await VSBrowser.instance.openResources(workspace);
+    await VSBrowser.instance.waitForWorkbench();
+    await sleep(3500);
+    await dismissOverlays();
+    await showLog();
+  });
+
+  it("starts a Plugins project (Initialise button + wizard)", async () => {
+    await step(COMPONENT, "Scaffold the plugin project that will implement the API", async () => {
+      await initProject("Plugins", env!, solutionFriendlyName, async () => {
+        await answerText(projectName); // plugin project name
+        await answerText(packageName); // plugin package name
+        await answerText("1.0.0"); // version
+        await pickByLabel("No", 600000); // set up unit testing? (not needed here)
+        await pickByLabel("No", 300000); // create a plugin class? the Custom API generator writes ours
+      });
+      expect(await waitForFile(path.join(workspace, "dataverse-powertools.json"), 300000), "project scaffolded").to.equal(true);
+      return `scaffolded ${projectName} (plugin package ${packageName})`;
+    });
+  });
+
+  it("creates a Custom API definition — New Custom API definition", async () => {
+    await step(COMPONENT, "Create the definition file", async () => {
+      await clearOutput();
+      await closeAnyOpenMenu();
+      await expandComponentCards();
+      await clickOverflowItem("New Custom API definition", { timeoutMs: 45000 });
+      await answerText(apiUniqueName); // unique name
+      pluginTypeName = `${projectName}.${className}`;
+      await answerText(pluginTypeName); // plug-in type that implements it
+      // Written at the COMPONENT root, which for a root-initialised project is the workspace root — the
+      // plugin .csproj lives a level down in ${projectName}/.
+      const definitionPath = path.join(workspace, `${apiUniqueName}.customapi.json`);
+      expect(await waitForFile(definitionPath, 60000), `${apiUniqueName}.customapi.json`).to.equal(true);
+
+      // The scaffold has to be a valid, Global, non-function API with one in and one out — everything
+      // downstream (handler shape, invoke prompts, the assertions below) reads from it.
+      const def = JSON.parse(fs.readFileSync(definitionPath, "utf8"));
+      expect(def.binding, "scaffolded as Global (unbound)").to.equal("Global");
+      expect(def.isFunction, "scaffolded as an Action, not a Function").to.equal(false);
+      expect(
+        def.requestParameters.map((p: any) => p.uniqueName),
+        "one request parameter",
+      ).to.deep.equal(["InputValue"]);
+      expect(
+        def.responseProperties.map((p: any) => p.uniqueName),
+        "one response property",
+      ).to.deep.equal(["OutputValue"]);
+      await expectOutput([`Created Custom API definition`], { step: "new definition", timeoutMs: 60000 });
+      return `wrote ${apiUniqueName}.customapi.json (Global action, InputValue → OutputValue)`;
+    });
+  });
+
+  it("generates the C# handler and the typed TypeScript client", async () => {
+    await step(COMPONENT, "Generate handler + client", async () => {
+      await clearOutput();
+      await closeAnyOpenMenu();
+      await expandComponentCards();
+      await clickOverflowItem("Generate Custom API handlers", { timeoutMs: 45000 });
+      // The log names the DEFINITION FILE, not the unique name: "✓ dvpt_X.customapi.json → …".
+      await expectOutput([`✓ ${apiUniqueName}.customapi.json → `, `${className}.generated.cs`], { step: "generate handler", timeoutMs: 120000 });
+      // The handler has to end up somewhere the plug-in project COMPILES, or the type it declares never
+      // reaches the assembly and the Custom API deploy has nothing to point at. Accept either location
+      // for now and record which one, so the run shows the whole consequence chain rather than stopping
+      // at the first symptom.
+      const atComponentRoot = path.join(workspace, "CustomApi", `${className}.generated.cs`);
+      const inPluginProject = path.join(workspace, projectName, "CustomApi", `${className}.generated.cs`);
+      const found = (await waitForFile(inPluginProject, 30000)) ? inPluginProject : (await waitForFile(atComponentRoot, 30000)) ? atComponentRoot : undefined;
+      expect(found, `${className}.generated.cs written somewhere`).to.not.equal(undefined);
+      handlerPath = found!;
+      const buildable = handlerPath.startsWith(path.join(workspace, projectName) + path.sep);
+      console.log(`    [e2e] handler written to ${path.relative(workspace, handlerPath)} — ${buildable ? "inside" : "OUTSIDE"} the plug-in project`);
+      expect(buildable, `the generated handler is inside ${projectName}/ so dotnet build compiles it`).to.equal(true);
+
+      await clearOutput();
+      await closeAnyOpenMenu();
+      await expandComponentCards();
+      await clickOverflowItem("Generate Custom API TS clients", { timeoutMs: 45000 });
+      await expectOutput([`✓ ${apiUniqueName}.customapi.json → clients/`], { step: "generate client", timeoutMs: 120000 });
+      // The client is TypeScript for a web-resource/PCF project, so the component root is right for it.
+      // It is named after the plug-in CLASS, not the API's unique name.
+      const clientFile = path.join(workspace, "clients", `${className}.client.ts`);
+      expect(await waitForFile(clientFile, 60000), `clients/${className}.client.ts`).to.equal(true);
+
+      // The generated client must be usable: the typed request/response and the message name.
+      const clientSource = fs.readFileSync(clientFile, "utf8");
+      expect(clientSource, "the client calls the API by its unique name").to.contain(apiUniqueName);
+      expect(clientSource, "the client types the request parameter").to.contain("InputValue");
+      expect(clientSource, "the client types the response property").to.contain("OutputValue");
+      return `generated CustomApi/${className}.generated.cs and clients/${apiUniqueName}.ts`;
+    });
+  });
+
+  it("implements the handler, then deploys the package — Build & deploy package", async () => {
+    await step(COMPONENT, "Implement + deploy the plug-in package", async () => {
+      // Replace the generated TODO with the one line a user would write. Done here rather than in the
+      // template so regenerating never silently overwrites real logic.
+      const handler = handlerPath;
+      const source = fs.readFileSync(handler, "utf8");
+      const implemented = source.replace(
+        /\/\/ TODO: implement the .*\n.*\/\/ Read typed inputs from 'request', set typed outputs on 'response'\./,
+        `response.OutputValue = "echo: " + request.InputValue;`,
+      );
+      expect(implemented, "the TODO was found and replaced").to.not.equal(source);
+      fs.writeFileSync(handler, implemented);
+
+      await clearOutput();
+      await closeAnyOpenMenu();
+      await expandComponentCards();
+      // `contains` because the primary button carries a "▶ " prefix.
+      await clickPanelButton("Build & deploy package", { timeoutMs: 45000, contains: true });
+      await expectOutput(["Build Package & Deploy completed."], { step: "build & deploy package", timeoutMs: 900000 });
+
+      const packageId = await client.findPluginPackageId(pkgUnique());
+      expect(packageId, `plugin package ${pkgUnique()} in Dataverse`).to.not.equal(undefined);
+      // The Custom API deploy resolves the plug-in TYPE by name; the package import is what creates it.
+      // If this is undefined the next step cannot work, and the reason is here rather than in a vague
+      // "not found" message.
+      const typeId = await (async (): Promise<string | undefined> => {
+        const deadline = Date.now() + 180000;
+        for (;;) {
+          const id = await client.findPluginTypeId(pluginTypeName);
+          if (id || Date.now() > deadline) {
+            return id;
+          }
+          await sleep(5000);
+        }
+      })();
+      expect(typeId, `plugin type ${pluginTypeName} registered by the package import`).to.not.equal(undefined);
+      return `deployed ${pkgUnique()}; plug-in type ${pluginTypeName} exists (${typeId})`;
+    });
+  });
+
+  it("deploys the Custom API — and the rows really land in Dataverse", async () => {
+    await step(COMPONENT, "Deploy Custom APIs", async () => {
+      await clearOutput();
+      await closeAnyOpenMenu();
+      await expandComponentCards();
+      await clickOverflowItem("Deploy Custom APIs", { timeoutMs: 45000 });
+      // Gate on the reconcile SUMMARY, not on "Created CustomAPI": that line is written before the
+      // request parameters and response properties are reconciled, so verifying Dataverse on it found
+      // the API and its parameter but not yet its response property. The counts also assert the plan —
+      // one of each created, nothing updated, nothing deleted.
+      await expectOutput([`Created CustomAPI '${apiUniqueName}'.`, "Parameters: +1 ~0 -0; Response: +1 ~0 -0."], { step: "deploy custom api", timeoutMs: 300000 });
+
+      const customApiId = await client.findCustomApiId(apiUniqueName);
+      expect(customApiId, `customapi row for ${apiUniqueName}`).to.not.equal(undefined);
+      // Verify against Dataverse, not against our own log line: a POST that 400s and is swallowed would
+      // still print progress.
+      const row = await client.getCustomApi(apiUniqueName);
+      expect(row?.bindingtype, "stored as Global (bindingtype 0)").to.equal(0);
+      expect(row?.isfunction, "stored as an Action").to.equal(false);
+      expect(row?.plugintypeid, "wired to the plug-in type").to.not.equal(undefined);
+
+      const members = await client.getCustomApiMembers(customApiId!);
+      expect(members.requestParameters, "the request parameter was created").to.include("InputValue");
+      expect(members.responseProperties, "the response property was created").to.include("OutputValue");
+      return `customapi ${apiUniqueName} created (${customApiId}) with InputValue → OutputValue`;
+    });
+  });
+
+  it("EXECUTES the Custom API and returns the handler's output — Run Custom API…", async () => {
+    await step(COMPONENT, "Run Custom API and check the response", async () => {
+      await clearOutput();
+      await closeAnyOpenMenu();
+      await expandComponentCards();
+      // A freshly-created message can take a moment to be callable; retry the whole invoke rather than
+      // asserting on the first attempt.
+      let responseText = "";
+      const deadline = Date.now() + 420000;
+      for (let attempt = 1; ; attempt++) {
+        await clickOverflowItem("Run Custom API…", { timeoutMs: 45000 });
+        // No "which Custom API?" pick: that quick pick only appears with MORE than one definition in the
+        // component, and this suite creates exactly one — so the next prompt is the parameter itself.
+        await answerText("ping"); // InputValue
+        try {
+          // "POST dvpt_Echo…" — the logged path has no leading slash.
+          responseText = await expectOutput([`POST ${apiUniqueName}`, "Response:"], { step: `invoke custom api (attempt ${attempt})`, timeoutMs: 120000 });
+          break;
+        } catch (error) {
+          if (Date.now() > deadline) {
+            throw error;
+          }
+          console.log(`    [e2e] invoke attempt ${attempt} did not answer yet — the message may still be publishing; retrying.`);
+          await clearOutput();
+          await sleep(20000);
+        }
+      }
+
+      // The response has to carry the handler's OutputValue: that is the only thing proving the call
+      // reached the plug-in and came back, rather than merely returning 204.
+      expect(responseText, "the response contains the handler's OutputValue").to.contain("OutputValue");
+      expect(responseText, "the handler echoed the input we passed").to.contain("echo: ping");
+      return `called ${apiUniqueName} with InputValue="ping" and got OutputValue="echo: ping"`;
+    });
+  });
+
+  after(async function () {
+    // Remove the Custom API first: its members reference it, and the plug-in type cannot be removed
+    // while a Custom API points at it.
+    try {
+      const removed = await client.deleteCustomApi(apiUniqueName);
+      if (removed) {
+        console.log(`[cleanup] deleted Custom API ${apiUniqueName} and its members`);
+      }
+    } catch (error) {
+      console.log(`[cleanup] could not delete Custom API ${apiUniqueName}: ${String(error).slice(0, 120)}`);
+    }
+    try {
+      await client.deletePluginPackage(pkgUnique());
+    } catch {
+      /* best-effort */
+    }
+  });
+});

--- a/src/ui-test/e2e/fetchXmlQuery.e2e.ts
+++ b/src/ui-test/e2e/fetchXmlQuery.e2e.ts
@@ -39,7 +39,13 @@ describe("FetchXML query tools (e2e)", function () {
   let workspace: string;
   let solutionFriendlyName: string;
 
-  /** A plugin-style C# file: verbatim FetchXML, one interpolated GUID, handed to FetchExpression. */
+  /**
+   * A plugin-style C# file: verbatim FetchXML, one interpolated value, handed to FetchExpression.
+   *
+   * The interpolation is the STATE code rather than an account id, so the test run comes back with real
+   * rows and several columns — a query that matches nothing proves the plumbing but shows an empty grid,
+   * and this run is also where the documentation screenshot of the results view comes from.
+   */
   const CSHARP_FILE = "QueryProbe.cs";
   const CSHARP_SOURCE = `using System;
 using Microsoft.Xrm.Sdk;
@@ -52,13 +58,17 @@ namespace DvptQueryProbe
         // A marker the write-back test asserts is still present afterwards.
         public const string Marker = "DO-NOT-TOUCH";
 
-        public EntityCollection OpenCasesFor(IOrganizationService service, Guid accountId)
+        public EntityCollection ActiveAccounts(IOrganizationService service, int stateCode)
         {
             var fetchXml = $@"<fetch top='50'>
   <entity name='account'>
     <attribute name='name' />
+    <attribute name='accountnumber' />
+    <attribute name='telephone1' />
+    <attribute name='createdon' />
+    <order attribute='name' />
     <filter type='and'>
-      <condition attribute='accountid' operator='eq' value='{accountId}' />
+      <condition attribute='statecode' operator='eq' value='{stateCode}' />
     </filter>
   </entity>
 </fetch>";
@@ -289,14 +299,18 @@ namespace DvptQueryProbe
     // Wiki frame: the prompt that asks for the placeholder's value before the query runs.
     await sleep(2500);
     await shot("fetchxml-03-parameter-prompt");
-    // One parameter (accountId, inferred Uniqueidentifier from the column) — the prompt validates it,
-    // so an all-zero GUID is accepted and simply matches nothing.
-    await answerText("00000000-0000-0000-0000-000000000000");
+    // One parameter (stateCode, inferred as a whole number from the column) — 0 is Active, so the run
+    // comes back with real accounts.
+    await answerText("0");
 
     // Gate on the run's FINAL line. Metadata has to load first (the entity SET name comes from it),
     // so allow for that round trip.
     const text = await expectOutput(["[Query] GET accounts", "row(s) returned"], { step: "run C# query", timeoutMs: 240000 });
-    expect(/\[Query\] \d+ row\(s\) returned/.test(text), "the run logged a row count").to.equal(true);
+    const rowCount = Number(/\[Query\] (\d+) row\(s\) returned/.exec(text)?.[1] ?? "-1");
+    expect(rowCount, "the run logged a row count").to.be.at.least(0);
+    // Rows, not just a successful call: an empty grid would prove the plumbing while showing nothing,
+    // and this run is where the documentation screenshot of the results view comes from.
+    expect(rowCount, "the query returned actual rows (are there active accounts in the test org?)").to.be.greaterThan(0);
     await assertCommandDidNotError("run C# query");
     // Wiki frame: the results view for that run.
     await sleep(2000);
@@ -307,21 +321,22 @@ namespace DvptQueryProbe
     await openFile(csharpPath());
     await lensTitles();
     await clickLens("generator");
-    // FINAL signal for the open: state rendered. 5 elements = fetch/entity/attribute/filter/condition.
-    await expectOutput(["[Query] Generator ready for QueryProbe.cs", "5 elements"], { step: "open generator", timeoutMs: 120000 });
+    // FINAL signal for the open: state rendered. 9 elements =
+    // fetch/entity/4 attributes/order/filter/condition.
+    await expectOutput(["[Query] Generator ready for QueryProbe.cs", "9 elements"], { step: "open generator", timeoutMs: 120000 });
 
     const webview = await openGeneratorFrame();
     try {
       const rows = await webview.findWebElements(By.css("#tree .row"));
-      expect(rows.length, "the tree renders one row per element").to.equal(5);
+      expect(rows.length, "the tree renders one row per element").to.equal(9);
       const labels = await Promise.all(rows.map((row) => row.getText()));
       expect(labels.join(" | "), "the tree reads like the query").to.contain("account");
 
       // The parameter is bound to the code expression, not invented by the generator.
       const parameterInputs = await webview.findWebElements(By.css("#parameters input"));
-      expect(parameterInputs.length, "one parameter row for {accountId}").to.equal(1);
+      expect(parameterInputs.length, "one parameter row for {stateCode}").to.equal(1);
       const parameterText = await (await webview.findWebElement(By.css("#parameters"))).getText();
-      expect(parameterText, "the parameter names itself after the variable").to.contain("accountId");
+      expect(parameterText, "the parameter names itself after the variable").to.contain("stateCode");
     } finally {
       await webview.switchBack();
     }
@@ -370,10 +385,10 @@ namespace DvptQueryProbe
     expect(after, "the edit landed in the source file").to.contain("top='7'");
     expect(after, "the old value is gone").to.not.contain("top='50'");
     // ...and nothing else did: the surrounding code, the interpolation, and the literal's form.
-    expect(after, "the interpolated expression is preserved verbatim").to.contain("{accountId}");
+    expect(after, "the interpolated expression is preserved verbatim").to.contain("{stateCode}");
     expect(after, "the literal stays an interpolated verbatim string").to.contain('$@"<fetch');
     expect(after, "surrounding code is untouched").to.contain('public const string Marker = "DO-NOT-TOUCH";');
-    expect(after, "the method signature is untouched").to.contain("public EntityCollection OpenCasesFor(IOrganizationService service, Guid accountId)");
+    expect(after, "the method signature is untouched").to.contain("public EntityCollection ActiveAccounts(IOrganizationService service, int stateCode)");
   });
 
   it("re-detects the edited query, so the round trip is stable", async () => {

--- a/src/ui-test/e2e/lib.ts
+++ b/src/ui-test/e2e/lib.ts
@@ -966,6 +966,75 @@ export class E2EClient {
       await this.request("DELETE", `pluginpackages(${id})`);
     }
   }
+
+  // ---- Custom API (#225): verify what the deploy actually created, then remove it ----
+
+  /** The `customapi` row id for a unique name, or undefined when it is not in the environment. */
+  async findCustomApiId(uniqueName: string): Promise<string | undefined> {
+    const res = await this.request("GET", `customapis?$select=customapiid&$filter=uniquename eq '${uniqueName.replace(/'/g, "''")}'`);
+    if (!res.ok) {
+      return undefined;
+    }
+    const data: any = await res.json();
+    return data?.value?.[0]?.customapiid;
+  }
+
+  /** The Custom API's binding/function flags and plugin type, as Dataverse actually stored them. */
+  async getCustomApi(uniqueName: string): Promise<{ bindingtype: number; isfunction: boolean; displayname: string; plugintypeid?: string } | undefined> {
+    const res = await this.request("GET", `customapis?$select=bindingtype,isfunction,displayname,_plugintypeid_value&$filter=uniquename eq '${uniqueName.replace(/'/g, "''")}'`);
+    if (!res.ok) {
+      return undefined;
+    }
+    const data: any = await res.json();
+    const row = data?.value?.[0];
+    return row ? { bindingtype: row.bindingtype, isfunction: row.isfunction, displayname: row.displayname, plugintypeid: row._plugintypeid_value } : undefined;
+  }
+
+  /** Request parameter + response property unique names for a deployed Custom API. */
+  async getCustomApiMembers(customApiId: string): Promise<{ requestParameters: string[]; responseProperties: string[] }> {
+    const read = async (entitySet: string): Promise<string[]> => {
+      const res = await this.request("GET", `${entitySet}?$select=uniquename&$filter=_customapiid_value eq ${customApiId}`);
+      if (!res.ok) {
+        return [];
+      }
+      const data: any = await res.json();
+      return (data?.value ?? []).map((row: any) => row.uniquename);
+    };
+    return { requestParameters: await read("customapirequestparameters"), responseProperties: await read("customapiresponseproperties") };
+  }
+
+  /** The `plugintype` row id for a type name — what the Custom API deploy has to find. */
+  async findPluginTypeId(typeName: string): Promise<string | undefined> {
+    const res = await this.request("GET", `plugintypes?$select=plugintypeid&$filter=typename eq '${typeName.replace(/'/g, "''")}'`);
+    if (!res.ok) {
+      return undefined;
+    }
+    const data: any = await res.json();
+    return data?.value?.[0]?.plugintypeid;
+  }
+
+  /** Delete a Custom API and its members. Members go first — the API cannot be deleted under them. */
+  async deleteCustomApi(uniqueName: string): Promise<boolean> {
+    const id = await this.findCustomApiId(uniqueName);
+    if (!id) {
+      return false;
+    }
+    for (const entitySet of ["customapirequestparameters", "customapiresponseproperties"]) {
+      const res = await this.request(
+        "GET",
+        `${entitySet}?$select=${entitySet === "customapirequestparameters" ? "customapirequestparameterid" : "customapiresponsepropertyid"}&$filter=_customapiid_value eq ${id}`,
+      );
+      if (res.ok) {
+        const data: any = await res.json();
+        for (const row of data?.value ?? []) {
+          const memberId = row.customapirequestparameterid ?? row.customapiresponsepropertyid;
+          await this.request("DELETE", `${entitySet}(${memberId})`);
+        }
+      }
+    }
+    await this.request("DELETE", `customapis(${id})`);
+    return true;
+  }
 }
 
 /**


### PR DESCRIPTION
## The feature has now been registered and executed against a live environment — and it could not have worked before

Asked directly whether Custom APIs had ever been tested by registering one and calling it: no. Six unit specs covered the definition format, payload shapes, the reconcile plan and the generated code; nothing had ever made the wire calls, and both files said so in their own source.

The first live run found why that mattered.

### The blocker (fixed)

`Generate Custom API handlers` wrote the C# file to the **component root**, one level above the plug-in project. An SDK-style `.csproj` globs `**/*.cs` under its own directory and nothing above it, so the handler never reached the assembly, the plug-in type it declares never existed, and every deploy ended in:

```
✗ dvpt_Echo237262: plugin type 'CustomApiE2E.Echo237262' not found in the environment — deploy & register the plugin first.
```

That was the whole feature, for anyone, on shipped code. *New plugin class* already resolved this correctly via `findPrimaryPluginCsproj`; the Custom API generator now uses the same resolution (`customApiHandlerDirectory`, 4 unit tests), and the log line names the path relative to the component so "which project compiles this?" is answerable from the output.

### The evidence

New live suite `src/ui-test/e2e/customApiLifecycle.e2e.ts` — define → generate handler + client → deploy the package → deploy the API → **call it**. 6 passing, log audit clean:

```
plug-in type CustomApiE2E.Echo821306 exists (428e385e-9b96-f111-b8dc-7ced8d3a7d5e)
Created CustomAPI 'dvpt_Echo821306'.
Parameters: +1 ~0 -0; Response: +1 ~0 -0.
Added to solution 'dvpttests'.
POST dvpt_Echo821306
Response: {"OutputValue":"echo: ping"}
```

It verifies against Dataverse rather than against our own log lines: the `customapi` row's `bindingtype`, `isfunction` and plug-in-type link, and both members by unique name. The plug-in type is asserted to exist *before* the API deploy, so the next person gets the cause instead of the symptom. The generated TypeScript client was inspected too — typed request/response, correct `getMetadata` parameter types, `Xrm.WebApi.online.execute`.

### Still open before sign-off

- **[#254](https://github.com/pete-mc/dataverse-powertools/issues/254) — regenerating the handler destroys the user's `Execute` implementation.** Filed rather than fixed: it wants a generated/user partial-class split, which is a design change, and it is the one thing that would frustrate a real user immediately.
- **Bound (table-scoped) APIs** cannot be invoked from *Run Custom API…* — the command says so and points at the generated client. Unchanged, and documented.
- **Update and delete paths** are exercised by unit tests but not yet live: this run only proved create (`+1 ~0 -0`). A second run against an edited definition would cover `~` and `-`.

The wiki page has dropped its "not verified against a live environment" caveat accordingly, and gained the paths and the regeneration warning.

🤖 Generated with [Claude Code](https://claude.com/claude-code)