### PR TITLE
Panel: an open ⋯ menu survives a re-render (#259)

### DIFF
--- a/CHANGELOG-prerelease.md
+++ b/CHANGELOG-prerelease.md
@@ -9,6 +9,15 @@ Everything below has shipped to the pre-release channel and is not yet in a full
 
 ## 1.0.7 (pre-release)
 
+**The Actions panel's ⋯ menu no longer closes itself**
+
+Opening a card's overflow menu while something was happening in the background — most often the
+system-requirement scan that runs after a project is created — made the menu vanish under the
+pointer. Any refresh of the panel rebuilt it from scratch, taking the open menu with it, and a
+scan refreshes it repeatedly as each tool is checked. The menu now stays open across a refresh,
+picks up whatever actions the card has after it, and keeps your keyboard place if you were
+arrowing through it.
+
 **Name your PCF control when you scaffold it**
 
 Creating a PCF control now asks for its name and namespace, suggesting a name based on the

--- a/media/menuPanel.js
+++ b/media/menuPanel.js
@@ -6,6 +6,11 @@
   const vscode = acquireVsCodeApi();
   const root = document.getElementById("root");
   let openMenu = null;
+  // Which card's overflow menu is open, keyed by the card's stable id, plus a per-render
+  // map of "reopen the menu for this key" callbacks. Both exist for #259 — see the
+  // model handler at the bottom.
+  let openMenuKey = null;
+  const overflowOpeners = new Map();
 
   function execute(action) {
     vscode.postMessage({ type: "execute", command: action.command, args: action.args || [] });
@@ -16,6 +21,7 @@
       openMenu.remove();
       openMenu = null;
     }
+    openMenuKey = null;
   }
 
   document.addEventListener("click", function (event) {
@@ -50,18 +56,21 @@
     return b;
   }
 
-  /** ⋯ button opening a popup menu of rare actions. */
-  function overflowButton(actions, ownerLabel) {
+  /** ⋯ button opening a popup menu of rare actions.
+   *
+   * `ownerKey` is the owning card's stable id (`card.id`). The menu lives in DOM the next
+   * render throws away, so the opener is registered under that key and the model handler
+   * calls it again afterwards to put the menu back (#259).
+   */
+  function overflowButton(actions, ownerLabel, ownerKey) {
     const b = el("button", "iconbtn", "⋯");
     b.type = "button";
     b.setAttribute("aria-haspopup", "menu");
     b.setAttribute("aria-label", "More actions for " + ownerLabel);
-    b.addEventListener("click", function (event) {
-      event.stopPropagation();
-      if (openMenu) {
-        closeOverflow();
-        return;
-      }
+
+    /** Build and show the menu. `focusIndex` is the item to focus, or null to focus nothing
+     * — a restore after a re-render the user didn't ask for must not steal focus. */
+    function open(focusIndex) {
       const menu = el("div", "overflow-menu");
       menu.setAttribute("role", "menu");
       for (const action of actions) {
@@ -71,10 +80,26 @@
       }
       b.parentElement.appendChild(menu);
       openMenu = menu;
-      const first = menu.querySelector("button");
-      if (first) {
-        first.focus();
+      openMenuKey = ownerKey;
+      if (focusIndex !== null && focusIndex >= 0) {
+        const items = menu.querySelectorAll("button");
+        // The card's actions can change between renders; land on the last item rather
+        // than nothing if the menu got shorter.
+        const target = items[Math.min(focusIndex, items.length - 1)];
+        if (target) {
+          target.focus();
+        }
       }
+    }
+
+    overflowOpeners.set(ownerKey, open);
+    b.addEventListener("click", function (event) {
+      event.stopPropagation();
+      if (openMenu) {
+        closeOverflow();
+        return;
+      }
+      open(0);
     });
     return b;
   }
@@ -207,7 +232,7 @@
     row.appendChild(el("span", "grow"));
     row.appendChild(button(card.switchAction, "iconbtn text"));
     const anchor = el("span", "menu-anchor");
-    anchor.appendChild(overflowButton(card.overflow, "environment"));
+    anchor.appendChild(overflowButton(card.overflow, "environment", card.id));
     row.appendChild(anchor);
     c.appendChild(row);
     c.appendChild(el("div", "small", card.url + " · " + card.authLabel));
@@ -233,7 +258,7 @@
     row.appendChild(el("span", "grow"));
     if (card.overflow.length) {
       const anchor = el("span", "menu-anchor");
-      anchor.appendChild(overflowButton(card.overflow, card.name));
+      anchor.appendChild(overflowButton(card.overflow, card.name, card.id));
       row.appendChild(anchor);
     }
     c.appendChild(row);
@@ -687,7 +712,18 @@
     if (!message || message.type !== "model") {
       return;
     }
+    // #259: this render used to just close an open overflow menu. Most renders are not
+    // user-initiated — the system-requirement scan posts a model per progress tick — so a
+    // menu opened during a background scan vanished under the pointer, and the e2e's
+    // retry loop hit the same re-render every time. Remember what was open, and whether
+    // focus was inside it, and restore both once the new DOM exists.
+    const reopenKey = openMenuKey;
+    const focusIndex =
+      openMenu && openMenu.contains(document.activeElement)
+        ? Array.prototype.indexOf.call(openMenu.querySelectorAll("button"), document.activeElement)
+        : null;
     closeOverflow();
+    overflowOpeners.clear();
     root.replaceChildren();
     lastCards = message.model.cards;
     lastCollapseByDefault = !!message.model.collapseByDefault;
@@ -708,6 +744,14 @@
       root.appendChild(newGroupZone());
     }
     root.appendChild(renderFooter(message.model.footer));
+    // Reopen only if the owning card is still on screen; a card that went away takes its
+    // menu with it.
+    if (reopenKey !== null) {
+      const reopen = overflowOpeners.get(reopenKey);
+      if (reopen) {
+        reopen(focusIndex);
+      }
+    }
   });
 
   vscode.postMessage({ type: "ready" });

--- a/src/panel/menuPanel.dom.spec.ts
+++ b/src/panel/menuPanel.dom.spec.ts
@@ -207,6 +207,122 @@ describe("menuPanel.js (webview DOM, #143)", () => {
     expect(document.querySelector('[data-card-id="n1"]')).toBeFalsy();
   });
 
+  // #259 — the panel re-renders on every host model message, and most of those the user
+  // never asked for: the system-requirement scan alone posts one per progress tick. The
+  // render used to unconditionally close an open overflow menu, so a menu opened while a
+  // scan was running vanished under the pointer (and pcfAcceptance's Restore step, which
+  // retries the open/click for 45s, hit the same re-render on every attempt).
+  describe("overflow menu survives a re-render (#259)", () => {
+    const projectCard = (overflow: unknown[], id = "project:pcf") => ({
+      kind: "project",
+      id,
+      name: "MyControl",
+      typeLabel: "PCF",
+      overflow,
+      primary: { label: "Push", command: "dvpt.push" },
+      secondary: [],
+    });
+    const restore = { label: "Restore dependencies", command: "dvpt.restore" };
+    const openOverflow = (cardId = "project:pcf") => (document.querySelector(`[data-card-id="${cardId}"] .menu-anchor > button`) as HTMLButtonElement).click();
+    const menuItems = () => Array.from(document.querySelectorAll(".overflow-menu button.menu-item"));
+    const labels = () => menuItems().map((b) => b.textContent);
+
+    it("opens a card's overflow menu on the ⋯ button", () => {
+      loadPanel();
+      postModel({ cards: [projectCard([restore])], footer });
+      expect(menuItems().length).toBe(0);
+      openOverflow();
+      expect(labels()).toEqual(["Restore dependencies"]);
+    });
+
+    it("keeps the menu open when a background re-render replaces the DOM", () => {
+      loadPanel();
+      postModel({ cards: [projectCard([restore])], footer });
+      openOverflow();
+      // A requirement-scan progress tick: same cards, new model message.
+      postModel({ cards: [projectCard([restore])], footer });
+      expect(labels()).toEqual(["Restore dependencies"]);
+      // Exactly one menu — the old DOM went with replaceChildren(), it wasn't duplicated.
+      expect(document.querySelectorAll(".overflow-menu").length).toBe(1);
+    });
+
+    it("the reopened menu is live, not a stale copy — its items still post execute", () => {
+      const { posted } = loadPanel();
+      postModel({ cards: [projectCard([restore])], footer });
+      openOverflow();
+      postModel({ cards: [projectCard([restore])], footer });
+      posted.length = 0;
+      (menuItems()[0] as HTMLButtonElement).click();
+      expect(posted).toEqual([{ type: "execute", command: "dvpt.restore", args: [] }]);
+    });
+
+    it("the reopened menu shows the NEW model's actions", () => {
+      loadPanel();
+      postModel({ cards: [projectCard([restore])], footer });
+      openOverflow();
+      postModel({ cards: [projectCard([restore, { label: "Refresh Types", command: "dvpt.types" }])], footer });
+      expect(labels()).toEqual(["Restore dependencies", "Refresh Types"]);
+    });
+
+    it("does not resurrect a menu the user closed", () => {
+      loadPanel();
+      postModel({ cards: [projectCard([restore])], footer });
+      openOverflow();
+      document.dispatchEvent(new KeyboardEvent("keydown", { key: "Escape" }));
+      expect(menuItems().length).toBe(0);
+      postModel({ cards: [projectCard([restore])], footer });
+      expect(menuItems().length).toBe(0);
+    });
+
+    it("does not reopen a menu whose card is gone from the new model", () => {
+      loadPanel();
+      postModel({ cards: [projectCard([restore])], footer });
+      openOverflow();
+      postModel({ cards: [projectCard([restore], "project:other")], footer });
+      expect(menuItems().length).toBe(0);
+    });
+
+    it("restores focus to the same item when focus was inside the menu", () => {
+      loadPanel();
+      postModel({ cards: [projectCard([restore, { label: "Refresh Types", command: "dvpt.types" }])], footer });
+      openOverflow();
+      (menuItems()[1] as HTMLButtonElement).focus();
+      postModel({ cards: [projectCard([restore, { label: "Refresh Types", command: "dvpt.types" }])], footer });
+      expect(document.activeElement).toBe(menuItems()[1]);
+    });
+
+    it("does not steal focus on a re-render the user did not cause", () => {
+      loadPanel();
+      postModel({ cards: [projectCard([restore])], footer });
+      openOverflow();
+      // Focus moves out of the menu (the menu stays open — it only closes on a click,
+      // Escape, or an outside click).
+      (document.querySelector('[data-card-id="project:pcf"] button.action.primary') as HTMLButtonElement).focus();
+      postModel({ cards: [projectCard([restore])], footer });
+      expect(labels()).toEqual(["Restore dependencies"]);
+      expect(menuItems()).not.toContain(document.activeElement);
+    });
+
+    it("restores the environment card's menu too", () => {
+      loadPanel();
+      const env = {
+        kind: "environment",
+        id: "environment",
+        name: "Contoso",
+        connected: true,
+        url: "https://contoso.crm.dynamics.com",
+        authLabel: "OAuth",
+        switchAction: { label: "Switch", command: "dvpt.switch" },
+        overflow: [{ label: "Clear Stored Credentials", command: "dvpt.clearCreds" }],
+      };
+      postModel({ cards: [env], footer });
+      openOverflow("environment");
+      expect(labels()).toEqual(["Clear Stored Credentials"]);
+      postModel({ cards: [env], footer });
+      expect(labels()).toEqual(["Clear Stored Credentials"]);
+    });
+  });
+
   it("ignores messages that are not the model type", () => {
     loadPanel();
     postModel({ cards: [{ kind: "notice", id: "n1", text: "Real" }], footer });

--- a/src/ui-test/e2e/pcfAcceptance.e2e.ts
+++ b/src/ui-test/e2e/pcfAcceptance.e2e.ts
@@ -2,7 +2,7 @@ import * as path from "path";
 import * as fs from "fs";
 import { expect } from "chai";
 import { VSBrowser } from "vscode-extension-tester";
-import { openWorkspaceFolder, loadE2EEnv, freshWorkspace, pickByLabel, dismissOverlays, sleep, answerText, runScopedIdentifier, E2EClient } from "./lib";
+import { openWorkspaceFolder, loadE2EEnv, freshWorkspace, pickByLabel, dismissOverlays, sleep, answerText, expectOutput, clearOutput, runScopedIdentifier, E2EClient } from "./lib";
 import { clickPanelButton, clickOverflowItem, expandComponentCards } from "../supervised/supervisedLib";
 import { initProject, step, showLog } from "./acceptanceLib";
 
@@ -109,12 +109,22 @@ describe("ACCEPTANCE: PCF — build, code, publish via panel buttons", function 
 
   it("restores dependencies + builds the bundle — Restore + Local Build buttons", async () => {
     await step(COMPONENT, "Build (Restore deps + Local Build → out/controls/bundle.js)", async () => {
+      // The system-requirement scan kicked off by project init re-renders the panel on every
+      // progress tick, and each re-render used to close an overflow menu we had just opened —
+      // so the click below could never land while the scan ran (#259). The product now keeps
+      // the menu open across a re-render, but gating on the scan's FINAL line still removes
+      // the overlap rather than relying on the repair. No clearOutput first: the line may
+      // already have been written during init, and it is only ever appended.
+      await expectOutput("Requirement scan complete.", { timeoutMs: 180000, failMarkers: [], step: "requirement scan" });
+
       // pcf build (pcf-scripts) needs node_modules; a user runs Restore dependencies first.
+      await clearOutput();
       await expandComponentCards();
       await clickOverflowItem("Restore dependencies", { timeoutMs: 45000 });
-      // Wait for npm install to land a package-lock (best-effort — the Local Build below fails
-      // clearly if deps are still missing).
-      await pollDeep(workspace, (name) => name === "package-lock.json", 600000);
+      // Gate on the restore's own final line, not on package-lock.json appearing: npm writes
+      // the lockfile mid-install, so polling for it let Local Build start while the restore was
+      // still running, and the two commands interleaved.
+      await expectOutput("Restore Complete.", { timeoutMs: 600000, step: "restore dependencies" });
       await sleep(4000);
       await expandComponentCards();
       await clickPanelButton("Local Build", { timeoutMs: 30000 });


### PR DESCRIPTION
Closes #259.

## The bug

`media/menuPanel.js` handled every host→webview model message by calling `closeOverflow()` and then `root.replaceChildren()`. Most of those messages are not user-initiated — the system-requirement scan alone posts one per progress tick — so opening a card's `⋯` menu while a scan ran made it vanish under the pointer.

That is a real papercut for users, and it is also why `pcfAcceptance`'s *Restore* step was red: `clickOverflowItem` retries the open-and-click for 45s, and every attempt hit the same re-render. The step runs straight after project init, whose `npm install` takes ~52s on that box, so the overlap was reliable rather than occasional.

## The fix (product side)

The renderer now remembers which card's menu was open, keyed by the card's stable `id`, and reopens it once the new DOM exists:

- rebuilt from the **new** model, so the items reflect the current card rather than being a resurrected copy;
- focus restored **only** if it was inside the menu, so a re-render the user didn't cause can't steal focus;
- a menu the user closed (Escape/outside click), or one whose card is gone from the new model, stays closed.

## Tests

`menuPanel.js` had no DOM coverage for the overflow menu at all. `menuPanel.dom.spec.ts` — which loads the shipping script unchanged into jsdom — now covers it in 9 cases. **Six fail against the previous renderer**; the other three are guards that should pass either way (opens on click, doesn't resurrect a closed menu, doesn't reopen a departed card).

## Test side

Per the CLAUDE.md rule about gating on a command's FINAL signal, `pcfAcceptance`:

- waits for `Requirement scan complete.` before touching the overflow, removing the overlap rather than leaning on the product repair;
- gates the restore on `Restore Complete.` instead of polling for `package-lock.json`. That was the documented intermediate-artefact trap: npm writes the lockfile mid-install, so *Local Build* could start while the restore was still running.

## Verification

`lint` / `compile` / `test:coverage` (1322 unit tests, floor held) / `test:integration` (22 passing) all green locally. The e2e `pcfAcceptance` step itself needs a live org and has not been run here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)