### PR TITLE
Close out the Linux parity gaps; correct what the docs claim about replay

### DIFF
--- a/CHANGELOG-prerelease.md
+++ b/CHANGELOG-prerelease.md
@@ -7,4 +7,35 @@ is cleared to start accumulating the next cycle (`node scripts/rollupChangelog.m
 
 Everything below has shipped to the pre-release channel and is not yet in a full release.
 
-_Nothing yet — the next pre-release adds its section here._
+## 1.0.7 (pre-release)
+
+**Capturing a plug-in profile now works on macOS and Linux**
+
+*Profile next run* — and the per-step **Profile** CodeLens — were Windows-only. Everyone else had
+to capture in the Plug-in Registration Tool and come back to *Download a run*.
+
+They aren't Windows-only any more. Starting and stopping profiling are now ordinary Dataverse Web
+API calls made by the extension itself, so the whole capture → download → **Generate Replay Test**
+journey runs wherever VS Code does, under both service-principal and interactive sign-in. The
+bundled .NET Framework helper that used to do this is gone, along with the ~12MB of Plug-in
+Registration Tool assemblies it downloaded onto your machine the first time you profiled anything.
+
+*Replaying* a captured run under the debugger still needs .NET Framework — your plug-in test
+project targets it — so that step remains Windows (or macOS/Linux with mono). Capturing,
+downloading, generating the replay test and reading trace logs no longer do.
+
+**Stopping profiling now always puts your step back**
+
+Off Windows, *Stop* used to delete the profiler's clone and leave your original step **disabled** —
+which silently stopped your plug-in from running at all, and told you to go re-enable it in the
+Plug-in Registration Tool. Stopping now restores the step's name, its images and its enabled state
+on every platform.
+
+**New setting: `dataverse-powertools.debugBrowserArgs`**
+
+Extra command-line arguments to pass to the browser that *Debug Web Resources* and the PCF live-form
+debugger launch — a sibling to `dataverse-powertools.debugBrowserPath`. It exists for environments
+whose browser needs a flag to start at all (a container, or a Linux distribution whose sandbox
+restrictions stop Chromium launching). Empty by default on every platform: nothing is passed unless
+you ask for it, and in particular no sandbox-weakening flag ships as a default.
+

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -236,6 +236,13 @@ modern plugin flow already shells out to `dotnet`/`pac`.
   **verified on Ubuntu: it builds, then aborts with "Could not find 'mono' host"**. So replay means
   Windows, or mono elsewhere. Don't repeat the old "download + replay work anywhere" line; only the
   first half was true.
+  **The Framework pin is the PROJECT, not the harness** ([#269](https://github.com/pete-mc/dataverse-powertools/issues/269)):
+  `replayHarnessSource()` uses only `Convert.FromBase64String`/`DeflateStream`/`DataContractSerializer`/
+  `Microsoft.Xrm.Sdk`, all of which exist on .NET 8 — the pins are `ensureReplayCsproj` injecting the
+  Framework-only `Microsoft.CrmSdk.CoreAssemblies`, and the scaffolded `net471` TFMs. Proven by
+  replaying a REAL captured profile under net8.0 on Linux with the shipping harness and the
+  netstandard `Microsoft.PowerPlatform.Dataverse.Client`. `debugTypeForFramework` already returns
+  `coreclr` for non-net4, so the debugger needs no change. Only the DEPLOYED assembly must be net462.
 - **Still Windows-only:** the e2e browser automation (drives Edge on the Windows VM), and the
   net462 replay *runner* in the capture live spec for the same reason as above. With
   `plugins_old/` gone (#228) nothing else pins `spkl.exe`/`sn.exe`.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -229,10 +229,16 @@ modern plugin flow already shells out to `dotnet`/`pac`.
   are `i:nil`, and `profilerSteps.spec.ts` pins the exact bytes against a real serializer's output.
   Don't "tidy" that emitter. Enable also MOVES the step's images to the clone and DISABLES the
   original — miss either and the profiler silently never fires.
-- **Still Windows-only:** the e2e browser automation (drives Edge on the Windows VM) and the
-  net462 replay *runner* in the capture live spec (the product's own replay goes through the
-  user's test project and works anywhere). With `plugins_old/` gone (#228) nothing else pins
-  `spkl.exe`/`sn.exe`.
+- **Still needs .NET Framework: RUNNING a replay.** Capture, download, `Generate Replay Test` and
+  trace logs are cross-platform, but *executing* the generated test (and so `Replay & debug`) is
+  not: the scaffolded test project targets **net471** (`templates/plugin/*_tests.csproj`), and
+  while `dotnet build` compiles net4x anywhere, `dotnet test` needs a .NET Framework test host —
+  **verified on Ubuntu: it builds, then aborts with "Could not find 'mono' host"**. So replay means
+  Windows, or mono elsewhere. Don't repeat the old "download + replay work anywhere" line; only the
+  first half was true.
+- **Still Windows-only:** the e2e browser automation (drives Edge on the Windows VM), and the
+  net462 replay *runner* in the capture live spec for the same reason as above. With
+  `plugins_old/` gone (#228) nothing else pins `spkl.exe`/`sn.exe`.
 
 ## Test Explorer (native Testing API, #84)
 
@@ -263,10 +269,16 @@ runs them all (we don't have Jest's dependency graph, and guessing would skip th
   `permissions.additionalDirectories` in `.claude/settings.local.json` — edit it in
   place and push to its own `…wiki.git` remote.
 
-## Housekeeping still open (see the session that set up this foundation)
+## Housekeeping still open
 
-- ~15 stale Dependabot branches on the remote need triage.
-- Wiki likely needs updating for the spkl→`pac` and cross-platform changes. PCF, Custom API,
-  LM Tools and multi-component have no wiki/README coverage at all
-  ([#233](https://github.com/pete-mc/dataverse-powertools/issues/233)).
+- **~40 stale release branches on the remote.** `git ls-remote --heads origin` returns 42 heads, of
+  which **38 are `release/0.14.x`** plus `release/0.13.0`, `ci/nightly-live-tests` (its workflow was
+  deleted in `30a5501`) and `feature/supervised-ui-test`. There are **no** Dependabot branches left —
+  an earlier version of this file claimed ~15, and that is no longer true.
+- **e2e (ExTester) has never been RUN on Linux.** #265 made the harness portable (browser
+  resolution, `/proc`-based port discovery, `pgrep`/`ss`), but portability is inferred, not proven,
+  until `xvfb-run npm run test:e2e` passes off Windows.
+- Wiki: the profiler pages were updated for cross-platform capture (#264). The spkl→`pac` and
+  multi-component gaps ([#233](https://github.com/pete-mc/dataverse-powertools/issues/233)) are
+  CLOSED — check the wiki before assuming a gap is still open.
 - `src/plugins_old/` — DONE, removed in 1.0.3 (#228).

--- a/test/live/browserAutoLogin.ts
+++ b/test/live/browserAutoLogin.ts
@@ -4,6 +4,7 @@ import * as path from "path";
 import * as net from "net";
 import * as cp from "child_process";
 import CDP = require("chrome-remote-interface");
+import { testBrowserArgs } from "./testBrowser";
 
 // Unattended Azure AD sign-in for the test browser, driven over the DevTools Protocol.
 // Lets the live/e2e harness exercise the interactive ("Authenticated") user path — and
@@ -246,7 +247,14 @@ export async function preAuthenticateProfile(exePath: string, profileDir: string
   const log = opts.log ?? (() => undefined);
   fs.mkdirSync(profileDir, { recursive: true });
   const port = await freePort();
-  const child = cp.spawn(exePath, [`--remote-debugging-port=${port}`, `--user-data-dir=${profileDir}`, "--no-first-run", "--no-default-browser-check", "--new-window", orgUrl], { stdio: "ignore" });
+  // testBrowserArgs() carries the flags a headless Linux box needs to start Chromium at all
+  // (#265). Every other harness launch site passes them; this one did not, so pre-auth died with
+  // "No usable sandbox!" before CDP ever listened and both browser-matrix cases failed on Linux.
+  const child = cp.spawn(
+    exePath,
+    [`--remote-debugging-port=${port}`, `--user-data-dir=${profileDir}`, "--no-first-run", "--no-default-browser-check", ...testBrowserArgs(), "--new-window", orgUrl],
+    { stdio: "ignore" },
+  );
   try {
     const deadline = Date.now() + 25000;
     let up = false;

--- a/test/vscode.mock.ts
+++ b/test/vscode.mock.ts
@@ -61,10 +61,21 @@ export class Uri {
   }
 }
 
+// Debug session hooks. The web-resource debug feature registers an onDidTerminateDebugSession
+// listener the first time it runs (ensureTerminateHook), so a mock without `debug` throws — and
+// because that hook sets its "registered" flag BEFORE subscribing, only the FIRST live test to
+// launch a debug session failed, which reads like a browser-specific fault rather than a missing
+// mock. Returns a disposable, as the real API does.
+export const debug = {
+  onDidTerminateDebugSession: vi.fn((_listener: (session: { name?: string }) => void) => ({ dispose: vi.fn() })),
+  startDebugging: vi.fn(async () => true),
+  activeDebugSession: undefined as { name?: string } | undefined,
+};
+
 export const EventEmitter = class<T> {
   event = vi.fn();
   fire = vi.fn<(data: T) => void>();
   dispose = vi.fn();
 };
 
-export default { window, commands, workspace, StatusBarAlignment, ProgressLocation, Uri, EventEmitter };
+export default { window, commands, workspace, debug, StatusBarAlignment, ProgressLocation, Uri, EventEmitter };


### PR DESCRIPTION
Follow-up to #265 and #266, from actually running the last never-run suites on Linux.

## Harness fixes (two real gaps, both found by running the suites)

**The browser pre-auth path never got the Linux launch flags.** `preAuthenticateProfile` spawned Chromium with a hardcoded arg list, so it missed the flags every *other* harness launch site passes (#265). On Linux the browser died before CDP listened — `browser CDP endpoint never came up` — and **both** `debugBrowsersMatrix` cases failed. That suite now passes 2/2 on Linux for the first time.

**The vscode mock had no `debug` object.** The web-resource debug feature registers an `onDidTerminateDebugSession` listener the first time it runs, so any live spec driving it threw. It presented as a *browser-specific* fault, because `ensureTerminateHook` sets its "registered" flag **before** subscribing — so only the FIRST test to launch a debug session failed and the second sailed past.

## A doc claim that was never true

CLAUDE.md (and Requirements in the wiki) said download **and replay** work anywhere. Replay doesn't. The scaffolded test project targets `net471`: `dotnet build` compiles it on any OS, but `dotnet test` needs a .NET Framework test host — verified on Ubuntu, it builds and then aborts with `Could not find 'mono' host`. So capture / *Download a run* / **Generate Replay Test** are cross-platform; *running* the replay is Windows-or-mono. Corrected here and across the wiki.

## Housekeeping section corrected

`#233` is closed and there are **zero** Dependabot branches — it claimed ~15. The real backlog is **38 stale `release/0.14.x`** branches plus `release/0.13.0`, `ci/nightly-live-tests` (its workflow was deleted in `30a5501`) and `feature/supervised-ui-test`.

## Changelog

`CHANGELOG-prerelease.md` gains a **1.0.7** section for the two user-visible changes since 1.0.6 — cross-platform capture plus the Stop-profiling restore fix, and the new `debugBrowserArgs` setting. **`package.json` is deliberately not bumped**, so merging publishes nothing; the release stays your call.

## Verification

Lint clean · typecheck clean · 1284 unit tests · live suite on Linux with the interactive suites enabled: `debugBrowsersMatrix` 2/2, `interactiveSilent` 1/1 (seeded MSAL cache), `interactiveConnect` 1/1, profiler capture lifecycle green.

Wiki updated and pushed separately (`0117937`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)