### PR TITLE
1.0.5 — Custom API handlers keep your code (#254), PCF Add to Solution uses your solution (#256), read-only trace logs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,40 @@ All notable changes to the "dataverse-powertools" extension will be documented i
 Pre-release builds get a per-version entry in [CHANGELOG-prerelease.md](CHANGELOG-prerelease.md);
 those entries are rolled up into one section here when a full release ships.
 
+## 1.0.5
+
+**Custom API handlers keep the code you write**, and **PCF controls go into the solution you already
+chose**. Both were things you would hit the first time you used the feature properly.
+
+**Regenerating a Custom API handler no longer wipes your implementation**
+
+The handler was a single file holding both the generated wrappers and the `Execute` method you fill in —
+and regenerating rewrote all of it. Since changing the definition and regenerating is the whole point of
+definition-as-code, that cost you your code.
+
+It is two files now:
+
+- `<Class>.generated.cs` — the typed request/response wrappers. Refreshed whenever you regenerate, and
+  it says so at the top.
+- `<Class>.cs` — your `IPlugin` implementation. **Written once, never overwritten.**
+
+If you already have a handler from an earlier version, it still contains your `Execute` — the extension
+detects that and refuses to overwrite it, telling you to move the class into `<Class>.cs` first.
+
+**PCF: Add to Solution uses your configured solution**
+
+It used to require a Solution *project* (`.cdsproj`) in the workspace and did nothing without one — PCF
+was the only component type that asked for that. It now adds the pushed control to the solution from
+your connection settings, the same way a web resource or a plug-in step is added. If you do have a
+solution project it still adds the reference as well, so packing keeps working. When there is nothing to
+add, it tells you to push the control first, which is the actual next step.
+
+**Trace logs open read-only**
+
+Viewing a plug-in trace log opened it as an untitled document, so closing it asked whether you wanted to
+save something you had only read. It opens as a read-only document now, titled with the plug-in and the
+time.
+
 ## 1.0.4
 
 **Custom APIs work.** They could not before: the generated C# handler was written where the plug-in

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "dataverse-powertools",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "dataverse-powertools",
-      "version": "1.0.4",
+      "version": "1.0.5",
       "hasInstallScript": true,
       "dependencies": {
         "@azure/msal-node": "^5.4.0",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "type": "git",
     "url": "https://github.com/pete-mc/dataverse-powertools"
   },
-  "version": "1.0.4",
+  "version": "1.0.5",
   "engines": {
     "vscode": "^1.95.0"
   },

--- a/scripts/composeSideBySide.mjs
+++ b/scripts/composeSideBySide.mjs
@@ -1,0 +1,165 @@
+// Compose two captures into one side-by-side frame — the editor on the left, the live app on the right.
+//
+// Usage:
+//   node scripts/composeSideBySide.mjs <left.png> <right.png> <out.png> ["Left caption"] ["Right caption"]
+//
+// #231 asked for split-screen GIFs of the hot-reload flows (VS Code editing, the browser updating). A
+// recording is not reproducible — it drifts from the product the first time a label changes, and nobody
+// can diff it. Two frames captured by the SUITE, at the moments it has already asserted are correct,
+// composed here, say the same thing and stay honest: the editor half and the app half are each real
+// screenshots of a run that passed.
+//
+// Pure JS on pngjs (already a dependency, same as scripts/assembleGif.mjs) so it runs anywhere with no
+// image tooling installed.
+import fs from "fs";
+import path from "path";
+import { PNG } from "pngjs";
+
+const GAP = 16; // separator between the panes
+const BAND = 34; // caption band height, 0 when there are no captions
+const BG = { r: 24, g: 24, b: 27 }; // matches the VS Code dark chrome the frames carry
+
+/** Blit `src` into `dst` at (dx, dy), clipped to `dst`. */
+function blit(dst, src, dx, dy) {
+  for (let y = 0; y < src.height; y++) {
+    const ty = dy + y;
+    if (ty < 0 || ty >= dst.height) {
+      continue;
+    }
+    for (let x = 0; x < src.width; x++) {
+      const tx = dx + x;
+      if (tx < 0 || tx >= dst.width) {
+        continue;
+      }
+      const s = (src.width * y + x) << 2;
+      const d = (dst.width * ty + tx) << 2;
+      dst.data[d] = src.data[s];
+      dst.data[d + 1] = src.data[s + 1];
+      dst.data[d + 2] = src.data[s + 2];
+      dst.data[d + 3] = 255;
+    }
+  }
+}
+
+function fill(png, colour) {
+  for (let i = 0; i < png.data.length; i += 4) {
+    png.data[i] = colour.r;
+    png.data[i + 1] = colour.g;
+    png.data[i + 2] = colour.b;
+    png.data[i + 3] = 255;
+  }
+}
+
+/**
+ * A 5x7 bitmap font, enough for captions. Drawing text without a font library keeps this dependency-free;
+ * anything more elaborate belongs in the page's markdown, not burned into the image.
+ */
+const GLYPHS = {
+  A: ["01110", "10001", "10001", "11111", "10001", "10001", "10001"],
+  B: ["11110", "10001", "11110", "10001", "10001", "10001", "11110"],
+  C: ["01111", "10000", "10000", "10000", "10000", "10000", "01111"],
+  D: ["11110", "10001", "10001", "10001", "10001", "10001", "11110"],
+  E: ["11111", "10000", "11110", "10000", "10000", "10000", "11111"],
+  F: ["11111", "10000", "11110", "10000", "10000", "10000", "10000"],
+  G: ["01111", "10000", "10000", "10011", "10001", "10001", "01111"],
+  H: ["10001", "10001", "11111", "10001", "10001", "10001", "10001"],
+  I: ["11111", "00100", "00100", "00100", "00100", "00100", "11111"],
+  J: ["00111", "00010", "00010", "00010", "00010", "10010", "01100"],
+  K: ["10001", "10010", "10100", "11000", "10100", "10010", "10001"],
+  L: ["10000", "10000", "10000", "10000", "10000", "10000", "11111"],
+  M: ["10001", "11011", "10101", "10101", "10001", "10001", "10001"],
+  Q: ["01110", "10001", "10001", "10001", "10101", "10010", "01101"],
+  N: ["10001", "11001", "10101", "10011", "10001", "10001", "10001"],
+  O: ["01110", "10001", "10001", "10001", "10001", "10001", "01110"],
+  P: ["11110", "10001", "10001", "11110", "10000", "10000", "10000"],
+  R: ["11110", "10001", "10001", "11110", "10100", "10010", "10001"],
+  S: ["01111", "10000", "01110", "00001", "00001", "10001", "01110"],
+  T: ["11111", "00100", "00100", "00100", "00100", "00100", "00100"],
+  U: ["10001", "10001", "10001", "10001", "10001", "10001", "01110"],
+  V: ["10001", "10001", "10001", "10001", "10001", "01010", "00100"],
+  W: ["10001", "10001", "10001", "10101", "10101", "11011", "10001"],
+  X: ["10001", "01010", "00100", "00100", "00100", "01010", "10001"],
+  Y: ["10001", "01010", "00100", "00100", "00100", "00100", "00100"],
+  Z: ["11111", "00010", "00100", "01000", "10000", "10000", "11111"],
+  " ": ["00000", "00000", "00000", "00000", "00000", "00000", "00000"],
+  "-": ["00000", "00000", "00000", "11111", "00000", "00000", "00000"],
+  ".": ["00000", "00000", "00000", "00000", "00000", "00000", "00100"],
+  ":": ["00000", "00100", "00000", "00000", "00100", "00000", "00000"],
+  "1": ["00100", "01100", "00100", "00100", "00100", "00100", "01110"],
+  "2": ["01110", "10001", "00001", "00110", "01000", "10000", "11111"],
+};
+
+/**
+ * Refuse a caption this font cannot draw.
+ *
+ * Unknown characters used to render as blanks, so "Set a breakpoint" came out "SET A BREA POINT" — the
+ * image looked fine and said something else. A caption that cannot be drawn is a bug in the caller, not
+ * something to paper over.
+ */
+function assertDrawable(text, which) {
+  const missing = [...new Set([...(text ?? "").toUpperCase()])].filter((character) => !(character in GLYPHS));
+  if (missing.length > 0) {
+    console.error(`${which} caption uses characters this font has no glyph for: ${missing.join(" ")}`);
+    console.error("Add them to GLYPHS or reword the caption — silently dropping them would misspell the image.");
+    process.exit(1);
+  }
+}
+
+function drawText(png, text, x, y, scale = 2) {
+  let cursor = x;
+  for (const rawChar of text.toUpperCase()) {
+    const glyph = GLYPHS[rawChar] ?? GLYPHS[" "];
+    for (let gy = 0; gy < glyph.length; gy++) {
+      for (let gx = 0; gx < glyph[gy].length; gx++) {
+        if (glyph[gy][gx] !== "1") {
+          continue;
+        }
+        for (let sy = 0; sy < scale; sy++) {
+          for (let sx = 0; sx < scale; sx++) {
+            const px = cursor + gx * scale + sx;
+            const py = y + gy * scale + sy;
+            if (px < 0 || px >= png.width || py < 0 || py >= png.height) {
+              continue;
+            }
+            const o = (png.width * py + px) << 2;
+            png.data[o] = 230;
+            png.data[o + 1] = 230;
+            png.data[o + 2] = 235;
+            png.data[o + 3] = 255;
+          }
+        }
+      }
+    }
+    cursor += (5 + 1) * scale;
+  }
+}
+
+const [leftPath, rightPath, outPath, leftCaption, rightCaption] = process.argv.slice(2);
+if (!leftPath || !rightPath || !outPath) {
+  console.error('usage: node scripts/composeSideBySide.mjs <left.png> <right.png> <out.png> ["Left caption"] ["Right caption"]');
+  process.exit(2);
+}
+for (const file of [leftPath, rightPath]) {
+  if (!fs.existsSync(file)) {
+    console.error(`missing input: ${file} — run the suite that captures it first (nothing is composed from a stale frame)`);
+    process.exit(1);
+  }
+}
+
+const left = PNG.sync.read(fs.readFileSync(leftPath));
+const right = PNG.sync.read(fs.readFileSync(rightPath));
+const band = leftCaption || rightCaption ? BAND : 0;
+const height = Math.max(left.height, right.height) + band;
+const out = new PNG({ width: left.width + GAP + right.width, height });
+fill(out, BG);
+blit(out, left, 0, band);
+blit(out, right, left.width + GAP, band);
+if (band) {
+  assertDrawable(leftCaption, "left");
+  assertDrawable(rightCaption, "right");
+  drawText(out, (leftCaption ?? "").slice(0, 60), 8, 9);
+  drawText(out, (rightCaption ?? "").slice(0, 60), left.width + GAP + 8, 9);
+}
+fs.mkdirSync(path.dirname(outPath), { recursive: true });
+fs.writeFileSync(outPath, PNG.sync.write(out));
+console.log(`composed ${path.basename(outPath)} — ${out.width}x${out.height} (${path.basename(leftPath)} | ${path.basename(rightPath)})`);

--- a/scripts/redactScreenshots.mjs
+++ b/scripts/redactScreenshots.mjs
@@ -2,9 +2,19 @@
 //
 // Usage: node scripts/redactScreenshots.mjs <directory-of-pngs>
 //
-// The e2e screenshot frames (DVPT_E2E_SHOTS=1) show the sandbox org URL in the panel's connection
-// block, in the status bar, and in the query results header. Those frames go on the PUBLIC wiki and a
-// wiki push is one-way, so paint over those regions rather than relying on nobody reading them.
+// NOT USED BY DEFAULT ANY MORE — pass `--redact-identity` to paint anything.
+//
+// The e2e environment is a dedicated Dataverse PowerTools dev/demo org: it holds no real data, is wiped
+// periodically, and its owner has confirmed the URL is fine to publish. So the frames go on the wiki AS
+// CAPTURED, which is both more useful (a screenshot showing a real environment reads as real) and less
+// risky than painting rectangles over live UI — that is how a Locals pane got blanked in the one frame
+// meant to show it.
+//
+// Keep this script for the day the captures come from an org that does matter. Then:
+//   node scripts/redactScreenshots.mjs <dir> --redact-identity
+//
+// The e2e screenshot frames (DVPT_E2E_SHOTS=1) show the org URL in the panel's connection block, in the
+// status bar, and in the query results header. With the flag, those regions are painted over.
 //
 // Regions are measured against the 1718x872 window the e2e instance uses. If that size changes, the
 // script reports frames it could not fully cover instead of silently redacting the wrong pixels.
@@ -50,8 +60,16 @@ const FILL = { r: 37, g: 37, b: 38 }; // VS Code dark sidebar / status-bar backg
 
 const dir = process.argv[2];
 if (!dir || !fs.existsSync(dir)) {
-  console.error("usage: node scripts/redactScreenshots.mjs <directory-of-pngs>");
+  console.error("usage: node scripts/redactScreenshots.mjs <directory-of-pngs> [--redact-identity]");
   process.exit(2);
+}
+
+// Refuse to paint unless asked. The captures come from a disposable demo org whose URL is publishable,
+// and silently redacting cost real content once already.
+if (!process.argv.includes("--redact-identity")) {
+  console.log("redactScreenshots: nothing to do — the e2e org is a disposable demo environment and its URL is publishable.");
+  console.log("Pass --redact-identity to paint over the connection block, the status bar and the results header.");
+  process.exit(0);
 }
 
 let redacted = 0;

--- a/src/customapi/customApiCommands.ts
+++ b/src/customapi/customApiCommands.ts
@@ -11,7 +11,7 @@ import DataversePowerToolsContext from "../context";
 import { activeComponentRoot } from "../components/componentDiscovery";
 import { CUSTOM_API_FILE_SUFFIX, CustomApiDefinition, newCustomApiDefinition } from "./definition";
 import { validateCustomApiDefinition } from "./validate";
-import { generateCustomApiHandler, customApiHandlerFileName } from "./generateHandler";
+import { generateCustomApiWrappers, generateCustomApiUserHandler, looksLikeLegacyHandler, customApiHandlerFileName, customApiUserHandlerFileName } from "./generateHandler";
 import { generateTypedClient, customApiClientFileName } from "./generateTypedClient";
 import { findPrimaryPluginCsproj } from "../plugins/projectPaths";
 
@@ -118,11 +118,32 @@ export async function generateCustomApiHandlers(context: DataversePowerToolsCont
     }
 
     fs.mkdirSync(outDir, { recursive: true });
-    const outPath = path.join(outDir, customApiHandlerFileName(definition));
-    fs.writeFileSync(outPath, generateCustomApiHandler(definition), "utf8");
+    const wrappersPath = path.join(outDir, customApiHandlerFileName(definition));
+    const userPath = path.join(outDir, customApiUserHandlerFileName(definition));
+    const rel = (p: string): string => path.relative(root, p).replace(/\\/g, "/");
+
+    // A `*.generated.cs` from before the split still holds the IPlugin implementation, so rewriting it
+    // is exactly the data loss this split exists to prevent (#254). Refuse, and say what to do.
+    if (fs.existsSync(wrappersPath) && !fs.existsSync(userPath) && looksLikeLegacyHandler(fs.readFileSync(wrappersPath, "utf8"))) {
+      context.reportFailure(
+        `${name}: ${rel(wrappersPath)} still contains your Execute implementation (older layout). ` +
+          `Move the class into ${rel(userPath)}, then run this again — otherwise regenerating would overwrite your code.`,
+        { toast: `Custom API: ${path.basename(wrappersPath)} holds your implementation — move it to ${path.basename(userPath)} first. See the output.` },
+      );
+      failed++;
+      continue;
+    }
+
+    fs.writeFileSync(wrappersPath, generateCustomApiWrappers(definition), "utf8");
+    // The implementation is written ONCE. Regenerating after a definition change refreshes the typed
+    // wrappers and leaves your Execute body alone (#254).
+    const wroteUser = !fs.existsSync(userPath);
+    if (wroteUser) {
+      fs.writeFileSync(userPath, generateCustomApiUserHandler(definition), "utf8");
+    }
     // Say WHERE it landed relative to the component, so "which project is this compiled into?" is
-    // answerable from the log.
-    context.channel.appendLine(`✓ ${name} → ${path.relative(root, outPath).replace(/\\/g, "/")}`);
+    // answerable from the log — and whether your file was created or left as it was.
+    context.channel.appendLine(`✓ ${name} → ${rel(wrappersPath)}${wroteUser ? ` + ${rel(userPath)}` : ` (${path.basename(userPath)} left as you wrote it)`}`);
     generated++;
   }
 

--- a/src/customapi/generateHandler.spec.ts
+++ b/src/customapi/generateHandler.spec.ts
@@ -1,5 +1,13 @@
 import { describe, it, expect } from "vitest";
-import { generateCustomApiHandler, customApiParameterCSharpType, splitPluginTypeName, customApiHandlerFileName } from "./generateHandler";
+import {
+  generateCustomApiWrappers,
+  generateCustomApiUserHandler,
+  looksLikeLegacyHandler,
+  customApiParameterCSharpType,
+  splitPluginTypeName,
+  customApiHandlerFileName,
+  customApiUserHandlerFileName,
+} from "./generateHandler";
 import { newCustomApiDefinition, CustomApiDefinition } from "./definition";
 
 describe("customApiParameterCSharpType", () => {
@@ -34,16 +42,26 @@ describe("customApiHandlerFileName", () => {
   });
 });
 
-describe("generateCustomApiHandler", () => {
+describe("generateCustomApiWrappers", () => {
   const def = newCustomApiDefinition("sample_DoTheThing", "Sample.Plugins.DoTheThing");
-  const code = generateCustomApiHandler(def);
+  const code = generateCustomApiWrappers(def);
 
-  it("emits the namespace, request/response wrappers, and IPlugin class", () => {
+  it("emits the namespace and the request/response wrappers", () => {
     expect(code).toContain("namespace Sample.Plugins");
     expect(code).toContain("public sealed class DoTheThingRequest");
     expect(code).toContain("public sealed class DoTheThingResponse");
-    expect(code).toContain("public sealed class DoTheThing : IPlugin");
-    expect(code).toContain("public void Execute(IServiceProvider serviceProvider)");
+  });
+
+  // #254: the implementation lives in its own file now, so regenerating cannot take the user's Execute
+  // body with it. If it ever comes back into the generated file, this fails.
+  it("does NOT contain the IPlugin implementation", () => {
+    expect(code).not.toContain(": IPlugin");
+    expect(code).not.toContain("void Execute(IServiceProvider");
+  });
+
+  it("warns in the file itself that edits will be lost, and points at the user file", () => {
+    expect(code).toContain("GENERATED FILE");
+    expect(code).toContain("DoTheThing.cs");
   });
 
   it("generates a typed, guarded getter for a request parameter", () => {
@@ -67,15 +85,63 @@ describe("generateCustomApiHandler", () => {
         { uniqueName: "Count", name: "x.Count", type: "Integer" },
       ],
     };
-    const out = generateCustomApiHandler(typed);
+    const out = generateCustomApiWrappers(typed);
     expect(out).toContain("public EntityReference AccountId =>");
     expect(out).toContain("public int Count =>");
   });
 
   it("handles a definition with no parameters gracefully", () => {
     const empty: CustomApiDefinition = { ...def, requestParameters: [], responseProperties: [] };
-    const out = generateCustomApiHandler(empty);
+    const out = generateCustomApiWrappers(empty);
     expect(out).toContain("// (no request parameters defined)");
     expect(out).toContain("// (no response properties defined)");
+  });
+});
+
+// The other half of the #254 split: the file the user owns.
+describe("generateCustomApiUserHandler", () => {
+  const def = newCustomApiDefinition("sample_DoTheThing", "Sample.Plugins.DoTheThing");
+  const code = generateCustomApiUserHandler(def);
+
+  it("is the IPlugin implementation, wired to the generated wrappers", () => {
+    expect(code).toContain("public sealed class DoTheThing : IPlugin");
+    expect(code).toContain("public void Execute(IServiceProvider serviceProvider)");
+    expect(code).toContain("new DoTheThingRequest(context)");
+    expect(code).toContain("new DoTheThingResponse(context)");
+  });
+
+  it("says it will not be overwritten, so the reader knows where their code is safe", () => {
+    expect(code).toContain("YOUR FILE");
+    expect(code).toContain("never overwritten");
+  });
+
+  it("leaves a TODO naming the operation", () => {
+    expect(code).toContain('// TODO: implement the "sample_DoTheThing" operation.');
+  });
+
+  it("does not duplicate the wrapper classes", () => {
+    expect(code).not.toContain("public sealed class DoTheThingRequest");
+    expect(code).not.toContain("public sealed class DoTheThingResponse");
+  });
+});
+
+describe("customApiUserHandlerFileName", () => {
+  it("is the class name, with no .generated marker", () => {
+    expect(customApiUserHandlerFileName(newCustomApiDefinition("x", "A.B.MyHandler"))).toBe("MyHandler.cs");
+  });
+});
+
+describe("looksLikeLegacyHandler", () => {
+  // Refusing to overwrite a pre-split file is what stops #254 from biting the people it already bit.
+  it("recognises a pre-split generated file by its IPlugin implementation", () => {
+    const legacy = generateCustomApiUserHandler(newCustomApiDefinition("x", "A.B.C"));
+    expect(looksLikeLegacyHandler(legacy)).toBe(true);
+    expect(looksLikeLegacyHandler("public sealed class C : IPlugin { }")).toBe(true);
+    expect(looksLikeLegacyHandler("public void Execute(IServiceProvider serviceProvider)")).toBe(true);
+  });
+
+  it("does not flag a wrappers-only file", () => {
+    expect(looksLikeLegacyHandler(generateCustomApiWrappers(newCustomApiDefinition("x", "A.B.C")))).toBe(false);
+    expect(looksLikeLegacyHandler("")).toBe(false);
   });
 });

--- a/src/customapi/generateHandler.ts
+++ b/src/customapi/generateHandler.ts
@@ -6,7 +6,7 @@
 // and a definition change surfaces as a compiler error. No `vscode` import →
 // unit-testable.
 
-import { CustomApiDefinition, CustomApiParameterType, CustomApiRequestParameter, CustomApiResponseProperty } from "./definition";
+import { CUSTOM_API_FILE_SUFFIX, CustomApiDefinition, CustomApiParameterType, CustomApiRequestParameter, CustomApiResponseProperty } from "./definition";
 
 /** Map a Custom API parameter type to the C# type the SDK surfaces it as.
  * Keys are the platform's PascalCase type vocabulary, not identifiers. */
@@ -72,11 +72,14 @@ function escapeXml(value: string): string {
 }
 
 /**
- * Generate the full C# handler file (request wrapper + response wrapper + IPlugin
- * class) for a Custom API definition. The class name / namespace come from the
- * definition's pluginTypeName.
+ * The GENERATED half: the typed request and response wrappers. Rewritten every time, because it is a
+ * projection of the definition and must follow it.
+ *
+ * The `IPlugin` implementation is deliberately NOT here — it used to be, in the same file, so
+ * regenerating after a definition change destroyed whatever the user had written in `Execute` (#254).
+ * It now lives in its own file, written once (`generateCustomApiUserHandler`).
  */
-export function generateCustomApiHandler(def: CustomApiDefinition): string {
+export function generateCustomApiWrappers(def: CustomApiDefinition): string {
   const { namespaceName, className } = splitPluginTypeName(def.pluginTypeName);
   const requestClass = `${className}Request`;
   const responseClass = `${className}Response`;
@@ -87,11 +90,14 @@ export function generateCustomApiHandler(def: CustomApiDefinition): string {
   return `using System;
 using Microsoft.Xrm.Sdk;
 
+// GENERATED FILE — regenerated from ${def.uniqueName}${CUSTOM_API_FILE_SUFFIX} whenever the definition
+// changes. Do not edit: your changes here WILL be overwritten. Your implementation belongs in
+// ${className}.cs, which is written once and never regenerated.
+
 namespace ${namespaceName}
 {
     /// <summary>
-    /// Typed request wrapper for the "${def.uniqueName}" Custom API — reads
-    /// InputParameters as typed values. Generated from ${def.uniqueName}${".customapi.json"}; regenerate on change.
+    /// Typed request wrapper for the "${def.uniqueName}" Custom API — reads InputParameters as typed values.
     /// </summary>
     public sealed class ${requestClass}
     {
@@ -111,7 +117,24 @@ ${requestMembers || "        // (no request parameters defined)"}
 
 ${responseMembers || "        // (no response properties defined)"}
     }
+}
+`;
+}
 
+/**
+ * The USER half: the `IPlugin` implementation, written ONCE and never regenerated, so a definition
+ * change cannot take your code with it (#254).
+ */
+export function generateCustomApiUserHandler(def: CustomApiDefinition): string {
+  const { namespaceName, className } = splitPluginTypeName(def.pluginTypeName);
+  return `using System;
+using Microsoft.Xrm.Sdk;
+
+// YOUR FILE — written once when the handler was first generated, and never overwritten. Regenerating
+// refreshes ${className}.generated.cs (the typed wrappers) and leaves this alone.
+
+namespace ${namespaceName}
+{
     /// <summary>
     /// Implements the "${def.uniqueName}" Custom API message.
     /// Registered as plugin type ${def.pluginTypeName}.
@@ -121,8 +144,8 @@ ${responseMembers || "        // (no response properties defined)"}
         public void Execute(IServiceProvider serviceProvider)
         {
             var context = (IPluginExecutionContext)serviceProvider.GetService(typeof(IPluginExecutionContext));
-            var request = new ${requestClass}(context);
-            var response = new ${responseClass}(context);
+            var request = new ${className}Request(context);
+            var response = new ${className}Response(context);
 
             // TODO: implement the "${def.uniqueName}" operation.
             // Read typed inputs from 'request', set typed outputs on 'response'.
@@ -132,8 +155,22 @@ ${responseMembers || "        // (no response properties defined)"}
 `;
 }
 
+/**
+ * True when a `*.generated.cs` predates the #254 split — i.e. it still carries the `IPlugin`
+ * implementation, so overwriting it could destroy the user's code.
+ */
+export function looksLikeLegacyHandler(existingSource: string): boolean {
+  return /:\s*IPlugin\b/.test(existingSource) || /\bvoid\s+Execute\s*\(\s*IServiceProvider/.test(existingSource);
+}
+
 /** Output file name for a definition's generated handler. */
 export function customApiHandlerFileName(def: CustomApiDefinition): string {
   const { className } = splitPluginTypeName(def.pluginTypeName);
   return `${className}.generated.cs`;
+}
+
+/** File name for the USER's implementation — written once, never regenerated (#254). */
+export function customApiUserHandlerFileName(def: CustomApiDefinition): string {
+  const { className } = splitPluginTypeName(def.pluginTypeName);
+  return `${className}.cs`;
 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -4,6 +4,7 @@ import path = require("path");
 import fs = require("fs");
 import DataversePowerToolsContext from "./context";
 import { getProjectTypeActivation, registerAllComponentCommands } from "./projectTypes/activation";
+import { registerTraceLogDocumentProvider } from "./plugins/traceLogs";
 import { componentScopedContext } from "./components/componentDiscovery";
 import { componentsToInitialise } from "./components/discovery";
 import { clearStoredCredentials } from "./general/connectionStringManager";
@@ -35,6 +36,9 @@ export async function activate(vscodeContext: vscode.ExtensionContext) {
   // Every project type's commands register ONCE here; handlers resolve which
   // component an invocation targets (#47) — no per-type registration anymore.
   registerAllComponentCommands(context);
+  // Read-only documents for generated trace logs. ONCE, globally: a scheme can only be registered once,
+  // so a per-component initialise* would throw on the second component.
+  registerTraceLogDocumentProvider(context.vscode);
   // Workspace-level / connection commands (restore deps, connection string, switch env, open
   // portals, add component, …) also register ONCE here — NOT per workspace load inside
   // generalInitialise (which re-runs on every load and from createNewProject, and would throw

--- a/src/pcf/deployPcf.ts
+++ b/src/pcf/deployPcf.ts
@@ -4,6 +4,9 @@ import * as path from "path";
 import DataversePowerToolsContext from "../context";
 import { runPac } from "../general/modelbuilder/commandRunner";
 import { activeComponentRoot } from "../components/componentDiscovery";
+import { dataverseApiUrl, logDataverseError, logDataverseHttpError } from "../general/dataverse/webApi";
+import { addDataverseSolutionComponent } from "../general/dataverse/addDataverseSolutionComponent";
+import { CONTROL_MANIFEST_FILENAME, findControlDir } from "./controlManifest";
 
 const SOLUTION_DOCS_URL = "https://learn.microsoft.com/power-apps/developer/component-framework/import-custom-controls";
 
@@ -52,6 +55,98 @@ function findSolutionProjectDir(): string | undefined {
 // via `pac solution add-reference --path <pcfComponentRoot>` (a local, auth-free op).
 // Deeper solution integration is a fast-follow — `pac pcf push` remains the one-click
 // inner loop.
+/** Solution component type for a PCF control (`customcontrol`). Web resources are 61, plug-in steps 92. */
+export const CUSTOM_CONTROL_COMPONENT_TYPE = 66;
+
+/**
+ * OData resource that finds a pushed control from its manifest name.
+ *
+ * Dataverse stores the control PREFIXED with the publisher's customization prefix — a manifest of
+ * `namespace="SampleNamespace" constructor="SampleControl"` lands as
+ * `dvpt_SampleNamespace.SampleControl`. So `name eq '<namespace>.<constructor>'` never matches. Query on
+ * the suffix and let `matchesControlName` pick the row, which keeps this working whatever prefix the
+ * solution's publisher uses.
+ */
+export function customControlResource(controlName: string): string {
+  return `customcontrols?$select=customcontrolid,name&$filter=endswith(name,'${controlName.replace(/'/g, "''")}')`;
+}
+
+/** True when a stored `customcontrol.name` is this manifest's control, with or without a prefix. */
+export function matchesControlName(storedName: string, controlName: string): boolean {
+  return storedName === controlName || storedName.endsWith(`_${controlName}`);
+}
+
+/** The `customcontrol` row id for a pushed control, or undefined when it is not in the environment. */
+async function findCustomControlId(context: DataversePowerToolsContext, controlName: string): Promise<string | undefined> {
+  // Initialise the connection if it is not live yet — the same readiness check the solution helper does.
+  if (!context.dataverse?.isValid && !(await context.dataverse?.initialize())) {
+    return undefined;
+  }
+  if (!context.dataverse.organizationUrl) {
+    return undefined;
+  }
+  try {
+    const response = await fetch(dataverseApiUrl(context.dataverse.organizationUrl, customControlResource(controlName)), {
+      method: "GET",
+      /* eslint-disable-next-line @typescript-eslint/naming-convention */
+      headers: { Authorization: "Bearer " + (await context.dataverse.getAuthorizationToken()), "Content-Type": "application/json" },
+    });
+    if (!response.ok) {
+      await logDataverseHttpError(context.channel, `find PCF control '${controlName}'`, response);
+      return undefined;
+    }
+    const data: any = await response.json();
+    const row = (data?.value ?? []).find((candidate: any) => matchesControlName(String(candidate?.name ?? ""), controlName));
+    return row?.customcontrolid;
+  } catch (error) {
+    logDataverseError(context.channel, `find PCF control '${controlName}'`, error);
+    return undefined;
+  }
+}
+
+/** `<namespace>.<constructor>` from a ControlManifest — the name the `customcontrol` row carries. */
+export function controlNameFromManifest(manifestXml: string): string | undefined {
+  const namespaceName = /namespace="([^"]+)"/.exec(manifestXml ?? "")?.[1];
+  const constructorName = /constructor="([^"]+)"/.exec(manifestXml ?? "")?.[1];
+  return namespaceName && constructorName ? `${namespaceName}.${constructorName}` : undefined;
+}
+
+/**
+ * Put the PUSHED control into the solution configured for this component, the same way a web resource
+ * or a plug-in step is added: resolve the row, then AddSolutionComponent. Returns false (quietly, with
+ * a reason in the log) when there is nothing to add yet.
+ */
+async function addControlToConfiguredSolution(context: DataversePowerToolsContext, componentRoot: string): Promise<boolean> {
+  const solutionUniqueName = context.projectSettings.solutionName;
+  if (!solutionUniqueName) {
+    context.channel.appendLine("No solution is configured for this component — set one in the connection settings.");
+    return false;
+  }
+
+  const controlDir = findControlDir(componentRoot);
+  const manifestPath = controlDir ? path.join(controlDir, CONTROL_MANIFEST_FILENAME) : undefined;
+  const controlName = manifestPath ? controlNameFromManifest(fs.readFileSync(manifestPath, "utf8")) : undefined;
+  if (!controlName) {
+    context.channel.appendLine("Could not read the control's namespace/constructor from ControlManifest.Input.xml.");
+    return false;
+  }
+
+  const controlId = await findCustomControlId(context, controlName);
+  if (!controlId) {
+    context.channel.appendLine(`'${controlName}' is not in the environment yet, so there is nothing to add to '${solutionUniqueName}'.`);
+    return false;
+  }
+
+  const associated = await addDataverseSolutionComponent(context, solutionUniqueName, CUSTOM_CONTROL_COMPONENT_TYPE, controlId);
+  if (associated) {
+    context.channel.appendLine(`Added PCF control '${controlName}' to solution '${solutionUniqueName}'.`);
+    vscode.window.showInformationMessage(`Added '${controlName}' to solution '${solutionUniqueName}'.`);
+  } else {
+    context.reportFailure(`Could not add '${controlName}' to solution '${solutionUniqueName}'.`);
+  }
+  return associated;
+}
+
 export async function deployPcf(context: DataversePowerToolsContext): Promise<void> {
   const componentRoot = activeComponentRoot(context);
   if (!componentRoot) {
@@ -59,17 +154,18 @@ export async function deployPcf(context: DataversePowerToolsContext): Promise<vo
     return;
   }
 
+  // Add the control to the solution you already chose, exactly like a web resource or a plug-in step:
+  // resolve the pushed customcontrol row and POST AddSolutionComponent. Requiring a whole Solution
+  // PROJECT for this was PCF-only and surprising — no other component type asks for one (#256).
+  const added = await addControlToConfiguredSolution(context, componentRoot);
+
   const solutionDir = findSolutionProjectDir();
   if (!solutionDir) {
-    context.channel.appendLine(
-      "A PCF control ships inside a solution. Add a Solution component to this workspace (Add Component → Solution), then run this again to reference the control — or use Push to deploy it directly to the environment for development.",
-    );
-    const choice = await vscode.window.showInformationMessage(
-      "A PCF control ships inside a solution. Add a Solution component (or use Push for a quick dev deploy), then add the control as a reference.",
-      "Learn more",
-    );
-    if (choice === "Learn more") {
-      void vscode.env.openExternal(vscode.Uri.parse(SOLUTION_DOCS_URL));
+    if (!added) {
+      // Nothing to add, and no project to reference: the missing step is almost always the push, so say
+      // that rather than sending people off to create a Solution component.
+      context.channel.appendLine("Push the control first — Add to Solution puts the control that is IN the environment into your solution.");
+      vscode.window.showWarningMessage("Push the PCF control first, then Add to Solution.");
     }
     return;
   }

--- a/src/pcf/deployPcfSolution.spec.ts
+++ b/src/pcf/deployPcfSolution.spec.ts
@@ -1,0 +1,61 @@
+import { describe, it, expect } from "vitest";
+import { CUSTOM_CONTROL_COMPONENT_TYPE, controlNameFromManifest, customControlResource, matchesControlName } from "./deployPcf";
+
+// #256: "Add to Solution" used to demand a Solution PROJECT (.cdsproj) in the workspace — PCF was the
+// only component type that did. A web resource (component type 61) and a plug-in step (92) are added to
+// the solution named in the connection settings over the Web API, with no project anywhere. These pin
+// the pieces that make PCF behave the same way.
+
+describe("CUSTOM_CONTROL_COMPONENT_TYPE", () => {
+  it("is 66 — the solution component type for a customcontrol", () => {
+    expect(CUSTOM_CONTROL_COMPONENT_TYPE).toBe(66);
+  });
+});
+
+describe("controlNameFromManifest", () => {
+  const manifest = `<?xml version="1.0" encoding="utf-8"?>
+<manifest>
+  <control namespace="SampleNamespace" constructor="SampleControl" version="0.0.1" display-name-key="SampleControl">
+  </control>
+</manifest>`;
+
+  it("builds the <namespace>.<constructor> name the customcontrol row carries", () => {
+    expect(controlNameFromManifest(manifest)).toBe("SampleNamespace.SampleControl");
+  });
+
+  it("returns undefined when either half is missing, so we never query for a half-formed name", () => {
+    expect(controlNameFromManifest(`<control namespace="OnlyNs" />`)).toBeUndefined();
+    expect(controlNameFromManifest(`<control constructor="OnlyCtor" />`)).toBeUndefined();
+    expect(controlNameFromManifest("")).toBeUndefined();
+  });
+});
+
+// Dataverse stores the control PREFIXED with the publisher's customization prefix — a manifest of
+// namespace="SampleNamespace" constructor="SampleControl" lands as "dvpt_SampleNamespace.SampleControl".
+// An equality filter on the manifest name therefore never matches, which made a SUCCESSFUL push look
+// like "not in the environment yet".
+describe("customControlResource", () => {
+  it("matches on the SUFFIX, because the stored name carries a publisher prefix", () => {
+    expect(customControlResource("Ns.Ctl")).toContain("endswith(name,'Ns.Ctl')");
+    expect(customControlResource("Ns.Ctl")).toContain("$select=customcontrolid,name");
+  });
+
+  it("escapes a quote in the name rather than building broken OData", () => {
+    expect(customControlResource("N's.Ctl")).toContain("endswith(name,'N''s.Ctl')");
+  });
+});
+
+describe("matchesControlName", () => {
+  it("accepts the prefixed name Dataverse actually stores", () => {
+    expect(matchesControlName("dvpt_SampleNamespace.SampleControl", "SampleNamespace.SampleControl")).toBe(true);
+  });
+
+  it("accepts an unprefixed name too", () => {
+    expect(matchesControlName("SampleNamespace.SampleControl", "SampleNamespace.SampleControl")).toBe(true);
+  });
+
+  it("rejects a different control that merely ends similarly", () => {
+    expect(matchesControlName("dvpt_OtherNamespace.SampleControl", "SampleNamespace.SampleControl")).toBe(false);
+    expect(matchesControlName("XSampleNamespace.SampleControl", "SampleNamespace.SampleControl")).toBe(false);
+  });
+});

--- a/src/plugins/traceLogs.ts
+++ b/src/plugins/traceLogs.ts
@@ -60,6 +60,39 @@ export async function viewPluginTraceLogs(context: DataversePowerToolsContext): 
   if (!pick) {
     return;
   }
-  const document = await vscode.workspace.openTextDocument({ language: "markdown", content: formatTraceLog(pick.target) });
+  // Open it READ-ONLY through a virtual document, not as an untitled one. An untitled document counts
+  // as unsaved, so closing a trace log you have only read prompted "do you want to save?" every time —
+  // for something the extension generated and nobody edits.
+  const uri = traceLogUri(pick.target);
+  traceLogContents.set(uri.toString(), formatTraceLog(pick.target));
+  traceLogChanged.fire(uri);
+  const document = await vscode.workspace.openTextDocument(uri);
+  await vscode.languages.setTextDocumentLanguage(document, "markdown");
   await vscode.window.showTextDocument(document, { preview: true });
+}
+
+/** Scheme for generated trace-log documents. Read-only: VS Code never offers to save these. */
+export const TRACE_LOG_SCHEME = "dvpt-tracelog";
+
+const traceLogContents = new Map<string, string>();
+const traceLogChanged = new vscode.EventEmitter<vscode.Uri>();
+
+/** A stable, readable URI per log — the title bar shows the type and time rather than "Untitled-1". */
+function traceLogUri(log: PluginTraceLogRecord): vscode.Uri {
+  const type = (log.typename ?? "plugin").split(",")[0].split(".").pop() ?? "plugin";
+  const when = (log.createdon ?? "").replace(/[:.]/g, "-");
+  return vscode.Uri.parse(`${TRACE_LOG_SCHEME}:${type} ${when}.md`);
+}
+
+/**
+ * Serve generated trace-log documents. Registered ONCE at activation (never in a per-component
+ * `initialise*` — a second component would throw on the duplicate scheme).
+ */
+export function registerTraceLogDocumentProvider(context: vscode.ExtensionContext): void {
+  context.subscriptions.push(
+    vscode.workspace.registerTextDocumentContentProvider(TRACE_LOG_SCHEME, {
+      onDidChange: traceLogChanged.event,
+      provideTextDocumentContent: (uri) => traceLogContents.get(uri.toString()) ?? "",
+    }),
+  );
 }

--- a/src/ui-test/e2e/browserLib.ts
+++ b/src/ui-test/e2e/browserLib.ts
@@ -459,6 +459,129 @@ export async function autoLoginWithRetry(port: number, orgUrl: string, opts: Aut
  * re-navigating it doesn't recover — a brand-new browser does. Returns the signed-in browser (the
  * caller owns closing it) plus whether it reached the org.
  */
+/** The device code from pac's own prompt, or undefined if it hasn't printed one yet. */
+export function parseDeviceCode(output: string): string | undefined {
+  // ">>> To finish signing in to pac, open https://login.microsoft.com/device and enter the code C4BTB5ESK"
+  return /enter the code\s+([A-Z0-9]{6,})/i.exec(output ?? "")?.[1];
+}
+
+/**
+ * Complete pac's DEVICE CODE sign-in in a browser.
+ *
+ * Under interactive auth there is no client secret, so `pac auth create` can only use the device-code
+ * flow: it prints a code and blocks until a human enters it. That is correct behaviour, and it is why
+ * PCF — the one component type whose Dataverse path goes through `pac` — could not be covered
+ * unattended (#227). With an MFA-exempt account in a dedicated dev tenant, the flow is drivable: type
+ * the code, sign in, confirm.
+ */
+export async function completeDeviceCodeLogin(
+  exePath: string,
+  profileDir: string,
+  code: string,
+  opts: { username: string; password: string; deviceUrl?: string; log?: (message: string) => void },
+): Promise<boolean> {
+  const log = opts.log ?? ((): void => undefined);
+  const url = opts.deviceUrl ?? "https://login.microsoft.com/device";
+  log(`[device-code] opening ${url} to enter ${code}`);
+  const browser = await launchBrowser(exePath, profileDir, url, 45000);
+  let client: CDP.Client | undefined;
+  try {
+    client = await CDP({ port: browser.port });
+    await sleep(4000);
+    // The code box is #otc on the device-login page. Set it through the value setter so the page's
+    // framework sees the change (a raw .value assignment leaves its model empty and Next stays disabled).
+    const entered = await (async (): Promise<boolean> => {
+      const deadline = Date.now() + 90000;
+      for (;;) {
+        const ok = await evalOn(
+          client!,
+          `(() => { const el = document.querySelector('#otc') || document.querySelector('input[name=otc]');
+             if (!el) { return false; }
+             const set = Object.getOwnPropertyDescriptor(window.HTMLInputElement.prototype, 'value').set;
+             set.call(el, ${JSON.stringify(code)});
+             el.dispatchEvent(new Event('input', { bubbles: true }));
+             el.dispatchEvent(new Event('change', { bubbles: true }));
+             const next = document.querySelector('#idSIButton9') || document.querySelector('input[type=submit]');
+             if (next) { next.click(); }
+             return true; })()`,
+        );
+        if (ok === true || Date.now() > deadline) {
+          return ok === true;
+        }
+        await sleep(2000);
+      }
+    })();
+    if (!entered) {
+      log("[device-code] the code box never appeared");
+      browser.kill();
+      return false;
+    }
+    await sleep(5000);
+    // The ordinary managed-AAD sequence, driven here rather than through autoLoginBrowser: that one
+    // waits to land on the ORG host, which a device-code sign-in never does — it ends on a "you have
+    // signed in to Power Platform CLI" page.
+    const fill = async (selector: string, value: string): Promise<boolean> =>
+      (await evalOn(
+        client!,
+        `(() => { const el = document.querySelector(${JSON.stringify(selector)});
+           if (!el || el.offsetParent === null) { return false; }
+           const set = Object.getOwnPropertyDescriptor(window.HTMLInputElement.prototype, 'value').set;
+           set.call(el, ${JSON.stringify(value)});
+           el.dispatchEvent(new Event('input', { bubbles: true }));
+           const b = document.querySelector('#idSIButton9') || document.querySelector('input[type=submit]');
+           if (b) { b.click(); }
+           return true; })()`,
+      )) === true;
+
+    for (const [selector, value, what] of [
+      ["input[name=loginfmt]", opts.username, "username"],
+      ["input[name=passwd]", opts.password, "password"],
+    ] as const) {
+      const deadline = Date.now() + 90000;
+      let done = false;
+      while (!done && Date.now() < deadline) {
+        done = await fill(selector, value);
+        if (!done) {
+          await sleep(2000);
+        }
+      }
+      log(`[device-code] ${what}: ${done ? "entered" : "field never appeared"}`);
+    }
+
+    // "Stay signed in?" and the final "you're signing in to Power Platform CLI — Continue".
+    for (let attempt = 0; attempt < 8; attempt++) {
+      await evalOn(
+        client,
+        `(() => { const b = document.querySelector('#idSIButton9') || document.querySelector('input[type=submit]');
+           if (b && !b.disabled) { b.click(); return true; } return false; })()`,
+      );
+      await sleep(2500);
+    }
+
+    const pageText = String((await evalOn(client, "document.body ? document.body.innerText : ''")) ?? "");
+    const signedIn = /signed in|you may now close|Power Platform/i.test(pageText);
+    log(`[device-code] ${signedIn ? "confirmed" : `did not confirm — page said: ${pageText.slice(0, 160)}`}`);
+    // Give pac a moment to notice the completed authorisation before the browser goes away.
+    await sleep(8000);
+    browser.kill();
+    return signedIn;
+  } catch (error) {
+    log(`[device-code] failed: ${String(error).slice(0, 160)}`);
+    try {
+      browser.kill();
+    } catch {
+      /* ignore */
+    }
+    return false;
+  } finally {
+    try {
+      await client?.close();
+    } catch {
+      /* ignore */
+    }
+  }
+}
+
 export async function signInFreshBrowser(
   exePath: string,
   profileDir: string,

--- a/src/ui-test/e2e/browserLib.ts
+++ b/src/ui-test/e2e/browserLib.ts
@@ -1,6 +1,7 @@
 /* eslint-disable @typescript-eslint/naming-convention */
 import * as cp from "child_process";
 import * as fs from "fs";
+import * as path from "path";
 import * as net from "net";
 import * as http from "http";
 import CDP = require("chrome-remote-interface");
@@ -236,6 +237,34 @@ interface PageState {
 async function evalOn(client: CDP.Client, expression: string, awaitPromise = false): Promise<unknown> {
   const { result } = await client.Runtime.evaluate({ expression, awaitPromise, returnByValue: true });
   return result.value;
+}
+
+/**
+ * Screenshot the BROWSER (the model-driven app), not the editor — the other half of the hot-reload story
+ * and the only way to show a live form in the docs (#231). Written next to the VS Code frames so a page
+ * can put the two side by side. Opt-in with DVPT_E2E_SHOTS, like every other capture.
+ */
+export async function captureBrowserShot(port: number, name: string): Promise<void> {
+  if (process.env.DVPT_E2E_SHOTS !== "1") {
+    return;
+  }
+  let client: CDP.Client | undefined;
+  try {
+    client = await CDP({ port });
+    const { data } = await client.Page.captureScreenshot({ format: "png" });
+    const dir = path.join(path.resolve(__dirname, "..", "..", ".."), "sandbox", "screenshots-out", "profiling");
+    fs.mkdirSync(dir, { recursive: true });
+    fs.writeFileSync(path.join(dir, `${name}.png`), data, "base64");
+    console.log(`    [shot] ${name}.png (browser)`);
+  } catch (error) {
+    console.log(`    [shot] ${name} (browser) failed: ${String(error).slice(0, 120)}`);
+  } finally {
+    try {
+      await client?.close();
+    } catch {
+      /* ignore */
+    }
+  }
 }
 
 async function probe(client: CDP.Client): Promise<PageState> {

--- a/src/ui-test/e2e/browserLib.ts
+++ b/src/ui-test/e2e/browserLib.ts
@@ -244,13 +244,19 @@ async function evalOn(client: CDP.Client, expression: string, awaitPromise = fal
  * and the only way to show a live form in the docs (#231). Written next to the VS Code frames so a page
  * can put the two side by side. Opt-in with DVPT_E2E_SHOTS, like every other capture.
  */
-export async function captureBrowserShot(port: number, name: string): Promise<void> {
+export async function captureBrowserShot(port: number, name: string, half?: { width: number; height: number }): Promise<void> {
   if (process.env.DVPT_E2E_SHOTS !== "1") {
     return;
   }
   let client: CDP.Client | undefined;
   try {
     client = await CDP({ port });
+    // For a frame that will be stitched beside the editor, render at HALF the screen so the composed
+    // image is one screen wide rather than two full ones squeezed together.
+    if (half) {
+      await client.Emulation.setDeviceMetricsOverride({ width: half.width, height: half.height, deviceScaleFactor: 1, mobile: false });
+      await sleep(1500);
+    }
     const { data } = await client.Page.captureScreenshot({ format: "png" });
     const dir = path.join(path.resolve(__dirname, "..", "..", ".."), "sandbox", "screenshots-out", "profiling");
     fs.mkdirSync(dir, { recursive: true });
@@ -259,6 +265,15 @@ export async function captureBrowserShot(port: number, name: string): Promise<vo
   } catch (error) {
     console.log(`    [shot] ${name} (browser) failed: ${String(error).slice(0, 120)}`);
   } finally {
+    try {
+      // Always drop the emulation override: leaving the page at half width would change what every
+      // later assertion in the suite sees.
+      if (half && client) {
+        await client.Emulation.clearDeviceMetricsOverride();
+      }
+    } catch {
+      /* ignore */
+    }
     try {
       await client?.close();
     } catch {

--- a/src/ui-test/e2e/customApiLifecycle.e2e.ts
+++ b/src/ui-test/e2e/customApiLifecycle.e2e.ts
@@ -27,6 +27,12 @@ import { initProject, step, showLog } from "./acceptanceLib";
 // The generated handler is a stub with a TODO, so the test writes one line of real implementation into
 // it (echo the input) before deploying: without that the call would return 200 and nothing, which would
 // prove the plumbing while proving nothing about the data.
+//
+// It then EDITS the definition and deploys a SECOND time, because create was the only arm the first
+// version of this suite covered. Update and delete had never run outside a mock, and "the environment
+// ends up matching the file" is the actual promise — a parameter you removed has to disappear from
+// Dataverse, not linger. The same edit proves #254: regenerating refreshes the wrappers and leaves the
+// implementation you wrote alone.
 const COMPONENT = "Custom API";
 
 /**
@@ -63,6 +69,8 @@ describe("ACCEPTANCE: Custom API — define, deploy and execute via panel button
   const className = `Echo${Date.now().toString().slice(-6)}`;
   let pluginTypeName = "";
   let handlerPath = "";
+  /** Captured on the first deploy so the re-deploy can prove the API row was UPDATED, not recreated. */
+  let customApiIdFirstDeploy: string | undefined;
   const isWindows = process.platform === "win32";
 
   function pkgUnique(): string {
@@ -139,18 +147,17 @@ describe("ACCEPTANCE: Custom API — define, deploy and execute via panel button
       await clickOverflowItem("Generate Custom API handlers", { timeoutMs: 45000 });
       // The log names the DEFINITION FILE, not the unique name: "✓ dvpt_X.customapi.json → …".
       await expectOutput([`✓ ${apiUniqueName}.customapi.json → `, `${className}.generated.cs`], { step: "generate handler", timeoutMs: 120000 });
-      // The handler has to end up somewhere the plug-in project COMPILES, or the type it declares never
-      // reaches the assembly and the Custom API deploy has nothing to point at. Accept either location
-      // for now and record which one, so the run shows the whole consequence chain rather than stopping
-      // at the first symptom.
-      const atComponentRoot = path.join(workspace, "CustomApi", `${className}.generated.cs`);
-      const inPluginProject = path.join(workspace, projectName, "CustomApi", `${className}.generated.cs`);
-      const found = (await waitForFile(inPluginProject, 30000)) ? inPluginProject : (await waitForFile(atComponentRoot, 30000)) ? atComponentRoot : undefined;
-      expect(found, `${className}.generated.cs written somewhere`).to.not.equal(undefined);
-      handlerPath = found!;
-      const buildable = handlerPath.startsWith(path.join(workspace, projectName) + path.sep);
-      console.log(`    [e2e] handler written to ${path.relative(workspace, handlerPath)} — ${buildable ? "inside" : "OUTSIDE"} the plug-in project`);
-      expect(buildable, `the generated handler is inside ${projectName}/ so dotnet build compiles it`).to.equal(true);
+      // The handler has to be somewhere the plug-in project COMPILES, or the type it declares never
+      // reaches the assembly and the Custom API deploy has nothing to point at (#225).
+      const outDir = path.join(workspace, projectName, "CustomApi");
+      const wrappersPath = path.join(outDir, `${className}.generated.cs`);
+      expect(await waitForFile(wrappersPath, 30000), `${projectName}/CustomApi/${className}.generated.cs`).to.equal(true);
+      // Two files, not one: the wrappers are regenerated, the implementation is the user's (#254).
+      handlerPath = path.join(outDir, `${className}.cs`);
+      expect(await waitForFile(handlerPath, 30000), `${projectName}/CustomApi/${className}.cs (the file you own)`).to.equal(true);
+      const wrappers = fs.readFileSync(wrappersPath, "utf8");
+      expect(wrappers, "the wrappers file has no implementation to lose").to.not.contain(": IPlugin");
+      expect(fs.readFileSync(handlerPath, "utf8"), "the implementation is in the file you own").to.contain(": IPlugin");
 
       await clearOutput();
       await closeAnyOpenMenu();
@@ -167,22 +174,58 @@ describe("ACCEPTANCE: Custom API — define, deploy and execute via panel button
       expect(clientSource, "the client calls the API by its unique name").to.contain(apiUniqueName);
       expect(clientSource, "the client types the request parameter").to.contain("InputValue");
       expect(clientSource, "the client types the response property").to.contain("OutputValue");
-      return `generated CustomApi/${className}.generated.cs and clients/${apiUniqueName}.ts`;
+      return `generated CustomApi/${className}.generated.cs + ${className}.cs and clients/${className}.client.ts`;
     });
   });
 
-  it("implements the handler, then deploys the package — Build & deploy package", async () => {
-    await step(COMPONENT, "Implement + deploy the plug-in package", async () => {
-      // Replace the generated TODO with the one line a user would write. Done here rather than in the
-      // template so regenerating never silently overwrites real logic.
-      const handler = handlerPath;
-      const source = fs.readFileSync(handler, "utf8");
-      const implemented = source.replace(
-        /\/\/ TODO: implement the .*\n.*\/\/ Read typed inputs from 'request', set typed outputs on 'response'\./,
-        `response.OutputValue = "echo: " + request.InputValue;`,
-      );
-      expect(implemented, "the TODO was found and replaced").to.not.equal(source);
-      fs.writeFileSync(handler, implemented);
+  // #254 was: regenerating rewrote the single handler file, taking the user's Execute body with it.
+  it("keeps YOUR implementation when the handler is regenerated (#254)", async () => {
+    await step(COMPONENT, "Regenerate after editing the definition", async () => {
+      // Write the implementation the way a user would, then change the definition and regenerate.
+      const marker = "// MY-IMPLEMENTATION-MUST-SURVIVE";
+      const implemented = fs
+        .readFileSync(handlerPath, "utf8")
+        .replace(
+          /\/\/ TODO: implement the .*\n.*\/\/ Read typed inputs from 'request', set typed outputs on 'response'\./,
+          `${marker}\n            response.OutputValue = "echo: " + request.InputValue;`,
+        );
+      expect(implemented, "the TODO was found and replaced").to.not.contain("// TODO: implement");
+      fs.writeFileSync(handlerPath, implemented);
+
+      // A real definition change: a second request parameter the wrappers must pick up.
+      const definitionPath = path.join(workspace, `${apiUniqueName}.customapi.json`);
+      const def = JSON.parse(fs.readFileSync(definitionPath, "utf8"));
+      def.requestParameters.push({
+        uniqueName: "Multiplier",
+        name: `${apiUniqueName}.Multiplier`,
+        displayName: "Multiplier",
+        type: "Integer",
+        isOptional: true,
+        description: "Added to prove regeneration refreshes the wrappers.",
+      });
+      fs.writeFileSync(definitionPath, JSON.stringify(def, null, 2) + "\n");
+
+      await clearOutput();
+      await closeAnyOpenMenu();
+      await expandComponentCards();
+      await clickOverflowItem("Generate Custom API handlers", { timeoutMs: 45000 });
+      // The log states which file was left alone, so the guarantee is visible and not just implied.
+      await expectOutput([`✓ ${apiUniqueName}.customapi.json → `, `${className}.cs left as you wrote it`], { step: "regenerate handler", timeoutMs: 120000 });
+
+      const afterUser = fs.readFileSync(handlerPath, "utf8");
+      expect(afterUser, "MY implementation survived regeneration").to.contain(marker);
+      expect(afterUser, "and so did the line I wrote").to.contain('response.OutputValue = "echo: " + request.InputValue;');
+      const afterWrappers = fs.readFileSync(path.join(workspace, projectName, "CustomApi", `${className}.generated.cs`), "utf8");
+      expect(afterWrappers, "the wrappers picked up the new parameter").to.contain("public int Multiplier =>");
+      return `regenerated after adding Multiplier: wrappers refreshed, ${className}.cs untouched`;
+    });
+  });
+
+  it("deploys the plug-in package — Build & deploy package", async () => {
+    await step(COMPONENT, "Deploy the plug-in package", async () => {
+      // The implementation was written in the step above (and survived regeneration), so this compiles
+      // real logic — an echo — rather than an empty TODO.
+      expect(fs.readFileSync(handlerPath, "utf8"), "the handler implements the echo").to.contain('response.OutputValue = "echo: " + request.InputValue;');
 
       await clearOutput();
       await closeAnyOpenMenu();
@@ -220,8 +263,8 @@ describe("ACCEPTANCE: Custom API — define, deploy and execute via panel button
       // Gate on the reconcile SUMMARY, not on "Created CustomAPI": that line is written before the
       // request parameters and response properties are reconciled, so verifying Dataverse on it found
       // the API and its parameter but not yet its response property. The counts also assert the plan —
-      // one of each created, nothing updated, nothing deleted.
-      await expectOutput([`Created CustomAPI '${apiUniqueName}'.`, "Parameters: +1 ~0 -0; Response: +1 ~0 -0."], { step: "deploy custom api", timeoutMs: 300000 });
+      // both request parameters and the one response property created, nothing updated or deleted.
+      await expectOutput([`Created CustomAPI '${apiUniqueName}'.`, "Parameters: +2 ~0 -0; Response: +1 ~0 -0."], { step: "deploy custom api", timeoutMs: 300000 });
 
       const customApiId = await client.findCustomApiId(apiUniqueName);
       expect(customApiId, `customapi row for ${apiUniqueName}`).to.not.equal(undefined);
@@ -235,7 +278,8 @@ describe("ACCEPTANCE: Custom API — define, deploy and execute via panel button
       const members = await client.getCustomApiMembers(customApiId!);
       expect(members.requestParameters, "the request parameter was created").to.include("InputValue");
       expect(members.responseProperties, "the response property was created").to.include("OutputValue");
-      return `customapi ${apiUniqueName} created (${customApiId}) with InputValue → OutputValue`;
+      customApiIdFirstDeploy = customApiId;
+      return `customapi ${apiUniqueName} created (${customApiId}) with InputValue + Multiplier → OutputValue`;
     });
   });
 
@@ -252,7 +296,11 @@ describe("ACCEPTANCE: Custom API — define, deploy and execute via panel button
         await clickOverflowItem("Run Custom API…", { timeoutMs: 45000 });
         // No "which Custom API?" pick: that quick pick only appears with MORE than one definition in the
         // component, and this suite creates exactly one — so the next prompt is the parameter itself.
+        // ONE PROMPT PER REQUEST PARAMETER, in definition order. The regeneration step above added
+        // Multiplier, so there are two now; answering only the first leaves the command waiting and no
+        // call is ever made.
         await answerText("ping"); // InputValue
+        await answerText("2"); // Multiplier (optional, but the prompt still appears)
         try {
           // "POST dvpt_Echo…" — the logged path has no leading slash.
           responseText = await expectOutput([`POST ${apiUniqueName}`, "Response:"], { step: `invoke custom api (attempt ${attempt})`, timeoutMs: 120000 });
@@ -272,6 +320,55 @@ describe("ACCEPTANCE: Custom API — define, deploy and execute via panel button
       expect(responseText, "the response contains the handler's OutputValue").to.contain("OutputValue");
       expect(responseText, "the handler echoed the input we passed").to.contain("echo: ping");
       return `called ${apiUniqueName} with InputValue="ping" and got OutputValue="echo: ping"`;
+    });
+  });
+
+  // The create path was proven above. UPDATE and DELETE were only ever unit-tested against a mock, so a
+  // second deploy of an EDITED definition is the only thing that shows Dataverse ends up matching the
+  // file rather than accumulating whatever earlier versions left behind.
+  it("re-deploys an EDITED definition: updates what changed and DELETES what was removed", async () => {
+    await step(COMPONENT, "Re-deploy after editing (update + delete reconcile)", async () => {
+      const definitionPath = path.join(workspace, `${apiUniqueName}.customapi.json`);
+      const def = JSON.parse(fs.readFileSync(definitionPath, "utf8"));
+      // 1. change an existing parameter  → update
+      const inputValue = def.requestParameters.find((p: any) => p.uniqueName === "InputValue");
+      inputValue.displayName = "Input Value (renamed)";
+      inputValue.isOptional = true;
+      // 2. remove the parameter added earlier → delete
+      def.requestParameters = def.requestParameters.filter((p: any) => p.uniqueName !== "Multiplier");
+      // 3. add a response property → create, alongside an existing one
+      def.responseProperties.push({
+        uniqueName: "Echoed",
+        name: `${apiUniqueName}.Echoed`,
+        displayName: "Echoed",
+        type: "Boolean",
+        description: "Added on the second deploy.",
+      });
+      // 4. change the API row itself → the "Updated CustomAPI" arm rather than "Created"
+      def.displayName = `${apiUniqueName} (renamed)`;
+      fs.writeFileSync(definitionPath, JSON.stringify(def, null, 2) + "\n");
+
+      await clearOutput();
+      await closeAnyOpenMenu();
+      await expandComponentCards();
+      await clickOverflowItem("Deploy Custom APIs", { timeoutMs: 45000 });
+      const summary = await expectOutput([`Updated CustomAPI '${apiUniqueName}'.`, "Parameters: +", "Response: +"], { step: "re-deploy custom api", timeoutMs: 300000 });
+      const counts = /Parameters: (\+\d+ ~\d+ -\d+); Response: (\+\d+ ~\d+ -\d+)\./.exec(summary);
+      console.log(`    [e2e] reconcile summary — Parameters: ${counts?.[1] ?? "?"}; Response: ${counts?.[2] ?? "?"}`);
+      expect(summary, "a request parameter was deleted").to.match(/Parameters: \+\d+ ~\d+ -[1-9]/);
+
+      // Assert the EFFECT in Dataverse, not the counts: the environment must match the file now.
+      const customApiId = await client.findCustomApiId(apiUniqueName);
+      expect(customApiId, "the API is still there (updated, not recreated)").to.equal(customApiIdFirstDeploy);
+      const row = await client.getCustomApi(apiUniqueName);
+      expect(row?.displayname, "the display name change was applied").to.equal(`${apiUniqueName} (renamed)`);
+
+      const members = await client.getCustomApiMembers(customApiId!);
+      expect(members.requestParameters, "the kept parameter is still there").to.include("InputValue");
+      expect(members.requestParameters, "the REMOVED parameter is gone from the environment").to.not.include("Multiplier");
+      expect(members.responseProperties, "the original response property is still there").to.include("OutputValue");
+      expect(members.responseProperties, "the ADDED response property was created").to.include("Echoed");
+      return `re-deploy reconciled: InputValue updated, Multiplier deleted, Echoed created, API row updated in place (${customApiId})`;
     });
   });
 

--- a/src/ui-test/e2e/lib.ts
+++ b/src/ui-test/e2e/lib.ts
@@ -985,6 +985,37 @@ export class E2EClient {
     return row?.customcontrolid;
   }
 
+  /** Force the org's plug-in trace level (0 Off, 1 Exception, 2 All) — teardown insurance for a shared org. */
+  async setTraceLogLevel(level: 0 | 1 | 2): Promise<boolean> {
+    const res = await this.request("GET", "organizations?$select=organizationid&$top=1");
+    if (!res.ok) {
+      return false;
+    }
+    const data: any = await res.json();
+    const id = data?.value?.[0]?.organizationid;
+    if (!id) {
+      return false;
+    }
+
+    const patch = await this.request("PATCH", `organizations(${id})`, { plugintracelogsetting: level });
+    return patch.ok;
+  }
+
+  /**
+   * Whether the plug-in wrote a trace log — proof the run happened with tracing on (#231).
+   *
+   * `typename` is the ASSEMBLY-QUALIFIED name ("Ns.Class, Assembly, Version=…, Culture=…, PublicKeyToken=…"),
+   * so an equality filter on the plain type name never matches even when the row is right there.
+   */
+  async hasTraceLogFor(typeName: string): Promise<boolean> {
+    const res = await this.request("GET", `plugintracelogs?$select=plugintracelogid&$top=1&$filter=startswith(typename,'${typeName.replace(/'/g, "''")}')`);
+    if (!res.ok) {
+      return false;
+    }
+    const data: any = await res.json();
+    return (data?.value?.length ?? 0) > 0;
+  }
+
   /** Whether a pushed control is a component OF the given solution (#256). */
   async isCustomControlInSolution(fullName: string, solutionUniqueName: string): Promise<boolean> {
     const id = await this.findCustomControlId(fullName);

--- a/src/ui-test/e2e/lib.ts
+++ b/src/ui-test/e2e/lib.ts
@@ -192,6 +192,27 @@ export function shotsEnabled(): boolean {
   return process.env.DVPT_E2E_SHOTS === "1";
 }
 
+/** The window size the e2e instance runs at; a side-by-side half is exactly half of it. */
+export const E2E_WINDOW = { width: 1718, height: 872 };
+export const SIDE_BY_SIDE_HALF = { width: Math.floor(E2E_WINDOW.width / 2), height: E2E_WINDOW.height };
+
+/**
+ * Resize the VS Code window to one half of the screen, for a capture that will be stitched next to a
+ * browser frame — so the composed image reads as ONE screen rather than two overlapping full ones.
+ * Returns a function that puts the window back.
+ */
+export async function useHalfWidthWindow(): Promise<() => Promise<void>> {
+  const window = VSBrowser.instance.driver.manage().window();
+  const previous = await window.getRect().catch(() => ({ width: E2E_WINDOW.width, height: E2E_WINDOW.height, x: 0, y: 0 }));
+  await window.setRect({ width: SIDE_BY_SIDE_HALF.width, height: SIDE_BY_SIDE_HALF.height, x: 0, y: 0 }).catch(() => undefined);
+  // Let the workbench relayout before anything is captured — a mid-reflow frame looks broken.
+  await sleep(2500);
+  return async (): Promise<void> => {
+    await window.setRect({ width: previous.width, height: previous.height, x: previous.x, y: previous.y }).catch(() => undefined);
+    await sleep(2000);
+  };
+}
+
 /**
  * Clear what an earlier step left visible in the MAIN document: every outline this module applied, the
  * focus ring on the last-clicked control, and any text selection. `keepOwnOutline` spares the outline

--- a/src/ui-test/e2e/lib.ts
+++ b/src/ui-test/e2e/lib.ts
@@ -201,16 +201,37 @@ export const SIDE_BY_SIDE_HALF = { width: Math.floor(E2E_WINDOW.width / 2), heig
  * browser frame — so the composed image reads as ONE screen rather than two overlapping full ones.
  * Returns a function that puts the window back.
  */
-export async function useHalfWidthWindow(): Promise<() => Promise<void>> {
-  const window = VSBrowser.instance.driver.manage().window();
-  const previous = await window.getRect().catch(() => ({ width: E2E_WINDOW.width, height: E2E_WINDOW.height, x: 0, y: 0 }));
-  await window.setRect({ width: SIDE_BY_SIDE_HALF.width, height: SIDE_BY_SIDE_HALF.height, x: 0, y: 0 }).catch(() => undefined);
-  // Let the workbench relayout before anything is captured — a mid-reflow frame looks broken.
-  await sleep(2500);
-  return async (): Promise<void> => {
-    await window.setRect({ width: previous.width, height: previous.height, x: previous.x, y: previous.y }).catch(() => undefined);
-    await sleep(2000);
-  };
+export async function shotEditorHalf(name: string): Promise<void> {
+  if (!shotsEnabled()) {
+    return;
+  }
+  try {
+    await clearShotArtefacts(false);
+    fs.mkdirSync(SHOTS_DIR, { recursive: true });
+
+    const { PNG } = require("pngjs");
+    const full = PNG.sync.read(Buffer.from(await VSBrowser.instance.driver.takeScreenshot(), "base64"));
+    const width = Math.min(SIDE_BY_SIDE_HALF.width, full.width);
+    // Crop from the LEFT. Taking the right half looked more "editor-ish" but cut every line of code
+    // mid-statement; the left half keeps the line numbers, the start of each line, and the output panel
+    // — which is what makes the hot-reload story readable next to the form.
+    const left = 0;
+    const half = new PNG({ width, height: full.height });
+    for (let y = 0; y < full.height; y++) {
+      for (let x = 0; x < width; x++) {
+        const source = (full.width * y + (left + x)) << 2;
+        const target = (width * y + x) << 2;
+        half.data[target] = full.data[source];
+        half.data[target + 1] = full.data[source + 1];
+        half.data[target + 2] = full.data[source + 2];
+        half.data[target + 3] = 255;
+      }
+    }
+    fs.writeFileSync(path.join(SHOTS_DIR, `${name}.png`), PNG.sync.write(half));
+    console.log(`    [shot] ${name}.png (editor half ${width}x${full.height})`);
+  } catch (error) {
+    console.log(`    [shot] ${name} (editor half) failed: ${String(error).slice(0, 120)}`);
+  }
 }
 
 /**

--- a/src/ui-test/e2e/lib.ts
+++ b/src/ui-test/e2e/lib.ts
@@ -967,6 +967,28 @@ export class E2EClient {
     }
   }
 
+  // ---- PCF custom control (#227): prove an interactive push really landed, then remove it ----
+
+  /** The `customcontrol` row id for a `<namespace>.<name>` control, or undefined when absent. */
+  async findCustomControlId(fullName: string): Promise<string | undefined> {
+    const res = await this.request("GET", `customcontrols?$select=customcontrolid&$filter=name eq '${fullName.replace(/'/g, "''")}'`);
+    if (!res.ok) {
+      return undefined;
+    }
+    const data: any = await res.json();
+    return data?.value?.[0]?.customcontrolid;
+  }
+
+  /** Delete a pushed custom control. Best-effort: a control referenced by a form cannot be removed. */
+  async deleteCustomControl(fullName: string): Promise<boolean> {
+    const id = await this.findCustomControlId(fullName);
+    if (!id) {
+      return false;
+    }
+    const res = await this.request("DELETE", `customcontrols(${id})`);
+    return res.ok;
+  }
+
   // ---- Custom API (#225): verify what the deploy actually created, then remove it ----
 
   /** The `customapi` row id for a unique name, or undefined when it is not in the environment. */

--- a/src/ui-test/e2e/lib.ts
+++ b/src/ui-test/e2e/lib.ts
@@ -969,14 +969,37 @@ export class E2EClient {
 
   // ---- PCF custom control (#227): prove an interactive push really landed, then remove it ----
 
-  /** The `customcontrol` row id for a `<namespace>.<name>` control, or undefined when absent. */
+  /**
+   * The `customcontrol` row id for a `<namespace>.<constructor>` control, or undefined when absent.
+   *
+   * Dataverse PREFIXES the stored name with the publisher's customization prefix
+   * (`dvpt_SampleNamespace.SampleControl`), so an equality filter on the manifest name never matches.
+   */
   async findCustomControlId(fullName: string): Promise<string | undefined> {
-    const res = await this.request("GET", `customcontrols?$select=customcontrolid&$filter=name eq '${fullName.replace(/'/g, "''")}'`);
+    const res = await this.request("GET", `customcontrols?$select=customcontrolid,name&$filter=endswith(name,'${fullName.replace(/'/g, "''")}')`);
     if (!res.ok) {
       return undefined;
     }
     const data: any = await res.json();
-    return data?.value?.[0]?.customcontrolid;
+    const row = (data?.value ?? []).find((candidate: any) => candidate?.name === fullName || String(candidate?.name ?? "").endsWith(`_${fullName}`));
+    return row?.customcontrolid;
+  }
+
+  /** Whether a pushed control is a component OF the given solution (#256). */
+  async isCustomControlInSolution(fullName: string, solutionUniqueName: string): Promise<boolean> {
+    const id = await this.findCustomControlId(fullName);
+    if (!id) {
+      return false;
+    }
+    const res = await this.request(
+      "GET",
+      `solutioncomponents?$select=solutioncomponentid&$filter=objectid eq ${id} and solutionid/uniquename eq '${solutionUniqueName.replace(/'/g, "''")}'`,
+    );
+    if (!res.ok) {
+      return false;
+    }
+    const data: any = await res.json();
+    return (data?.value?.length ?? 0) > 0;
   }
 
   /** Delete a pushed custom control. Best-effort: a control referenced by a form cannot be removed. */

--- a/src/ui-test/e2e/pcfInteractiveLifecycle.e2e.ts
+++ b/src/ui-test/e2e/pcfInteractiveLifecycle.e2e.ts
@@ -1,5 +1,6 @@
 import * as path from "path";
 import * as fs from "fs";
+import * as os from "os";
 import { expect } from "chai";
 import { VSBrowser } from "vscode-extension-tester";
 import {
@@ -14,10 +15,14 @@ import {
   sleep,
   expectOutput,
   clearOutput,
+  waitForLogFile,
+  logFileSize,
   E2EClient,
   resetAllCredentials,
 } from "./lib";
 import { clickPanelButton, expandComponentCards } from "../supervised/supervisedLib";
+import { completeDeviceCodeLogin, parseDeviceCode } from "./browserLib";
+import { resolveBrowser } from "../../webresources/debug/browserResolver";
 
 // End-to-end: a PCF control created and pushed under INTERACTIVE (OAuth) sign-in (#227).
 //
@@ -110,7 +115,12 @@ describe("PCF lifecycle — interactive auth (e2e)", function () {
     } catch {
       text = "";
     }
-    expect(/resulted in an error|Error /i.test(text), `no error notification after ${context} — saw: ${text.slice(0, 200)}`).to.equal(false);
+    // Only VS Code's own command-failure toast and the extension's explicit "Error <verb>ing" messages.
+    // A looser /Error /i matched the word inside `npm install --loglevel=error` in a PROGRESS
+    // notification (and inside the CSS that comes back with the notification's text), failing a step
+    // that had gone fine.
+    const failed = /resulted in an error/i.test(text) || /\bError (building|refreshing|pushing|running|deploying)\b/i.test(text);
+    expect(failed, `no error notification after ${context} — saw: ${text.slice(0, 200)}`).to.equal(false);
     await dismissOverlays();
   }
 
@@ -164,6 +174,12 @@ describe("PCF lifecycle — interactive auth (e2e)", function () {
     expect(controlNamespace, "manifest namespace").to.not.equal("");
     expect(controlConstructor, "manifest constructor").to.not.equal("");
     console.log(`    [e2e] scaffolded control ${controlNamespace}.${controlConstructor}`);
+    // The manifest is written by `pac pcf init`, which finishes LONG before `npm install` does — so a
+    // file assert says "ready" while node_modules/.bin is still filling up. Clicking Refresh Types there
+    // ran `pcf-scripts` before it existed and reported "'pcf-scripts' is not recognized", which looks
+    // exactly like the missing-local-bin bug this repo has had before but was just a race with the
+    // restore. Wait for the restore's OWN final line.
+    await expectOutput(["Restore Complete."], { step: "npm restore after pcf init", timeoutMs: 900000 });
     await assertCommandDidNotError("PCF init (interactive)");
   });
 
@@ -173,6 +189,26 @@ describe("PCF lifecycle — interactive auth (e2e)", function () {
     // `dataverse-powertools.isPcf`, so a palette entry that is filtered out silently does NOTHING —
     // no command, no output, no error, just a suite waiting 20 minutes for a line that cannot come.
     // The card is also what a user clicks.
+    // Wait for the LOCAL BIN to settle, not just for a "Restore Complete." line. The component restores
+    // more than once (init, then again on discovery), and `npm install` empties and refills
+    // node_modules/.bin while it runs — so a command launched in that window dies with
+    // "'pcf-scripts' is not recognized", which reads exactly like this repo's missing-local-bin bug and
+    // is really a race. The bin existing, and STAYING there, is the precondition the command needs.
+    const localBin = path.join(workspace, "node_modules", ".bin", process.platform === "win32" ? "pcf-scripts.cmd" : "pcf-scripts");
+    const binReady = await (async (): Promise<boolean> => {
+      const deadline = Date.now() + 900000;
+      let consecutive = 0;
+      while (Date.now() < deadline) {
+        consecutive = fs.existsSync(localBin) ? consecutive + 1 : 0;
+        if (consecutive >= 3) {
+          return true;
+        }
+        await sleep(5000);
+      }
+      return false;
+    })();
+    expect(binReady, "node_modules/.bin/pcf-scripts settled before running the pcf-scripts commands").to.equal(true);
+
     await clearOutput();
     await expandComponentCards();
     await clickPanelButton("Refresh Types", { timeoutMs: 45000 });
@@ -198,10 +234,34 @@ describe("PCF lifecycle — interactive auth (e2e)", function () {
       await sleep(5000);
     }
 
+    const pushBaseline = logFileSize();
     await clearOutput();
     await expandComponentCards();
     // "▶ Push to {environment}" — substring match for the prefix and the environment name.
     await clickPanelButton("Push to", { timeoutMs: 45000, contains: true });
+
+    // `pac pcf push` needs a pac profile, and under interactive auth there is NO client secret — so
+    // `pac auth create` uses the device-code flow: it prints a code and blocks until someone enters it.
+    // That is correct behaviour, and it is the reason this path had never been covered unattended. The
+    // test account is MFA-exempt in a dedicated dev tenant, so drive it: read pac's own code out of the
+    // log and complete the sign-in in a browser.
+    const deviceLog = await waitForLogFile(/enter the code\s+[A-Z0-9]{6,}/i, { timeoutMs: 240000, sinceByte: pushBaseline }).catch(() => "");
+    const code = parseDeviceCode(deviceLog);
+    if (code) {
+      console.log(`    [e2e] pac asked for device code ${code} — completing the sign-in`);
+      const resolved = resolveBrowser("auto", undefined, { platform: process.platform, env: process.env, exists: fs.existsSync });
+      expect(resolved?.executablePath, "a browser to complete the device-code sign-in").to.not.equal(undefined);
+      const completed = await completeDeviceCodeLogin(resolved.executablePath!, path.join(os.tmpdir(), `dvpt-devicecode-${Date.now()}`), code, {
+        username: env!.username!,
+        password: env!.password!,
+        log: (m) => console.log(`    [e2e] ${m}`),
+      });
+      expect(completed, "the device-code sign-in completed").to.equal(true);
+    } else {
+      // A profile may already exist from an earlier run, in which case pac never asks. Say which
+      // happened, so a green run cannot quietly stop covering the device-code path.
+      console.log("    [e2e] pac did not ask for a device code — an existing pac profile was reused");
+    }
     // Gate on the command's FINAL line, not on pac chatter: pac exits 0 even on failure in this repo's
     // experience, so the extension's own completion line is the signal.
     await expectOutput(["PCF push complete."], { step: "push pcf (interactive)", timeoutMs: 1200000 });
@@ -229,8 +289,14 @@ describe("PCF lifecycle — interactive auth (e2e)", function () {
     await clearOutput();
     await expandComponentCards();
     await clickPanelButton("Add to Solution", { timeoutMs: 45000 });
-    await expectOutput(["PCF control added as a solution reference."], { step: "add pcf to solution", timeoutMs: 300000 });
-    await assertCommandDidNotError("Add PCF Control to Solution");
+    // #256: this adds the PUSHED control to the solution configured for the component, like a web
+    // resource — no Solution project required, so no `added as a solution reference` line here.
+    await expectOutput([`Added PCF control '${controlNamespace}.${controlConstructor}' to solution`], { step: "add pcf to solution", timeoutMs: 300000 });
+    await assertCommandDidNotError("Add to Solution");
+
+    // Confirm in Dataverse: the control is a component OF that solution, not merely that we logged it.
+    const inSolution = await client.isCustomControlInSolution(`${controlNamespace}.${controlConstructor}`, env!.solutionName);
+    expect(inSolution, `the control is a component of solution '${env!.solutionName}'`).to.equal(true);
   });
 
   after(async function () {

--- a/src/ui-test/e2e/pcfInteractiveLifecycle.e2e.ts
+++ b/src/ui-test/e2e/pcfInteractiveLifecycle.e2e.ts
@@ -1,0 +1,186 @@
+import * as path from "path";
+import * as fs from "fs";
+import { expect } from "chai";
+import { VSBrowser } from "vscode-extension-tester";
+import {
+  loadE2EEnv,
+  freshWorkspace,
+  answerText,
+  answerFlexible,
+  pickByLabel,
+  runCommand,
+  waitForFile,
+  dismissOverlays,
+  sleep,
+  expectOutput,
+  clearOutput,
+  E2EClient,
+  resetAllCredentials,
+} from "./lib";
+
+// End-to-end: a PCF control created and pushed under INTERACTIVE (OAuth) sign-in (#227).
+//
+// #141 closed its interactive-auth box by ARGUMENT — PCF shares ensurePacAuthForCurrentConnection with
+// the plugin and web-resource interactive suites, so it "must" work. That is the same reasoning that let
+// this class of bug ship repeatedly: #91 (typings), #90 (register form events), #128/#129 (early-bound),
+// #159 — all "shared code, must be fine", all broken under interactive because interactive sets NO
+// tenantId and something gated on it.
+//
+// PCF is the one component type whose Dataverse path runs through `pac` rather than the Web API, so its
+// OAuth story is the LEAST like the suites that already pass: the pac profile has to be created from a
+// connection that has no client secret and no tenant. Only a live push proves it.
+//
+// The interactive connect is silent because DVPT_TEST_MSAL_CACHE_FILE points at a cache pre-seeded by
+// preAcquireInteractiveCache.mjs (there is no browser to drive inside ExTester). Self-skips without
+// sandbox/.env or a seeded cache.
+describe("PCF lifecycle — interactive auth (e2e)", function () {
+  this.timeout(1800000);
+  const env = loadE2EEnv();
+  const hasCache = !!process.env.DVPT_TEST_MSAL_CACHE_FILE && fs.existsSync(process.env.DVPT_TEST_MSAL_CACHE_FILE || "");
+  /** Unique per run: a control left in the org by an earlier run would make "pushed" un-provable. */
+  const namespaceName = "DvptE2E";
+  const controlName = `IntCtl${Date.now().toString().slice(-6)}`;
+  let workspace: string;
+  let solutionFriendlyName: string;
+  let client: E2EClient;
+
+  afterEach(async function () {
+    if (this.currentTest?.state === "failed") {
+      try {
+        const dir = path.resolve(__dirname, "..", "..", "..", "sandbox", "screenshots-out");
+        fs.mkdirSync(dir, { recursive: true });
+        const img = await VSBrowser.instance.driver.takeScreenshot();
+        const name = (this.currentTest?.title || "step").replace(/[^a-z0-9]+/gi, "-").slice(0, 40);
+        fs.writeFileSync(path.join(dir, `e2e-pcf-int-fail-${name}.png`), img, "base64");
+      } catch {
+        /* ignore */
+      }
+    }
+  });
+
+  /** Read visible notification text: a command can error AFTER writing files, so file asserts alone lie. */
+  async function assertCommandDidNotError(context: string): Promise<void> {
+    await sleep(2500);
+    let text = "";
+    try {
+      text = String(
+        (await VSBrowser.instance.driver.executeScript(
+          "return Array.from(document.querySelectorAll('.notification-list-item-message, .notification-toast')).map(function(e){return e.textContent || '';}).join(' ||| ');",
+        )) ?? "",
+      );
+    } catch {
+      text = "";
+    }
+    expect(/resulted in an error|Error /i.test(text), `no error notification after ${context} — saw: ${text.slice(0, 200)}`).to.equal(false);
+    await dismissOverlays();
+  }
+
+  before(async function () {
+    if (!env || !hasCache) {
+      this.skip();
+    }
+    client = new E2EClient(env!);
+    await client.connect();
+    solutionFriendlyName = (await client.getSolutionFriendlyName(env!.solutionName)) ?? env!.solutionName;
+    workspace = freshWorkspace("pcf-interactive");
+    await VSBrowser.instance.openResources(workspace);
+    await VSBrowser.instance.waitForWorkbench();
+    await sleep(3500);
+    await dismissOverlays();
+    try {
+      await runCommand("Dataverse PowerTools: Show Log");
+    } catch {
+      /* the command may not be registered until the extension activates */
+    }
+  });
+
+  it("creates a PCF project via the wizard using interactive sign-in", async () => {
+    const log = (m: string): void => console.log(`    [e2e] ${m}`);
+    // Fresh-credential isolation: service-principal leftovers once masked a broken OAuth path.
+    await resetAllCredentials(log);
+    await runCommand("Dataverse PowerTools: Initialise Project");
+    log("project type: PCF Control");
+    await pickByLabel("PCF Control");
+    log("auth type: OAuth");
+    await pickByLabel("OAuth");
+    // Silent sign-in from the seeded cache, then environments come from Global Discovery — no
+    // tenant/clientId/clientSecret prompts at all, which is the condition under which the bugs above hid.
+    log("environment (silent sign-in + discovery)");
+    await answerFlexible(env!.url, 180000);
+    log(`solution (${solutionFriendlyName})`);
+    await pickByLabel(solutionFriendlyName);
+    log("namespace");
+    await answerText(namespaceName);
+    log("control name");
+    await answerText(controlName);
+    log("template");
+    await pickByLabel("Field", 120000);
+    log("framework");
+    // The label is "Standard (no framework)" — the VALUE is "none", which is not what the picker shows.
+    await pickByLabel("Standard (no framework)", 120000);
+    // pac pcf init + npm install run here, so allow for the restore.
+    expect(await waitForFile(path.join(workspace, "dataverse-powertools.json"), 300000), "dataverse-powertools.json").to.equal(true);
+    const manifest = path.join(workspace, controlName, "ControlManifest.Input.xml");
+    expect(await waitForFile(manifest, 600000), `${controlName}/ControlManifest.Input.xml`).to.equal(true);
+    await assertCommandDidNotError("PCF init (interactive)");
+  });
+
+  // No-auth sanity first: if scaffolding regressed, the suite says so here rather than blaming OAuth.
+  it("refreshes types and builds locally (scaffolding sanity, no auth involved)", async () => {
+    await clearOutput();
+    await runCommand("Dataverse PowerTools: Refresh PCF Types");
+    await expectOutput(["PCF types refreshed successfully."], { step: "refresh pcf types", timeoutMs: 600000 });
+    await assertCommandDidNotError("Refresh PCF Types");
+
+    await clearOutput();
+    await runCommand("Dataverse PowerTools: Build PCF Control");
+    await expectOutput(["PCF build completed successfully."], { step: "build pcf", timeoutMs: 900000 });
+    await assertCommandDidNotError("Build PCF Control");
+  });
+
+  // THE point of this suite: `pac pcf push` under a connection with no secret and no tenant.
+  it("PUSHES the control to the environment under interactive auth, and it lands in Dataverse", async () => {
+    await clearOutput();
+    await runCommand("Dataverse PowerTools: Push PCF Control");
+    // Gate on the command's FINAL line, not on pac chatter: pac exits 0 even on failure in this repo's
+    // experience, so the extension's own completion line is the signal.
+    await expectOutput(["PCF push complete."], { step: "push pcf (interactive)", timeoutMs: 1200000 });
+    await assertCommandDidNotError("Push PCF Control");
+
+    // Verify in Dataverse, not from our log: the customcontrol row has to exist, named
+    // <namespace>.<control>. Push imports it through a temporary solution, so allow a moment.
+    const fullName = `${namespaceName}.${controlName}`;
+    const id = await (async (): Promise<string | undefined> => {
+      const deadline = Date.now() + 300000;
+      for (;;) {
+        const found = await client.findCustomControlId(fullName).catch(() => undefined);
+        if (found || Date.now() > deadline) {
+          return found;
+        }
+        await sleep(7000);
+      }
+    })();
+    expect(id, `customcontrol ${fullName} exists in Dataverse after an interactive push`).to.not.equal(undefined);
+  });
+
+  it("adds the control to the solution — Add PCF Control to Solution (interactive)", async () => {
+    await clearOutput();
+    await runCommand("Dataverse PowerTools: Add PCF Control to Solution");
+    await expectOutput(["PCF control added as a solution reference."], { step: "add pcf to solution", timeoutMs: 300000 });
+    await assertCommandDidNotError("Add PCF Control to Solution");
+  });
+
+  after(async function () {
+    if (!env || !hasCache) {
+      return;
+    }
+    try {
+      const removed = await client.deleteCustomControl(`${namespaceName}.${controlName}`);
+      if (removed) {
+        console.log(`[cleanup] deleted custom control ${namespaceName}.${controlName}`);
+      }
+    } catch (error) {
+      console.log(`[cleanup] could not delete custom control: ${String(error).slice(0, 120)}`);
+    }
+  });
+});

--- a/src/ui-test/e2e/pcfInteractiveLifecycle.e2e.ts
+++ b/src/ui-test/e2e/pcfInteractiveLifecycle.e2e.ts
@@ -17,6 +17,7 @@ import {
   E2EClient,
   resetAllCredentials,
 } from "./lib";
+import { clickPanelButton, expandComponentCards } from "../supervised/supervisedLib";
 
 // End-to-end: a PCF control created and pushed under INTERACTIVE (OAuth) sign-in (#227).
 //
@@ -33,13 +34,51 @@ import {
 // The interactive connect is silent because DVPT_TEST_MSAL_CACHE_FILE points at a cache pre-seeded by
 // preAcquireInteractiveCache.mjs (there is no browser to drive inside ExTester). Self-skips without
 // sandbox/.env or a seeded cache.
+/** First file anywhere under dir whose name matches (skips node_modules/obj). */
+function findDeep(dir: string, predicate: (name: string) => boolean): string | undefined {
+  let entries: fs.Dirent[] = [];
+  try {
+    entries = fs.readdirSync(dir, { withFileTypes: true });
+  } catch {
+    return undefined;
+  }
+  for (const entry of entries) {
+    const full = path.join(dir, entry.name);
+    if (entry.isFile() && predicate(entry.name)) {
+      return full;
+    }
+    if (entry.isDirectory() && entry.name !== "node_modules" && entry.name !== "obj") {
+      const hit = findDeep(full, predicate);
+      if (hit) {
+        return hit;
+      }
+    }
+  }
+  return undefined;
+}
+
+/** findDeep, polled — `pac pcf init` plus npm install takes minutes. */
+async function pollDeep(dir: string, predicate: (name: string) => boolean, timeoutMs: number): Promise<string | undefined> {
+  const deadline = Date.now() + timeoutMs;
+  for (;;) {
+    const hit = findDeep(dir, predicate);
+    if (hit) {
+      return hit;
+    }
+    if (Date.now() > deadline) {
+      return undefined;
+    }
+    await sleep(4000);
+  }
+}
+
 describe("PCF lifecycle — interactive auth (e2e)", function () {
   this.timeout(1800000);
   const env = loadE2EEnv();
   const hasCache = !!process.env.DVPT_TEST_MSAL_CACHE_FILE && fs.existsSync(process.env.DVPT_TEST_MSAL_CACHE_FILE || "");
-  /** Unique per run: a control left in the org by an earlier run would make "pushed" un-provable. */
-  const namespaceName = "DvptE2E";
-  const controlName = `IntCtl${Date.now().toString().slice(-6)}`;
+  /** Read from the manifest pac writes — the wizard does not ask for either. */
+  let controlNamespace = "";
+  let controlConstructor = "";
   let workspace: string;
   let solutionFriendlyName: string;
   let client: E2EClient;
@@ -109,49 +148,70 @@ describe("PCF lifecycle — interactive auth (e2e)", function () {
     await answerFlexible(env!.url, 180000);
     log(`solution (${solutionFriendlyName})`);
     await pickByLabel(solutionFriendlyName);
-    log("namespace");
-    await answerText(namespaceName);
-    log("control name");
-    await answerText(controlName);
-    log("template");
+    // Template + framework are the ONLY control prompts: pac pcf init names the control itself, and the
+    // namespace/constructor are read back from the manifest below.
+    log("control template");
     await pickByLabel("Field", 120000);
-    log("framework");
-    // The label is "Standard (no framework)" — the VALUE is "none", which is not what the picker shows.
+    log("rendering framework");
     await pickByLabel("Standard (no framework)", 120000);
     // pac pcf init + npm install run here, so allow for the restore.
     expect(await waitForFile(path.join(workspace, "dataverse-powertools.json"), 300000), "dataverse-powertools.json").to.equal(true);
-    const manifest = path.join(workspace, controlName, "ControlManifest.Input.xml");
-    expect(await waitForFile(manifest, 600000), `${controlName}/ControlManifest.Input.xml`).to.equal(true);
+    const manifestPath = await pollDeep(workspace, (name) => name === "ControlManifest.Input.xml", 600000);
+    expect(manifestPath, "ControlManifest.Input.xml scaffolded").to.not.equal(undefined);
+    const xml = fs.readFileSync(manifestPath!, "utf8");
+    controlNamespace = /namespace="([^"]+)"/.exec(xml)?.[1] ?? "";
+    controlConstructor = /constructor="([^"]+)"/.exec(xml)?.[1] ?? "";
+    expect(controlNamespace, "manifest namespace").to.not.equal("");
+    expect(controlConstructor, "manifest constructor").to.not.equal("");
+    console.log(`    [e2e] scaffolded control ${controlNamespace}.${controlConstructor}`);
     await assertCommandDidNotError("PCF init (interactive)");
   });
 
   // No-auth sanity first: if scaffolding regressed, the suite says so here rather than blaming OAuth.
   it("refreshes types and builds locally (scaffolding sanity, no auth involved)", async () => {
+    // Buttons, not the command palette: the PCF commands are enablement-gated on
+    // `dataverse-powertools.isPcf`, so a palette entry that is filtered out silently does NOTHING —
+    // no command, no output, no error, just a suite waiting 20 minutes for a line that cannot come.
+    // The card is also what a user clicks.
     await clearOutput();
-    await runCommand("Dataverse PowerTools: Refresh PCF Types");
+    await expandComponentCards();
+    await clickPanelButton("Refresh Types", { timeoutMs: 45000 });
     await expectOutput(["PCF types refreshed successfully."], { step: "refresh pcf types", timeoutMs: 600000 });
-    await assertCommandDidNotError("Refresh PCF Types");
+    await assertCommandDidNotError("Refresh Types");
 
     await clearOutput();
-    await runCommand("Dataverse PowerTools: Build PCF Control");
+    await expandComponentCards();
+    await clickPanelButton("Local Build", { timeoutMs: 45000 });
     await expectOutput(["PCF build completed successfully."], { step: "build pcf", timeoutMs: 900000 });
-    await assertCommandDidNotError("Build PCF Control");
+    await assertCommandDidNotError("Local Build");
   });
 
   // THE point of this suite: `pac pcf push` under a connection with no secret and no tenant.
   it("PUSHES the control to the environment under interactive auth, and it lands in Dataverse", async () => {
+    // `pac pcf init` names the control from its own defaults (SampleNamespace.SampleControl), so the name
+    // is NOT unique per run — a row left by an earlier run would satisfy the assertions below without
+    // this push doing anything. Delete it first, so "it exists" can only mean this push created it. (The
+    // same hollow assertion made #249's bogus build failure invisible.)
+    const existing = await client.deleteCustomControl(`${controlNamespace}.${controlConstructor}`).catch(() => false);
+    if (existing) {
+      console.log(`    [e2e] removed a pre-existing ${controlNamespace}.${controlConstructor} so the push has to recreate it`);
+      await sleep(5000);
+    }
+
     await clearOutput();
-    await runCommand("Dataverse PowerTools: Push PCF Control");
+    await expandComponentCards();
+    // "▶ Push to {environment}" — substring match for the prefix and the environment name.
+    await clickPanelButton("Push to", { timeoutMs: 45000, contains: true });
     // Gate on the command's FINAL line, not on pac chatter: pac exits 0 even on failure in this repo's
     // experience, so the extension's own completion line is the signal.
     await expectOutput(["PCF push complete."], { step: "push pcf (interactive)", timeoutMs: 1200000 });
     await assertCommandDidNotError("Push PCF Control");
 
-    // Verify in Dataverse, not from our log: the customcontrol row has to exist, named
-    // <namespace>.<control>. Push imports it through a temporary solution, so allow a moment.
-    const fullName = `${namespaceName}.${controlName}`;
-    const id = await (async (): Promise<string | undefined> => {
-      const deadline = Date.now() + 300000;
+    // Verify in Dataverse, not from our log. Two things, because either alone can mislead: the
+    // customcontrol row (the control is registered) and its bundle web resource (the code really landed).
+    const fullName = `${controlNamespace}.${controlConstructor}`;
+    const controlId = await (async (): Promise<string | undefined> => {
+      const deadline = Date.now() + 420000;
       for (;;) {
         const found = await client.findCustomControlId(fullName).catch(() => undefined);
         if (found || Date.now() > deadline) {
@@ -160,12 +220,15 @@ describe("PCF lifecycle — interactive auth (e2e)", function () {
         await sleep(7000);
       }
     })();
-    expect(id, `customcontrol ${fullName} exists in Dataverse after an interactive push`).to.not.equal(undefined);
+    expect(controlId, `customcontrol ${fullName} exists in Dataverse after an INTERACTIVE push`).to.not.equal(undefined);
+    const bundle = await client.findWebresourceId(`cc_${fullName}/bundle.js`).catch(() => undefined);
+    expect(bundle, `the control's bundle web resource cc_${fullName}/bundle.js landed`).to.not.equal(undefined);
   });
 
   it("adds the control to the solution — Add PCF Control to Solution (interactive)", async () => {
     await clearOutput();
-    await runCommand("Dataverse PowerTools: Add PCF Control to Solution");
+    await expandComponentCards();
+    await clickPanelButton("Add to Solution", { timeoutMs: 45000 });
     await expectOutput(["PCF control added as a solution reference."], { step: "add pcf to solution", timeoutMs: 300000 });
     await assertCommandDidNotError("Add PCF Control to Solution");
   });
@@ -175,9 +238,11 @@ describe("PCF lifecycle — interactive auth (e2e)", function () {
       return;
     }
     try {
-      const removed = await client.deleteCustomControl(`${namespaceName}.${controlName}`);
-      if (removed) {
-        console.log(`[cleanup] deleted custom control ${namespaceName}.${controlName}`);
+      if (controlNamespace && controlConstructor) {
+        const removed = await client.deleteCustomControl(`${controlNamespace}.${controlConstructor}`);
+        if (removed) {
+          console.log(`[cleanup] deleted custom control ${controlNamespace}.${controlConstructor}`);
+        }
       }
     } catch (error) {
       console.log(`[cleanup] could not delete custom control: ${String(error).slice(0, 120)}`);

--- a/src/ui-test/e2e/pluginProfilerReplay.e2e.ts
+++ b/src/ui-test/e2e/pluginProfilerReplay.e2e.ts
@@ -639,6 +639,24 @@ describe("DEBUGGING: Plugin — profile capture → replay → execute via panel
     });
   });
 
+  // #231 wanted a LIVE-TRIGGERED trace log: not a hand-made example, but the record a real execution
+  // wrote. The territory create above already ran the plug-in, and its Trace() line is in the org — so
+  // this opens the viewer on that record and captures what a user would read.
+  it("shows the trace log written by the run we triggered (live trace capture)", async () => {
+    await step(COMPONENT, "View plugin trace logs for the triggered run", async () => {
+      await runCommandResilient("Dataverse PowerTools: View Plugin Trace Logs");
+      // Most recent first, and this suite's territory create is the most recent thing to have run.
+      await pickFirst(120000);
+      await sleep(3000);
+      await dismissOverlays();
+      const rendered = String((await VSBrowser.instance.driver.executeScript("return document.querySelector('.monaco-editor')?.innerText ?? '';")) ?? "");
+      // Prove it is OUR run's trace before publishing the frame: the plug-in's own Trace() text.
+      expect(rendered, `the rendered trace log is from the plug-in we triggered — saw: ${rendered.slice(0, 200)}`).to.contain("Onboarded territory");
+      await shot("10-live-trace-log");
+      return "opened the trace log for the triggered run (contains the plug-in's own Trace output)";
+    });
+  });
+
   // Drive the CodeLens route for real. Last, so a failure here cannot disturb the capture flow above,
   // and it toggles back OFF so the step is left active for the next run (the #241 lesson).
   it("starts and stops profiling from the per-step CodeLens", async () => {

--- a/src/ui-test/e2e/pluginProfilerReplay.e2e.ts
+++ b/src/ui-test/e2e/pluginProfilerReplay.e2e.ts
@@ -689,8 +689,14 @@ describe("DEBUGGING: Plugin — profile capture → replay → execute via panel
       // TIDY BEFORE ASSERTING. The trace document is an untitled markdown editor, and leaving it active
       // made the NEXT test ask it for CodeLenses and find none — so a failure here cascaded into a
       // second, unrelated-looking failure. Cleanup must not depend on the assertions passing.
-      await runCommandResilient("View: Close Editor").catch(() => undefined);
+      // REVERT and close. The viewer opens the log as an UNTITLED document, which VS Code considers
+      // dirty, so a plain "Close Editor" raises a "save your changes?" modal — the suite then sat on
+      // that dialog until the hour-long mocha timeout killed the session, and the next test reported a
+      // dead driver. Reverting discards without asking; the modal dismissal is belt and braces.
+      await runCommandResilient("View: Revert and Close Editor").catch(() => undefined);
       await sleep(1500);
+      await pushModalButton("Don't Save").catch(() => undefined);
+      await sleep(500);
       // Prove it is OUR run's trace before publishing the frame: the plug-in's own Trace() output.
       expect(rendered, `the trace log is from the plug-in we triggered — saw: ${rendered.slice(0, 200)}`).to.contain("Onboarded territory");
       expect(rendered, "the trace log names the plug-in type that wrote it").to.contain(typeName);

--- a/src/ui-test/e2e/pluginProfilerReplay.e2e.ts
+++ b/src/ui-test/e2e/pluginProfilerReplay.e2e.ts
@@ -183,6 +183,8 @@ describe("DEBUGGING: Plugin — profile capture → replay → execute via panel
   const className = "TerritoryOnboarding";
   let typeName = `${projectName}.${className}`; // refined from the scaffolded file's real namespace
   let triggeredTerritoryId: string | undefined;
+  /** The second trigger, fired with tracing ON so the viewer has a real row to show (#231). */
+  let tracedTerritoryId: string | undefined;
 
   function pkgUnique(): string {
     const settings = JSON.parse(fs.readFileSync(path.join(workspace, "dataverse-powertools.json"), "utf8"));
@@ -644,15 +646,57 @@ describe("DEBUGGING: Plugin — profile capture → replay → execute via panel
   // this opens the viewer on that record and captures what a user would read.
   it("shows the trace log written by the run we triggered (live trace capture)", async () => {
     await step(COMPONENT, "View plugin trace logs for the triggered run", async () => {
+      // Plug-in tracing is OFF by default, so the earlier trigger wrote no plugintracelog row and the
+      // viewer had nothing to show. Turn it on, fire the plug-in again, THEN look — a trace log is only
+      // worth capturing if it came from a real execution.
+      await runCommandResilient("Dataverse PowerTools: Set Plugin Trace Log Level");
+      await pickByLabel("All", 60000);
+      await pushModalButton("Set to All").catch(() => undefined); // the firehose confirmation
+      await waitForLogFile("[Trace] Plug-in trace log level set to 2", { timeoutMs: 120000 });
+
+      tracedTerritoryId = await client.createTerritory();
+      if (!tracedTerritoryId) {
+        throw new Error("could not create a territory to trigger the plugin for its trace log");
+      }
+      // The step is ASYNC, so the row appears a moment after the create returns.
+      const wroteTrace = await (async (): Promise<boolean> => {
+        const deadline = Date.now() + 180000;
+        for (;;) {
+          if (await client.hasTraceLogFor(typeName).catch(() => false)) {
+            return true;
+          }
+          if (Date.now() > deadline) {
+            return false;
+          }
+          await sleep(5000);
+        }
+      })();
+      expect(wroteTrace, `a plugintracelog row for ${typeName} after triggering with tracing on`).to.equal(true);
+
       await runCommandResilient("Dataverse PowerTools: View Plugin Trace Logs");
-      // Most recent first, and this suite's territory create is the most recent thing to have run.
-      await pickFirst(120000);
+      // Pick OUR plug-in's log, not the first one. A territory create can fire more than one registered
+      // plug-in (an older package from a previous run was still active in the shared org), so "newest
+      // first" is not the same as "ours" — the first attempt captured a different plug-in's trace.
+      await pickByLabel(className, 120000);
       await sleep(3000);
       await dismissOverlays();
-      const rendered = String((await VSBrowser.instance.driver.executeScript("return document.querySelector('.monaco-editor')?.innerText ?? '';")) ?? "");
-      // Prove it is OUR run's trace before publishing the frame: the plug-in's own Trace() text.
-      expect(rendered, `the rendered trace log is from the plug-in we triggered — saw: ${rendered.slice(0, 200)}`).to.contain("Onboarded territory");
+      // Read the DOCUMENT, not the DOM: Monaco renders only the visible lines, so scraping innerText
+      // returned the header plus a column of line numbers while the trace body sat below the fold.
+      // eslint-disable-next-line @typescript-eslint/naming-convention
+      const { TextEditor } = require("vscode-extension-tester");
+      const rendered = await new TextEditor().getText();
       await shot("10-live-trace-log");
+      // TIDY BEFORE ASSERTING. The trace document is an untitled markdown editor, and leaving it active
+      // made the NEXT test ask it for CodeLenses and find none — so a failure here cascaded into a
+      // second, unrelated-looking failure. Cleanup must not depend on the assertions passing.
+      await runCommandResilient("View: Close Editor").catch(() => undefined);
+      await sleep(1500);
+      // Prove it is OUR run's trace before publishing the frame: the plug-in's own Trace() output.
+      expect(rendered, `the trace log is from the plug-in we triggered — saw: ${rendered.slice(0, 200)}`).to.contain("Onboarded territory");
+      expect(rendered, "the trace log names the plug-in type that wrote it").to.contain(typeName);
+      // Put the firehose back — the docs tell users to, and leaving it on costs the shared org.
+      await runCommandResilient("Dataverse PowerTools: Set Plugin Trace Log Level").catch(() => undefined);
+      await pickByLabel("Off", 60000).catch(() => undefined);
       return "opened the trace log for the triggered run (contains the plug-in's own Trace output)";
     });
   });
@@ -804,6 +848,16 @@ describe("DEBUGGING: Plugin — profile capture → replay → execute via panel
       if (triggeredTerritoryId) {
         await client.deleteTerritory(triggeredTerritoryId);
       }
+      // The second trigger, fired with tracing on for the trace-log capture (#231).
+      if (tracedTerritoryId) {
+        await client.deleteTerritory(tracedTerritoryId);
+      }
+    } catch {
+      /* best-effort */
+    }
+    // Never leave the org's trace level on All — it is a shared environment and this is a firehose.
+    try {
+      await client.setTraceLogLevel(0);
     } catch {
       /* best-effort */
     }

--- a/src/ui-test/e2e/webresourceComprehensive.e2e.ts
+++ b/src/ui-test/e2e/webresourceComprehensive.e2e.ts
@@ -19,8 +19,17 @@ import {
   sleep,
   E2EClient,
 } from "./lib";
-import { resetAllCredentials } from "./lib";
-import { signInFreshBrowser, autoLoginWithRetry, bannerOnForm, bannerAfterReload, findDebugPortByProfile, killBrowsersByProfile, killStaleE2EProcesses } from "./browserLib";
+import { resetAllCredentials, shot } from "./lib";
+import {
+  signInFreshBrowser,
+  autoLoginWithRetry,
+  bannerOnForm,
+  bannerAfterReload,
+  findDebugPortByProfile,
+  killBrowsersByProfile,
+  killStaleE2EProcesses,
+  captureBrowserShot,
+} from "./browserLib";
 import { resolveBrowser } from "../../webresources/debug/browserResolver";
 
 // COMPREHENSIVE end-to-end webresource journey — every step driven through the REAL VS Code UI,
@@ -282,6 +291,11 @@ describe("Web resources — comprehensive UI lifecycle (e2e)", function () {
     log(`local banner on first load: ${first}`);
     await expectOutput("[debug] served local", { timeoutMs: 60000, step: "debug serve local" });
     expect(first, "local bundle served onto the form").to.contain(loadedBanner);
+    // #231: the live-app half of the hot-reload story. A screenshot of the FORM showing the banner your
+    // local build produced is the only thing that demonstrates "served into the real app" — the editor
+    // side cannot show it.
+    await captureBrowserShot(port, "webresource-hot-1-form-serving-local-build");
+    await shot("webresource-hot-2-editor-serving");
 
     // ---- Breakpoint hit (#114): set a breakpoint in OnLoad via the UI, assert
     // it binds (filled dot, not the hollow unverified one), let the hot reload
@@ -339,6 +353,9 @@ describe("Web resources — comprehensive UI lifecycle (e2e)", function () {
     const after = await bannerAfterReload(port, [loadedBanner, reloadBanner], reloadBanner);
     log(`banner after edit: ${after}`);
     expect(after, "form hot-reloaded to the edited banner").to.contain(reloadBanner);
+    // The same form after editing the source: same page, new value, no redeploy. Paired with the frame
+    // above this is the before/after a split-screen recording would show.
+    await captureBrowserShot(port, "webresource-hot-3-form-after-edit");
 
     await clearOutput();
     await runCommand("Dataverse PowerTools: Stop Debugging Web Resources");

--- a/src/ui-test/e2e/webresourceComprehensive.e2e.ts
+++ b/src/ui-test/e2e/webresourceComprehensive.e2e.ts
@@ -19,7 +19,7 @@ import {
   sleep,
   E2EClient,
 } from "./lib";
-import { resetAllCredentials, shot, useHalfWidthWindow, SIDE_BY_SIDE_HALF } from "./lib";
+import { resetAllCredentials, shot, shotEditorHalf, SIDE_BY_SIDE_HALF } from "./lib";
 import {
   signInFreshBrowser,
   autoLoginWithRetry,
@@ -298,8 +298,7 @@ describe("Web resources — comprehensive UI lifecycle (e2e)", function () {
     // HALF-WIDTH pair: the editor and the app are each captured at half the screen, so composeSideBySide
     // stitches them into something that reads as ONE screen rather than two full ones jammed together.
     // Only the hot-reload story needs this — a single-surface step is clearer as one full-width frame.
-    const restoreWindow = await useHalfWidthWindow();
-    await shot("webresource-hot-1-editor-half");
+    await shotEditorHalf("webresource-hot-1-editor-half");
     await captureBrowserShot(port, "webresource-hot-2-form-serving-local-build", SIDE_BY_SIDE_HALF);
 
     // ---- Breakpoint hit (#114): set a breakpoint in OnLoad via the UI, assert
@@ -360,9 +359,8 @@ describe("Web resources — comprehensive UI lifecycle (e2e)", function () {
     expect(after, "form hot-reloaded to the edited banner").to.contain(reloadBanner);
     // The same form after editing the source: same page, new value, no redeploy. Paired with the frame
     // above this is the before/after a split-screen recording would show.
-    await shot("webresource-hot-3-editor-after-edit");
+    await shotEditorHalf("webresource-hot-3-editor-after-edit");
     await captureBrowserShot(port, "webresource-hot-4-form-after-edit", SIDE_BY_SIDE_HALF);
-    await restoreWindow();
 
     await clearOutput();
     await runCommand("Dataverse PowerTools: Stop Debugging Web Resources");

--- a/src/ui-test/e2e/webresourceComprehensive.e2e.ts
+++ b/src/ui-test/e2e/webresourceComprehensive.e2e.ts
@@ -19,7 +19,7 @@ import {
   sleep,
   E2EClient,
 } from "./lib";
-import { resetAllCredentials, shot } from "./lib";
+import { resetAllCredentials, shot, useHalfWidthWindow, SIDE_BY_SIDE_HALF } from "./lib";
 import {
   signInFreshBrowser,
   autoLoginWithRetry,
@@ -294,8 +294,13 @@ describe("Web resources — comprehensive UI lifecycle (e2e)", function () {
     // #231: the live-app half of the hot-reload story. A screenshot of the FORM showing the banner your
     // local build produced is the only thing that demonstrates "served into the real app" — the editor
     // side cannot show it.
-    await captureBrowserShot(port, "webresource-hot-1-form-serving-local-build");
-    await shot("webresource-hot-2-editor-serving");
+    //
+    // HALF-WIDTH pair: the editor and the app are each captured at half the screen, so composeSideBySide
+    // stitches them into something that reads as ONE screen rather than two full ones jammed together.
+    // Only the hot-reload story needs this — a single-surface step is clearer as one full-width frame.
+    const restoreWindow = await useHalfWidthWindow();
+    await shot("webresource-hot-1-editor-half");
+    await captureBrowserShot(port, "webresource-hot-2-form-serving-local-build", SIDE_BY_SIDE_HALF);
 
     // ---- Breakpoint hit (#114): set a breakpoint in OnLoad via the UI, assert
     // it binds (filled dot, not the hollow unverified one), let the hot reload
@@ -355,7 +360,9 @@ describe("Web resources — comprehensive UI lifecycle (e2e)", function () {
     expect(after, "form hot-reloaded to the edited banner").to.contain(reloadBanner);
     // The same form after editing the source: same page, new value, no redeploy. Paired with the frame
     // above this is the before/after a split-screen recording would show.
-    await captureBrowserShot(port, "webresource-hot-3-form-after-edit");
+    await shot("webresource-hot-3-editor-after-edit");
+    await captureBrowserShot(port, "webresource-hot-4-form-after-edit", SIDE_BY_SIDE_HALF);
+    await restoreWindow();
 
     await clearOutput();
     await runCommand("Dataverse PowerTools: Stop Debugging Web Resources");


### PR DESCRIPTION
## 1.0.5 — three fixes you would hit the first time you used these features properly

### Regenerating a Custom API handler destroyed your implementation (#254)

The handler was one file holding both the generated wrappers and the `Execute` method you fill in, and
regenerating rewrote all of it. Changing the definition and regenerating is the entire premise of
definition-as-code, so it cost you your code every time.

Split in two: `<Class>.generated.cs` (wrappers, always refreshed, says so at the top) and `<Class>.cs`
(your implementation, **written once, never overwritten**). A pre-split file still holds an `Execute`, so
overwriting it would be the very loss this prevents — that case is detected and refused with
instructions.

### PCF "Add to Solution" demanded a Solution project (#256)

It required a `.cdsproj` in the workspace and did nothing without one. No other component type asks for
that: a web resource (component type 61) and a plug-in step (92) go into the solution named in the
connection settings over the Web API. PCF now does the same with type 66, and still adds the project
reference when a `.cdsproj` exists so packing keeps working.

### Trace logs prompted to save on close

They opened as untitled documents, which VS Code counts as unsaved. Read-only virtual documents now.

## What is actually verified

Everything below ran against a live environment, not a mock.

**Custom API — 8 passing.** Define, generate handler + client, deploy the package, deploy the API, then
CALL it and check the response:

```
Created CustomAPI 'dvpt_Echo821306'.
Parameters: +2 ~0 -0; Response: +1 ~0 -0.
POST dvpt_Echo821306 → {"OutputValue":"echo: ping"}
```

Then it EDITS the definition and deploys again, covering the update and delete arms that had only ever
run against a mock — `Parameters: +0 ~1 -1`, with the removed parameter confirmed gone from Dataverse and
the API row updated in place rather than recreated. And it proves #254: write an implementation, add a
parameter, regenerate — wrappers refresh, implementation untouched.

**PCF under interactive auth (#227)** — the suite #141 closed by argument rather than by test. Two things
only a live run could show:

* `pac auth create` under interactive auth uses the DEVICE CODE flow — it prints a code and blocks. The
  suite reads pac's own code from the log and completes the sign-in in a browser with the MFA-exempt
  account, so the one genuinely un-automatable step is automated.
* Dataverse stores a control PREFIXED with the publisher's prefix (`dvpt_SampleNamespace.SampleControl`),
  so `name eq '<namespace>.<constructor>'` never matches. That wrong assumption was in the product AND
  the test client, so they agreed with each other and were both wrong — a successful push read as "not in
  the environment".

**Docs (#231, #233).** Five live captures produced and published — the paused breakpoint, a
live-triggered trace log, and the web-resource hot reload as side-by-side pairs (editor and live form at
half the screen each, stitched into one). Five new wiki pages. Redaction is off by default now that the
test org is confirmed disposable.

## Notes

* 1145 unit tests, 22 integration tests, lint and webpack clean.
* The PCF live-form capture is deliberately not produced: the probe control is deployed but not placed on
  any form, and adding it to a shared org's form purely for a screenshot was not worth it. Recorded on
  #231 with what it would take.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
