### PR TITLE
Fix a live-test flake that impersonates a product bug, and make the browser harness run off Windows

### DIFF
--- a/package.json
+++ b/package.json
@@ -869,6 +869,14 @@
           "type": "string",
           "default": "",
           "markdownDescription": "Optional full path to the Edge/Chrome executable used by **Debug Web Resources**. Leave blank to auto-detect a supported browser."
+        },
+        "dataverse-powertools.debugBrowserArgs": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "default": [],
+          "markdownDescription": "Extra command-line flags passed to the browser launched by **Debug Web Resources** and **Debug on live form**.\n\nMainly for Linux: Ubuntu 23.10+ restricts unprivileged user namespaces via AppArmor, so Chromium's sandbox cannot start and the browser exits with `No usable sandbox!` before the debugger can attach. Setting `[\"--no-sandbox\", \"--disable-dev-shm-usage\"]` works around it.\n\nNot a default, deliberately — `--no-sandbox` disables a real security boundary on a browser signed in to your Dataverse environment, and most machines don't need it."
         }
       }
     }

--- a/src/pcf/debug/debugPcfLiveForm.ts
+++ b/src/pcf/debug/debugPcfLiveForm.ts
@@ -96,6 +96,7 @@ export async function debugPcfLiveForm(context: DataversePowerToolsContext): Pro
   const settings = vscode.workspace.getConfiguration("dataverse-powertools");
   const prefer = (settings.get<string>("debugBrowser") || "auto") as BrowserPreference;
   const overridePath = settings.get<string>("debugBrowserPath") || undefined;
+  const extraArgs = settings.get<string[]>("debugBrowserArgs") || [];
   let browser;
   try {
     browser = resolveBrowser(prefer, overridePath, { platform: process.platform, env: process.env, exists: fs.existsSync });
@@ -149,7 +150,7 @@ export async function debugPcfLiveForm(context: DataversePowerToolsContext): Pro
     const port = await findFreePort();
 
     // 4. Launch on about:blank; navigate only after interception is armed (avoids a reload race).
-    browserProc = cp.spawn(browser.executablePath, buildBrowserArgs({ port, userDataDir, url: "about:blank" }), { detached: false, stdio: "ignore" });
+    browserProc = cp.spawn(browser.executablePath, buildBrowserArgs({ port, userDataDir, url: "about:blank", extraArgs }), { detached: false, stdio: "ignore" });
     browserProc.on("exit", () => void stopPcfLiveDebug());
 
     // 5. Connect CDP, bypass the service worker (#64), intercept the deployed control's bundle.

--- a/src/ui-test/e2e/browserLib.ts
+++ b/src/ui-test/e2e/browserLib.ts
@@ -49,6 +49,13 @@ export async function launchBrowser(exePath: string, profileDir: string, url: st
       `--user-data-dir=${profileDir}`,
       "--no-first-run",
       "--no-default-browser-check",
+      // Linux CI/VM only. Ubuntu 24.04 restricts unprivileged user namespaces via AppArmor, so
+      // Chromium's zygote sandbox cannot start and the process dies immediately with
+      // "No usable sandbox!" before CDP ever listens. Browser-automation frameworks inject these
+      // for their users; we spawn the binary directly, so we must. Scoped to this harness ON PURPOSE — it is
+      // excluded from the VSIX, so weakening the sandbox here never reaches a real user. The
+      // shipped Debug Web Resources flow (webresources/debug/browserArgs.ts) must NOT copy this.
+      ...(process.platform === "linux" ? ["--no-sandbox", "--disable-dev-shm-usage"] : []),
       // Prevent background-tab throttling: under ExTester the VS Code window has focus, so this Edge
       // is backgrounded and Chromium throttles its timers — which stalls AAD's sign-in transition.
       "--disable-background-timer-throttling",
@@ -90,19 +97,25 @@ export async function launchBrowser(exePath: string, profileDir: string, url: st
  *  reparented child processes that `child.kill()` on the launcher shim misses. Used to fully tear
  *  down step 7's browser before step 8 launches the debug browser: a lingering Edge instance makes
  *  the new launch delegate to it, so the port-bearing process exits and the debug port can't be
- *  found. Windows-only (this harness runs on the Windows VM). */
+ *  found. */
 export function killBrowsersByProfile(profileMatch: string): void {
   try {
-    cp.execFileSync(
-      "powershell",
-      [
-        "-NoProfile",
-        "-NonInteractive",
-        "-Command",
-        `Get-CimInstance Win32_Process -Filter "Name='msedge.exe' OR Name='chrome.exe'" | Where-Object { $_.CommandLine -like "*$env:DVPT_KP*" } | ForEach-Object { Stop-Process -Id $_.ProcessId -Force -ErrorAction SilentlyContinue }`,
-      ],
-      { env: { ...process.env, DVPT_KP: profileMatch }, encoding: "utf8" },
-    );
+    if (process.platform === "win32") {
+      cp.execFileSync(
+        "powershell",
+        [
+          "-NoProfile",
+          "-NonInteractive",
+          "-Command",
+          `Get-CimInstance Win32_Process -Filter "Name='msedge.exe' OR Name='chrome.exe'" | Where-Object { $_.CommandLine -like "*$env:DVPT_KP*" } | ForEach-Object { Stop-Process -Id $_.ProcessId -Force -ErrorAction SilentlyContinue }`,
+        ],
+        { env: { ...process.env, DVPT_KP: profileMatch }, encoding: "utf8" },
+      );
+      return;
+    }
+    // pkill -f matches against the full command line, the same thing the CIM filter inspects.
+    // Exit status 1 just means "nothing matched", which execFileSync raises — hence best-effort.
+    cp.execFileSync("pkill", ["-f", profileMatch], { encoding: "utf8" });
   } catch {
     /* best effort */
   }
@@ -113,25 +126,40 @@ export function killBrowsersByProfile(profileMatch: string): void {
  * 8GB VM this matters: a debug session that dies before teardown orphans its `node webpack --watch`
  * (kept rebuilding, ~100-300MB each) and its Edge browser, and enough of them accumulated across runs
  * will starve VS Code's Electron host mid-suite (seen as ECONNREFUSED to the webdriver, run 13). This
- * is best-effort and Windows-only (the e2e only runs on the Windows VM).
+ * is best-effort.
  */
 export function killStaleE2EProcesses(): void {
-  try {
-    cp.execFileSync(
-      "powershell",
-      [
-        "-NoProfile",
-        "-NonInteractive",
-        "-Command",
-        // Orphan webpack --watch node processes from prior debug sessions...
-        "Get-CimInstance Win32_Process -Filter \"Name='node.exe'\" | Where-Object { $_.CommandLine -match 'webpack' } | ForEach-Object { Stop-Process -Id $_.ProcessId -Force -ErrorAction SilentlyContinue };" +
-          // ...and orphan debug/verify browsers spawned under our e2e profile dirs.
-          "Get-CimInstance Win32_Process -Filter \"Name='msedge.exe' OR Name='chrome.exe'\" | Where-Object { $_.CommandLine -match 'dvpt-e2e-browser|webresource-debug-profile' } | ForEach-Object { Stop-Process -Id $_.ProcessId -Force -ErrorAction SilentlyContinue }",
-      ],
-      { encoding: "utf8" },
-    );
-  } catch {
-    /* best effort */
+  if (process.platform === "win32") {
+    try {
+      cp.execFileSync(
+        "powershell",
+        [
+          "-NoProfile",
+          "-NonInteractive",
+          "-Command",
+          // Orphan webpack --watch node processes from prior debug sessions...
+          "Get-CimInstance Win32_Process -Filter \"Name='node.exe'\" | Where-Object { $_.CommandLine -match 'webpack' } | ForEach-Object { Stop-Process -Id $_.ProcessId -Force -ErrorAction SilentlyContinue };" +
+            // ...and orphan debug/verify browsers spawned under our e2e profile dirs.
+            "Get-CimInstance Win32_Process -Filter \"Name='msedge.exe' OR Name='chrome.exe'\" | Where-Object { $_.CommandLine -match 'dvpt-e2e-browser|webresource-debug-profile' } | ForEach-Object { Stop-Process -Id $_.ProcessId -Force -ErrorAction SilentlyContinue }",
+        ],
+        { encoding: "utf8" },
+      );
+    } catch {
+      /* best effort */
+    }
+    return;
+  }
+  // Same two targets via pkill -f (extended regex over the full command line). `node.*webpack`
+  // rather than bare `webpack` on purpose — it mirrors the Windows filter's Name='node.exe' clause,
+  // and an unanchored `webpack` here would also match a developer's own build running on the box.
+  // Kept as separate calls so a no-match on the first (exit 1, which execFileSync throws on)
+  // doesn't skip the second.
+  for (const pattern of ["node.*webpack", "dvpt-e2e-browser|webresource-debug-profile"]) {
+    try {
+      cp.execFileSync("pkill", ["-f", pattern], { encoding: "utf8" });
+    } catch {
+      /* best effort — nothing matched */
+    }
   }
 }
 
@@ -161,6 +189,35 @@ function httpGetJson(port: number, pathname: string, timeoutMs = 1000): Promise<
  *  System32, so a bare "netstat" throws ENOENT and finds nothing. */
 function listeningPorts(): number[] {
   const ports = new Set<number>();
+  if (process.platform !== "win32") {
+    // `ss` on modern Linux, `netstat -an` as the fallback. Every :<port> on a LISTEN line is
+    // collected rather than pinned to a specific local-address form — addresses appear as
+    // 0.0.0.0, [::], 127.0.0.53%lo and more, and a regex tight enough to enumerate them silently
+    // drops ports. Callers probe each candidate over HTTP and discard the non-CDP ones, so a false
+    // positive costs one fast failed request while a false negative loses the browser entirely.
+    for (const [exe, args] of [
+      ["ss", ["-ltn"]],
+      ["netstat", ["-an"]],
+    ] as [string, string[]][]) {
+      try {
+        const out = cp.execFileSync(exe, args, { encoding: "utf8", maxBuffer: 1024 * 1024 * 8 });
+        for (const line of out.split("\n")) {
+          if (!/LISTEN/.test(line)) {
+            continue;
+          }
+          for (const m of line.matchAll(/:(\d+)\b/g)) {
+            ports.add(Number(m[1]));
+          }
+        }
+        if (ports.size > 0) {
+          break;
+        }
+      } catch {
+        /* try the next candidate */
+      }
+    }
+    return [...ports];
+  }
   const sysRoot = process.env.SystemRoot || process.env.windir || "C:\\Windows";
   for (const exe of [`${sysRoot}\\System32\\netstat.exe`, "netstat"]) {
     try {

--- a/src/webresources/debug/browserArgs.spec.ts
+++ b/src/webresources/debug/browserArgs.spec.ts
@@ -24,4 +24,21 @@ describe("buildBrowserArgs", () => {
     // Anti-throttling flags keep the backgrounded app/hot-reload live behind VS Code.
     expect(args).toContain("--disable-background-timer-throttling");
   });
+
+  // `dataverse-powertools.debugBrowserArgs` — the opt-in escape hatch for browsers that need a
+  // flag we refuse to ship as a default (the Ubuntu 23.10+ AppArmor "No usable sandbox!" case).
+  it("appends extraArgs, still before the url", () => {
+    const args = buildBrowserArgs({ port: 1, userDataDir: "/tmp/p", url: "https://x", extraArgs: ["--no-sandbox", "--disable-dev-shm-usage"] });
+    expect(args[args.length - 1]).toBe("https://x");
+    expect(args).toContain("--no-sandbox");
+    // Chromium takes the first non-flag argument as the page to open, so every user flag must
+    // land ahead of the URL or it would be swallowed as a second page.
+    expect(args.indexOf("--no-sandbox")).toBeLessThan(args.indexOf("https://x"));
+  });
+
+  it("sends no sandbox-weakening flag by default, on any platform", () => {
+    const args = buildBrowserArgs({ port: 1, userDataDir: "/tmp/p", url: "https://x" });
+    expect(args).not.toContain("--no-sandbox");
+    expect(args).not.toContain("--disable-dev-shm-usage");
+  });
 });

--- a/src/webresources/debug/browserArgs.ts
+++ b/src/webresources/debug/browserArgs.ts
@@ -8,6 +8,16 @@ export interface BrowserLaunchOptions {
   userDataDir: string;
   /** Initial URL to open (the org). */
   url: string;
+  /**
+   * Extra Chromium flags from `dataverse-powertools.debugBrowserArgs`. An escape hatch for
+   * environments whose browser needs a flag we deliberately don't ship as a default — the
+   * motivating case is Ubuntu 23.10+/24.04, which restricts unprivileged user namespaces via
+   * AppArmor so Chromium's sandbox can't start ("No usable sandbox!") and the process dies
+   * before CDP listens; `--no-sandbox` fixes it there. That is NOT a default: it would weaken
+   * the sandbox for every Linux user, including the majority who aren't affected, on a browser
+   * pointed at their live org. Opt in per machine instead.
+   */
+  extraArgs?: string[];
 }
 
 /**
@@ -27,6 +37,9 @@ export function buildBrowserArgs(options: BrowserLaunchOptions): string[] {
     "--disable-background-timer-throttling",
     "--disable-backgrounding-occluded-windows",
     "--disable-renderer-backgrounding",
+    // User flags go after ours so they can override an earlier one, but before the URL —
+    // Chromium treats the first non-flag argument as the page to open.
+    ...(options.extraArgs ?? []),
     "--new-window",
     options.url,
   ];

--- a/src/webresources/debug/debugWebresources.ts
+++ b/src/webresources/debug/debugWebresources.ts
@@ -81,6 +81,7 @@ export async function debugWebResources(context: DataversePowerToolsContext): Pr
   const settings = vscode.workspace.getConfiguration("dataverse-powertools");
   const prefer = (settings.get<string>("debugBrowser") || "auto") as BrowserPreference;
   const overridePath = settings.get<string>("debugBrowserPath") || undefined;
+  const extraArgs = settings.get<string[]>("debugBrowserArgs") || [];
 
   let browser;
   try {
@@ -144,7 +145,7 @@ export async function debugWebResources(context: DataversePowerToolsContext): Pr
     //    after interception is fully armed (step 5). Launching straight at the
     //    org forced a reload after arming, and that reload raced the app's
     //    boot, occasionally wedging the first load (user report).
-    browserProc = cp.spawn(browser.executablePath, buildBrowserArgs({ port, userDataDir, url: "about:blank" }), {
+    browserProc = cp.spawn(browser.executablePath, buildBrowserArgs({ port, userDataDir, url: "about:blank", extraArgs }), {
       detached: false,
       stdio: "ignore",
     });

--- a/test/live/browserAutoLogin.ts
+++ b/test/live/browserAutoLogin.ts
@@ -53,23 +53,47 @@ export async function readDevToolsPort(profileDir: string, timeoutMs = 25000): P
   }
 }
 
-/**
- * Discover the remote-debugging port of the browser launched with `--user-data-dir=profileDir`.
- * Chromium only writes `DevToolsActivePort` when the port is 0 (auto-picked); when a launcher
- * passes an explicit port (as Debug Web Resources does), read it from the process command line.
- * Windows-only (this harness runs on the Windows VM), via PowerShell/CIM.
- */
-export async function findDebugPortByProfile(profileDir: string, timeoutMs = 25000): Promise<number> {
+/** Windows: query the command line through CIM. */
+function debugPortFromCimSnapshot(profileDir: string): number {
   const script =
     `$p=$env:DVPT_PROFILE; ` +
     `$proc = Get-CimInstance Win32_Process -Filter "Name='msedge.exe' OR Name='chrome.exe'" | ` +
     `Where-Object { $_.CommandLine -like "*$p*" -and $_.CommandLine -like '*remote-debugging-port=*' } | Select-Object -First 1; ` +
     `if ($proc -and $proc.CommandLine -match 'remote-debugging-port=(\\d+)') { $matches[1] }`;
+  const out = cp.execFileSync("powershell", ["-NoProfile", "-NonInteractive", "-Command", script], { env: { ...process.env, DVPT_PROFILE: profileDir }, encoding: "utf8" }).trim();
+  return Number(out);
+}
+
+/**
+ * macOS/Linux: same question, asked of `ps`. `-ww` forces unlimited-width output: attached to a
+ * terminal ps truncates each command line to the window width, and a Chromium command line is
+ * long enough that the `--remote-debugging-port=` we want can fall off the end.
+ */
+function debugPortFromPsSnapshot(profileDir: string): number {
+  const out = cp.execFileSync("ps", ["-Aww", "-o", "args="], { encoding: "utf8" });
+  for (const line of out.split("\n")) {
+    if (!line.includes(profileDir)) {
+      continue;
+    }
+    const m = /--remote-debugging-port=(\d+)/.exec(line);
+    if (m) {
+      return Number(m[1]);
+    }
+  }
+  return 0;
+}
+
+/**
+ * Discover the remote-debugging port of the browser launched with `--user-data-dir=profileDir`.
+ * Chromium only writes `DevToolsActivePort` when the port is 0 (auto-picked); when a launcher
+ * passes an explicit port (as Debug Web Resources does), read it from the process command line.
+ */
+export async function findDebugPortByProfile(profileDir: string, timeoutMs = 25000): Promise<number> {
+  const snapshot = process.platform === "win32" ? debugPortFromCimSnapshot : debugPortFromPsSnapshot;
   const deadline = Date.now() + timeoutMs;
   for (;;) {
     try {
-      const out = cp.execFileSync("powershell", ["-NoProfile", "-NonInteractive", "-Command", script], { env: { ...process.env, DVPT_PROFILE: profileDir }, encoding: "utf8" }).trim();
-      const port = Number(out);
+      const port = snapshot(profileDir);
       if (port > 0) {
         return port;
       }

--- a/test/live/debugBrowsersMatrix.spec.ts
+++ b/test/live/debugBrowsersMatrix.spec.ts
@@ -11,7 +11,8 @@ import { DataverseWebresource } from "../../src/general/dataverse/DataverseWebre
 import { DataverseForm } from "../../src/general/dataverse/DataverseForm";
 import { debugWebResources, stopDebugWebResources } from "../../src/webresources/debug/debugWebresources";
 import { preAuthenticateProfile, autoLoginBrowser, findDebugPortByProfile } from "./browserAutoLogin";
-import { resolveBrowser } from "../../src/webresources/debug/browserResolver";
+import { BrowserPreference } from "../../src/webresources/debug/browserResolver";
+import { resolveTestBrowser, testBrowserArgs } from "./testBrowser";
 import DataversePowerToolsContext from "../../src/context";
 
 // Unattended #64 coverage across BOTH browsers using the interactive test user.
@@ -215,7 +216,14 @@ suite("Debug Web Resources — Edge + Chrome unattended (#64)", () => {
     it(
       `serves LOCAL into a real form and hot-reloads on ${browser}`,
       async () => {
-        (vscode.workspace as unknown as { getConfiguration: () => unknown }).getConfiguration = () => ({ get: (k: string) => (k === "debugBrowser" ? browser : undefined), update: () => undefined });
+        // Feed the real command the same browser the harness resolved, plus this platform's extra
+        // flags — DVPT_TEST_BROWSER_PATH may point at a Chromium that install-path probing cannot
+        // find, and Linux needs --no-sandbox that the product rightly does not default on.
+        (vscode.workspace as unknown as { getConfiguration: () => unknown }).getConfiguration = () => ({
+          get: (k: string) =>
+            k === "debugBrowser" ? browser : k === "debugBrowserPath" ? resolveTestBrowser(browser as BrowserPreference)?.executablePath : k === "debugBrowserArgs" ? testBrowserArgs() : undefined,
+          update: () => undefined,
+        });
         const workspacePath = path.join(tmpRoot, browser, "workspace");
         const binDir = path.join(workspacePath, "bin");
         const bundlePath = path.join(binDir, BUNDLE);
@@ -228,9 +236,10 @@ suite("Debug Web Resources — Edge + Chrome unattended (#64)", () => {
 
         // Sign the profile in first (clean browser, no interception attached) so the debug
         // session opens already authenticated — like a real developer's persistent profile.
-        const resolved = resolveBrowser(browser, undefined, { platform: process.platform, env: process.env, exists: fs.existsSync });
+        const resolved = resolveTestBrowser(browser as BrowserPreference);
+        expect(resolved, `no browser available for ${browser}`).toBeTruthy();
         log(`[${browser}] pre-authenticating the debug profile with the interactive test user`);
-        const authed = await preAuthenticateProfile(resolved.executablePath, profileDir, e.url, { username: u.username, password: u.password, orgHost, log });
+        const authed = await preAuthenticateProfile(resolved!.executablePath, profileDir, e.url, { username: u.username, password: u.password, orgHost, log });
         expect(authed, `pre-auth failed on ${browser}`).toBe(true);
 
         const ctx = makeContext(e.url, client.accessToken, workspacePath, globalStorage, browser);

--- a/test/live/interactiveConnect.spec.ts
+++ b/test/live/interactiveConnect.spec.ts
@@ -8,6 +8,7 @@ import * as cp from "child_process";
 import * as vscode from "vscode"; // aliased to test/vscode.mock.ts
 import CDP = require("chrome-remote-interface");
 import { loadLiveEnv, loadInteractiveTestUser, LiveEnv } from "../liveEnv";
+import { resolveTestBrowser, testBrowserArgs } from "./testBrowser";
 import { LiveDataverseClient } from "./dataverseClient";
 import { DataverseWebresource } from "../../src/general/dataverse/DataverseWebresource";
 import { acquireInteractiveToken } from "../../src/general/dataverse/tokenAcquisition";
@@ -21,10 +22,13 @@ import DataversePowerToolsContext from "../../src/context";
 //   DVPT_DEBUG_DEMO=1 npm run test:live -- test/live/interactiveConnect.spec.ts
 const env = loadLiveEnv();
 const user = loadInteractiveTestUser();
-const enabled = !!env && !!user && process.env.DVPT_DEBUG_DEMO === "1";
+// Resolved, not hard-coded: this used to pin the Windows Edge install path, which made the
+// interactive (OAuth) coverage Windows-only even though the auth code under test is not.
+const TEST_BROWSER = resolveTestBrowser();
+// Gated on a real browser too — without one this suite would spawn undefined and fail with an
+// ENOENT that says nothing about auth.
+const enabled = !!env && !!user && !!TEST_BROWSER && process.env.DVPT_DEBUG_DEMO === "1";
 const suite = enabled ? describe : describe.skip;
-
-const EDGE = "C:\\Program Files (x86)\\Microsoft\\Edge\\Application\\msedge.exe";
 const sleep = (ms: number): Promise<void> => new Promise((r) => setTimeout(r, ms));
 const log = (m: string): void => {
   // eslint-disable-next-line no-console
@@ -64,7 +68,11 @@ async function driveMsalLogin(authUrl: string, u: { username: string; password: 
   fs.rmSync(profile, { recursive: true, force: true });
   fs.mkdirSync(profile, { recursive: true });
   const port = await freePort();
-  const child = cp.spawn(EDGE, [`--remote-debugging-port=${port}`, `--user-data-dir=${profile}`, "--no-first-run", "--no-default-browser-check", "--new-window", authUrl], { stdio: "ignore" });
+  const child = cp.spawn(
+    TEST_BROWSER!.executablePath,
+    [`--remote-debugging-port=${port}`, `--user-data-dir=${profile}`, "--no-first-run", "--no-default-browser-check", ...testBrowserArgs(), "--new-window", authUrl],
+    { stdio: "ignore" },
+  );
   try {
     let client: CDP.Client | undefined;
     for (let i = 0; i < 40 && !client; i++) {

--- a/test/live/pcfLiveFormDebug.spec.ts
+++ b/test/live/pcfLiveFormDebug.spec.ts
@@ -7,7 +7,7 @@ import * as cp from "child_process";
 import CDP = require("chrome-remote-interface");
 import { loadLiveEnv, liveOrgUrl } from "../liveEnv";
 import { isPcfBundleUrl, pcfBundleCdpPattern, pcfBundleContentType } from "../../src/pcf/debug/pcfBundleUrl";
-import { resolveBrowser } from "../../src/webresources/debug/browserResolver";
+import { resolveTestBrowser, testBrowserArgs } from "./testBrowser";
 import { buildBrowserArgs } from "../../src/webresources/debug/browserArgs";
 
 // LIVE e2e for the PCF "Debug on live form (hot)" feature (#141 #5): prove the extension's CDP
@@ -19,12 +19,7 @@ import { buildBrowserArgs } from "../../src/webresources/debug/browserArgs";
 // Self-skips without creds or a browser. Mirrors the manual proof used to land 0.14.33/0.14.34.
 
 const env = loadLiveEnv();
-let browserPath: string | undefined;
-try {
-  browserPath = env ? resolveBrowser("auto", undefined, { platform: process.platform, env: process.env, exists: fs.existsSync }).executablePath : undefined;
-} catch {
-  browserPath = undefined;
-}
+const browserPath = env ? resolveTestBrowser()?.executablePath : undefined;
 
 const NS = "DvptE2E";
 const CTOR = "DebugProbe";
@@ -78,7 +73,7 @@ gate("PCF live-form debug — interception serves the local bundle (live)", () =
     const userDataDir = path.join(tmpDir, "profile");
     fs.mkdirSync(userDataDir, { recursive: true });
     const port = await freePort();
-    browserProc = cp.spawn(browserPath!, [...buildBrowserArgs({ port, userDataDir, url: "about:blank" }), "--headless=new"], { stdio: "ignore" });
+    browserProc = cp.spawn(browserPath!, [...buildBrowserArgs({ port, userDataDir, url: "about:blank", extraArgs: testBrowserArgs() }), "--headless=new"], { stdio: "ignore" });
 
     const client = await (async () => {
       const deadline = Date.now() + 20000;

--- a/test/live/preAcquireInteractiveCache.mjs
+++ b/test/live/preAcquireInteractiveCache.mjs
@@ -10,17 +10,42 @@ import * as path from "path";
 import * as net from "net";
 import * as cp from "child_process";
 import { createRequire } from "module";
-const require = createRequire("file:///C:/Users/Peter/sources/repos/dataverse-powertools/index.js");
+import { fileURLToPath } from "url";
+const require = createRequire(import.meta.url);
+const HERE = path.dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = path.resolve(HERE, "..", "..");
 const { PublicClientApplication } = require("@azure/msal-node");
 const CDP = require("chrome-remote-interface");
 
 const CLIENT_ID = "51f81489-12ee-4a9e-aaae-a2591f45987d"; // == DEFAULT_INTERACTIVE_CLIENT_ID
 const AUTHORITY = "https://login.microsoftonline.com/organizations";
-const EDGE = "C:\\Program Files (x86)\\Microsoft\\Edge\\Application\\msedge.exe";
+// Browser resolution mirrors src/webresources/debug/browserResolver.ts. It is duplicated rather
+// than imported because this is a standalone .mjs run by scripts/runE2E.mjs, and test/ is outside
+// the tsconfig scope so there is no compiled copy to import. DVPT_TEST_BROWSER_PATH wins: a
+// headless Linux box often has no system browser, only one fetched by another tool at a
+// version-stamped path that cannot be discovered by probing.
+const BROWSER_CANDIDATES = {
+  win32: [
+    "C:\\Program Files (x86)\\Microsoft\\Edge\\Application\\msedge.exe",
+    "C:\\Program Files\\Microsoft\\Edge\\Application\\msedge.exe",
+    "C:\\Program Files\\Google\\Chrome\\Application\\chrome.exe",
+  ],
+  darwin: ["/Applications/Microsoft Edge.app/Contents/MacOS/Microsoft Edge", "/Applications/Google Chrome.app/Contents/MacOS/Google Chrome"],
+  linux: ["/usr/bin/microsoft-edge", "/usr/bin/microsoft-edge-stable", "/opt/microsoft/msedge/msedge", "/usr/bin/google-chrome", "/usr/bin/google-chrome-stable", "/usr/bin/chromium", "/usr/bin/chromium-browser"],
+};
+function resolveBrowserPath() {
+  if (process.env.DVPT_TEST_BROWSER_PATH) return process.env.DVPT_TEST_BROWSER_PATH;
+  const found = (BROWSER_CANDIDATES[process.platform] || BROWSER_CANDIDATES.linux).find((c) => fs.existsSync(c));
+  if (!found) throw new Error("No Edge/Chrome/Chromium found. Set DVPT_TEST_BROWSER_PATH to a Chromium executable.");
+  return found;
+}
+// Ubuntu 23.10+ blocks Chromium's sandbox via its unprivileged-userns AppArmor restriction; without
+// these the browser dies with "No usable sandbox!" before its CDP port ever listens.
+const BROWSER_EXTRA_ARGS = process.platform === "linux" ? ["--no-sandbox", "--disable-dev-shm-usage"] : [];
 const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
 
 function env() {
-  const t = fs.readFileSync("C:/Users/Peter/sources/repos/dataverse-powertools/sandbox/.env", "utf8");
+  const t = fs.readFileSync(path.join(REPO_ROOT, "sandbox", ".env"), "utf8");
   const e = {};
   for (const l of t.split(/\r?\n/)) { const m = l.match(/^\s*([A-Z0-9_]+)\s*=\s*(.*)\s*$/); if (m) e[m[1]] = m[2]; }
   return e;
@@ -32,7 +57,7 @@ async function driveMsalLogin(authUrl, USER, PASS) {
   const profile = path.join(os.tmpdir(), "dvpt-preacquire-login");
   fs.rmSync(profile, { recursive: true, force: true }); fs.mkdirSync(profile, { recursive: true });
   const port = await freePort();
-  const child = cp.spawn(EDGE, [`--remote-debugging-port=${port}`, `--user-data-dir=${profile}`, "--no-first-run", "--no-default-browser-check", "--new-window", authUrl], { stdio: "ignore" });
+  const child = cp.spawn(resolveBrowserPath(), [`--remote-debugging-port=${port}`, `--user-data-dir=${profile}`, "--no-first-run", "--no-default-browser-check", ...BROWSER_EXTRA_ARGS, "--new-window", authUrl], { stdio: "ignore" });
   try {
     let client; for (let i = 0; i < 40 && !client; i++) { try { client = await CDP({ port }); } catch { await sleep(400); } }
     const { Runtime } = client; await Runtime.enable();

--- a/test/live/testBrowser.ts
+++ b/test/live/testBrowser.ts
@@ -1,0 +1,37 @@
+import * as fs from "fs";
+import { resolveBrowser, BrowserPreference, ResolvedBrowser } from "../../src/webresources/debug/browserResolver";
+
+// How the LIVE/e2e harness finds and launches a Chromium to drive under CDP.
+//
+// Two things differ from a developer's machine, and both bite only off-Windows:
+//
+// 1. A headless Linux box (CI, or a container) often has no system Edge or Chrome at all — only a
+//    Chromium unpacked by some other tool into a version-stamped directory that moves whenever it
+//    is upgraded. Such a path can't be found by probing the usual install locations, so it is
+//    CONFIGURED via DVPT_TEST_BROWSER_PATH rather than guessed. A normal dev machine sets nothing
+//    and falls through to the extension's own resolver.
+// 2. Ubuntu 23.10+ restricts unprivileged user namespaces via AppArmor, so Chromium's sandbox
+//    cannot start and the process dies with "No usable sandbox!" before its CDP port ever listens.
+//
+// The product deliberately does NOT default those flags on (see browserArgs.ts and the
+// `dataverse-powertools.debugBrowserArgs` setting) — weakening the sandbox for every Linux user
+// would be a real regression. This is harness code, so it applies them itself.
+
+/**
+ * Resolve the browser the harness should drive, or undefined when there is none — callers
+ * self-skip on undefined rather than failing, so a box without a browser reports "skipped"
+ * instead of a red that looks like a product fault.
+ */
+export function resolveTestBrowser(prefer: BrowserPreference = "auto"): ResolvedBrowser | undefined {
+  const override = process.env.DVPT_TEST_BROWSER_PATH || undefined;
+  try {
+    return resolveBrowser(prefer, override, { platform: process.platform, env: process.env, exists: fs.existsSync });
+  } catch {
+    return undefined;
+  }
+}
+
+/** Extra Chromium flags this platform's harness needs. Empty everywhere but Linux. */
+export function testBrowserArgs(): string[] {
+  return process.platform === "linux" ? ["--no-sandbox", "--disable-dev-shm-usage"] : [];
+}

--- a/vitest.live.config.ts
+++ b/vitest.live.config.ts
@@ -10,6 +10,18 @@ export default defineConfig({
     environment: "node",
     testTimeout: 60000,
     hookTimeout: 60000,
+    // Live spec FILES must not run concurrently. `pac` keeps ONE active auth profile
+    // per machine (~/.local/share/Microsoft/PowerAppsCli on Linux, %APPDATA% on
+    // Windows) and `pac auth create` makes the profile it creates the active one.
+    // Three specs — pacOrgSelect, pluginLifecycle, solutionPacRoundtrip — each create
+    // a profile and then rely on it still being active for `org who` / `modelbuilder` /
+    // `solution export`. Run in parallel they steal the active profile from each other:
+    // the observed failure was pacOrgSelect's `org who` reporting "No active environment
+    // set for the current auth profile" — which impersonates the very earlybound-OAuth
+    // regression that spec exists to guard, so the red looks like a product bug and is
+    // not one. Serialising files also removes the same class of collision between specs
+    // that create fixed-name Dataverse rows (see #258 for the cross-RUN half of that).
+    fileParallelism: false,
   },
   resolve: {
     alias: {


### PR DESCRIPTION
Three related pieces of work. Nothing here changes product behaviour by default; the one
user-facing addition is opt-in.

## 1. A live-test flake that looked exactly like a product regression

`pac` keeps **one active auth profile per machine**, and `pac auth create` makes the profile
it creates active. Three live specs — `pacOrgSelect`, `pluginLifecycle`, `solutionPacRoundtrip`
— each create a profile and then rely on it still being active for `org who` / `modelbuilder`
/ `solution export`. Running the spec files in parallel, they take the active profile from one
another.

What made this worth chasing rather than retrying: the failure surfaced as `pacOrgSelect`'s
`org who` reporting *"No active environment set for the current auth profile"* — which is
precisely the earlybound-OAuth regression that spec exists to guard. The red impersonated a
product bug. It reproduced in a full run and passed in isolation.

Fixed by serialising live spec files (`fileParallelism: false`). With no concurrency there is
no race, so the fix cannot be subtly wrong. A lock scoped to just the three pac specs was
considered and rejected: it would have to be held across `pluginLifecycle`'s multi-minute
`dotnet build` and would then fight vitest's hook timeouts, trading a known flake for a subtler
one. Cost is wall-clock only (~100s → ~220s), and it removes the same collision class between
specs that create fixed-name Dataverse rows (the cross-run half of that is #258).

## 2. New setting: `dataverse-powertools.debugBrowserArgs`

Ubuntu 23.10+ restricts unprivileged user namespaces via AppArmor, so Chromium's sandbox
cannot start and the browser exits with `No usable sandbox!` before the debugger attaches.
**Debug Web Resources** and **Debug on live form** are unusable on such a machine, and there
was no way to pass the flag that fixes it.

This adds an opt-in string-array setting, threaded through `buildBrowserArgs` into both
launchers.

**Deliberately not a Linux platform default.** Sending `--no-sandbox` whenever
`process.platform === "linux"` would disable a real security boundary for *every* Linux user
of the extension — including the majority whose sandbox works fine — on a browser signed in to
their Dataverse environment. Affected users opt in per machine. A test asserts no
sandbox-weakening flag ships by default on any platform.

## 3. The browser-driven harness now runs off Windows

The product's auth and debug code is cross-platform; the harness driving a browser was not, so
the interactive (OAuth) and CDP-debug suites could only ever run on Windows. All test-only
changes:

- Two spots pinned an absolute Windows Edge install path. Both now resolve a browser via a new
  `test/live/testBrowser.ts`, honouring `DVPT_TEST_BROWSER_PATH` and otherwise falling back to
  the extension's own resolver — a headless machine may have no system browser, only one at a
  version-stamped path that install probing cannot find.
- `preAcquireInteractiveCache.mjs` also hard-coded one developer's absolute checkout path in
  two places, so it could not run from any other clone. Now derived from `import.meta.url`.
- `findDebugPortByProfile` was PowerShell/CIM only; gains a `ps -Aww` branch for macOS/Linux.
- The reaping helpers gain `pkill` branches. The webpack pattern is `node.*webpack`, mirroring
  the Windows filter's `Name='node.exe'` clause — an unanchored `webpack` would also match a
  developer's own build.
- `listeningPorts` gains an `ss`/`netstat` branch that collects every `:<port>` on a LISTEN
  line rather than matching specific address forms: callers probe each candidate and discard
  non-CDP ones, so a false positive costs one fast failed request while a false negative loses
  the browser entirely.
- Suites gate on a resolved browser, so they skip cleanly instead of failing with an ENOENT
  that says nothing about what they test.

## Verification

Linux, all green: lint · `tsc -p .` · **1277 unit tests** · webpack compile. The `test/live`
edits were typechecked explicitly, since `tsconfig.json` is scoped to `src/**` and neither
eslint nor vitest would catch a type error there.

Live suite before this branch: **1 failed | 37 passed | 7 skipped**.
After: **40 passed | 5 skipped** — the flake is gone, and the PCF live-form debug suite, which
previously skipped for want of a browser, now runs and passes on Linux including the real CDP
interception assertion. Every remaining skip is deliberate and named (three suites behind
`DVPT_DEBUG_DEMO=1`, plus profiler capture on the Windows gate tracked by #264).

The Linux code paths were each verified by probe rather than by reasoning — two of the first
attempts were wrong and were caught that way: an `ss` regex that silently dropped ports, and a
`pkill -f webpack` broad enough to match an unrelated build.

## Note

No changelog entry or version bump here — following what recent non-release PRs do, and a
version change reaching `main` publishes to the Marketplace. `debugBrowserArgs` is user-facing
and should get a line at the next release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)