### PR TITLE
Close the #258 gaps: name your PCF control, stop two web-resource components deploying over each other, and scope e2e fixtures

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,3 +45,6 @@ tools/xrmdefinitelytyped/
 test/fixtures/profilerProbe/bin/
 test/fixtures/profilerProbe/obj/
 coverage-integration/
+
+# Scratch project the webpack-template contract spec builds (see webpackTemplateOutput.spec.ts)
+.tmp-webpack-spec-*/

--- a/CHANGELOG-prerelease.md
+++ b/CHANGELOG-prerelease.md
@@ -9,6 +9,26 @@ Everything below has shipped to the pre-release channel and is not yet in a full
 
 ## 1.0.7 (pre-release)
 
+**Name your PCF control when you scaffold it**
+
+Creating a PCF control now asks for its name and namespace, suggesting a name based on the
+component's folder. Before this it never asked, so *every* control this extension scaffolded was
+called `SampleNamespace.SampleControl` — which meant two PCF components in one workspace pushed to
+the same control in Dataverse and the second quietly replaced the first. Existing controls are
+untouched; this only affects newly scaffolded ones.
+
+**Two Web Resources components no longer deploy over each other**
+
+In bundled output mode the built library deploys as `<prefix>_library.js`. That name was fixed, so
+two Web Resources components in one workspace both produced it and whichever deployed second won.
+
+The bundle name is now a project setting, `webresourceLibraryName`. A component added in a
+subfolder is given its folder name automatically, so the collision doesn't arise; the root
+component keeps `library`, which means **no existing project's deployed web resource changes name**
+— nothing gets orphaned and no form registration breaks. Form registrations still recognise the
+old name too, so if you do rename a bundle, handlers pointing at the previous one are cleaned up
+rather than stranded. Existing projects pick this up through *Refresh Project Config Files*.
+
 **Replaying a plug-in profile now works on macOS and Linux too**
 
 Capturing stopped being Windows-only earlier in this cycle; *replaying* the captured run — and so

--- a/src/context.ts
+++ b/src/context.ts
@@ -234,6 +234,10 @@ interface ProjectSettings {
   settingsVersion?: number;
   /** Web resource build output (#88): one bundled library (default) or one JS per source file. */
   webresourceOutput?: "bundle" | "perFile";
+  /** Bundle-mode output name (#258): the deployed resource is `{prefix}_{this}.js`, default
+   * `library`. Set per component at scaffold so two web-resource components in one workspace
+   * don't deploy over each other. Read at BUILD time by the project's webpack.common.js. */
+  webresourceLibraryName?: string;
   tenantId?: string;
   /** Optional environment tag (e.g. DEV / TEST / PROD) shown as a badge in the actions panel. */
   environmentLabel?: string;

--- a/src/general/restoreDependencies.ts
+++ b/src/general/restoreDependencies.ts
@@ -137,9 +137,12 @@ export async function restoreDependencies(context: DataversePowerToolsContext, i
         const workspacePath = activeComponentRoot(context) ?? vscode.workspace.workspaceFolders[0].uri.fsPath;
         const restoreCommands = initialising ? context.template?.initCommands || [] : context.template?.restoreCommands || [];
         // PCF scaffold (#141): ask once, up front, for the control template + framework so the
-        // pac pcf init below uses the user's choice instead of the hardcoded field/none. The
-        // returned argv is fixed-enum tokens only (safe to run as-is, bypassing the string gate).
-        const pcfInitArgv = initialising && context.projectSettings.type === ProjectTypes.pcf ? await promptPcfInitArgs() : undefined;
+        // pac pcf init below uses the user's choice instead of the hardcoded field/none. It also
+        // asks for the control name/namespace (#258) — those used to be pac's SampleNamespace.
+        // SampleControl for EVERY control, so two PCF components deployed over each other. The
+        // component folder name seeds the suggestion. The name/namespace tokens are the only
+        // free text in this argv and are validated in pcfInitArgs; the rest are fixed enums.
+        const pcfInitArgv = initialising && context.projectSettings.type === ProjectTypes.pcf ? await promptPcfInitArgs(path.basename(workspacePath)) : undefined;
         for (const c of restoreCommands) {
           const resolvedCommand = pcfInitArgv && isPacPcfInit(c.command) ? pcfInitArgv : resolveInitCommand(c.command, workspacePath, context, initialising);
           const displayCommand = Array.isArray(resolvedCommand) ? resolvedCommand.join(" ") : resolvedCommand;

--- a/src/pcf/pcfArgs.spec.ts
+++ b/src/pcf/pcfArgs.spec.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { pcfInitArgs, pcfPushArgs } from "./pcfArgs";
+import { pcfInitArgs, pcfPushArgs, isValidPcfName, isValidPcfNamespace } from "./pcfArgs";
 
 describe("pcfInitArgs", () => {
   it("builds field + none", () => {
@@ -16,6 +16,65 @@ describe("pcfInitArgs", () => {
 
   it("builds dataset + react", () => {
     expect(pcfInitArgs({ template: "dataset", framework: "react" })).toEqual(["pcf", "init", "--template", "dataset", "--framework", "react"]);
+  });
+});
+
+// #258 — pac defaults to SampleNamespace.SampleControl when these are omitted, so every control
+// the extension scaffolded shared one name and the second one deployed over the first.
+describe("pcfInitArgs — control name + namespace", () => {
+  it("omits both flags entirely when neither is given (the previous behaviour)", () => {
+    expect(pcfInitArgs({ template: "field", framework: "none" })).toEqual(["pcf", "init", "--template", "field", "--framework", "none"]);
+  });
+
+  it("appends --namespace and --name after the existing flags", () => {
+    expect(pcfInitArgs({ template: "field", framework: "none", namespace: "Contoso", name: "TerritoryPicker" })).toEqual([
+      "pcf",
+      "init",
+      "--template",
+      "field",
+      "--framework",
+      "none",
+      "--namespace",
+      "Contoso",
+      "--name",
+      "TerritoryPicker",
+    ]);
+  });
+
+  it("allows either one alone", () => {
+    expect(pcfInitArgs({ template: "field", framework: "none", name: "Picker" })).toContain("--name");
+    expect(pcfInitArgs({ template: "field", framework: "none", name: "Picker" })).not.toContain("--namespace");
+    expect(pcfInitArgs({ template: "field", framework: "none", namespace: "Contoso" })).toContain("--namespace");
+  });
+
+  it("accepts a dotted namespace but not a dotted control name", () => {
+    expect(pcfInitArgs({ template: "field", framework: "none", namespace: "Contoso.Controls" })).toContain("Contoso.Controls");
+    expect(() => pcfInitArgs({ template: "field", framework: "none", name: "Contoso.Picker" })).toThrow(/control name/);
+  });
+
+  it("refuses text that is not a legal identifier, rather than putting it on the command line", () => {
+    for (const bad of ["My Control", "control;rm -rf /", "2Fast", "", "a-b", "$(whoami)"]) {
+      expect(() => pcfInitArgs({ template: "field", framework: "none", name: bad }), bad).toThrow();
+    }
+    for (const bad of ["Contoso Controls", "Contoso..Controls", ".Contoso", "Contoso.", "2Contoso"]) {
+      expect(() => pcfInitArgs({ template: "field", framework: "none", namespace: bad }), bad).toThrow();
+    }
+  });
+});
+
+describe("isValidPcfName / isValidPcfNamespace", () => {
+  it("accepts ordinary identifiers and underscores", () => {
+    expect(isValidPcfName("Picker")).toBe(true);
+    expect(isValidPcfName("_Picker2")).toBe(true);
+    expect(isValidPcfNamespace("Contoso")).toBe(true);
+    expect(isValidPcfNamespace("Contoso.Controls.V2")).toBe(true);
+  });
+
+  it("rejects the shapes pac would reject", () => {
+    expect(isValidPcfName("Contoso.Picker")).toBe(false);
+    expect(isValidPcfName("2Picker")).toBe(false);
+    expect(isValidPcfNamespace("Contoso..Controls")).toBe(false);
+    expect(isValidPcfNamespace("")).toBe(false);
   });
 });
 

--- a/src/pcf/pcfArgs.ts
+++ b/src/pcf/pcfArgs.ts
@@ -13,14 +13,53 @@ export type PcfFramework = "none" | "react";
 export interface PcfInitOptions {
   template: PcfTemplate;
   framework: PcfFramework;
+  /** `<control namespace="…">`. Dotted segments allowed (`Contoso.Controls`). */
+  namespace?: string;
+  /** `<control constructor="…">` — the control name. */
+  name?: string;
+}
+
+/** A single C#/TS-style identifier segment — what pac accepts for a control name. */
+const PCF_NAME_PATTERN = /^[A-Za-z_][A-Za-z0-9_]*$/;
+/** A namespace: one or more identifier segments joined by dots. */
+const PCF_NAMESPACE_PATTERN = /^[A-Za-z_][A-Za-z0-9_]*(\.[A-Za-z_][A-Za-z0-9_]*)*$/;
+
+/** Whether `value` is usable as a `pac pcf init --name`. */
+export function isValidPcfName(value: string): boolean {
+  return PCF_NAME_PATTERN.test(value);
+}
+
+/** Whether `value` is usable as a `pac pcf init --namespace`. */
+export function isValidPcfNamespace(value: string): boolean {
+  return PCF_NAMESPACE_PATTERN.test(value);
 }
 
 /**
  * `pac pcf init` — initialise a directory with a new PCF project.
  * `--template field|dataset`, `--framework none|react`. No auth required.
+ *
+ * `namespace`/`name` are the only user-supplied text that reaches this argv (#258). They are
+ * validated here as well as in the prompt's `validateInput`: the prompt is the usable check, this
+ * is the backstop that means no caller can put arbitrary text on the command line. pac is spawned
+ * with an args array and no shell (src/general/pac.ts), so this is about pac rejecting a malformed
+ * name — not about shell injection — but a name that fails here would otherwise fail deep inside
+ * the scaffold with a pac error instead of at the point it was chosen.
  */
-export function pcfInitArgs({ template, framework }: PcfInitOptions): string[] {
-  return ["pcf", "init", "--template", template, "--framework", framework];
+export function pcfInitArgs({ template, framework, namespace, name }: PcfInitOptions): string[] {
+  const args = ["pcf", "init", "--template", template, "--framework", framework];
+  if (namespace !== undefined) {
+    if (!isValidPcfNamespace(namespace)) {
+      throw new Error(`PCF namespace ${JSON.stringify(namespace)} is not valid — letters, digits and underscores, dot-separated, not starting with a digit.`);
+    }
+    args.push("--namespace", namespace);
+  }
+  if (name !== undefined) {
+    if (!isValidPcfName(name)) {
+      throw new Error(`PCF control name ${JSON.stringify(name)} is not valid — letters, digits and underscores, not starting with a digit.`);
+    }
+    args.push("--name", name);
+  }
+  return args;
 }
 
 /**

--- a/src/pcf/pcfInitPrompt.spec.ts
+++ b/src/pcf/pcfInitPrompt.spec.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { pcfTemplateChoices, pcfFrameworkChoices, PCF_INIT_DEFAULTS } from "./pcfInitPrompt";
+import { pcfTemplateChoices, pcfFrameworkChoices, suggestPcfName, PCF_INIT_DEFAULTS, PCF_FALLBACK_NAME } from "./pcfInitPrompt";
 import { pcfInitArgs } from "./pcfArgs";
 
 describe("pcfInitPrompt choices (#141)", () => {
@@ -30,5 +30,36 @@ describe("pcfInitPrompt choices (#141)", () => {
   it("defaults match the previous hardcoded scaffold (field/none) so cancelling is safe", () => {
     expect(PCF_INIT_DEFAULTS).toEqual({ template: "field", framework: "none" });
     expect(pcfInitArgs(PCF_INIT_DEFAULTS)).toEqual(["pcf", "init", "--template", "field", "--framework", "none"]);
+  });
+});
+
+// #258 — the suggestion is what stops two PCF components in one workspace sharing a control name.
+describe("suggestPcfName", () => {
+  it("PascalCases a folder name into an identifier", () => {
+    expect(suggestPcfName("acc-pcf")).toBe("AccPcf");
+    expect(suggestPcfName("territory picker")).toBe("TerritoryPicker");
+    expect(suggestPcfName("my_control")).toBe("MyControl");
+    expect(suggestPcfName("Grid")).toBe("Grid");
+  });
+
+  it("gives two different folders two different names — the whole point", () => {
+    expect(suggestPcfName("pcf-one")).not.toBe(suggestPcfName("pcf-two"));
+  });
+
+  it("keeps digits but never starts with one", () => {
+    expect(suggestPcfName("control2")).toBe("Control2");
+    expect(suggestPcfName("2fast")).toBe("_2fast");
+  });
+
+  it("falls back when nothing usable survives", () => {
+    expect(suggestPcfName("")).toBe(PCF_FALLBACK_NAME);
+    expect(suggestPcfName("---")).toBe(PCF_FALLBACK_NAME);
+    expect(suggestPcfName("", "Other")).toBe("Other");
+  });
+
+  it("always produces something pcfInitArgs accepts", () => {
+    for (const folder of ["acc-pcf", "2fast", "my control", "---", "a.b.c", "Ünïcødé"]) {
+      expect(() => pcfInitArgs({ template: "field", framework: "none", name: suggestPcfName(folder) }), folder).not.toThrow();
+    }
   });
 });

--- a/src/pcf/pcfInitPrompt.ts
+++ b/src/pcf/pcfInitPrompt.ts
@@ -1,5 +1,5 @@
 import * as vscode from "vscode";
-import { PcfTemplate, PcfFramework, PcfInitOptions, pcfInitArgs } from "./pcfArgs";
+import { PcfTemplate, PcfFramework, PcfInitOptions, pcfInitArgs, isValidPcfName, isValidPcfNamespace } from "./pcfArgs";
 
 // Scaffold-time quick-pick for a new PCF control (#141): let the user choose the control
 // TEMPLATE (field vs dataset) and FRAMEWORK (none vs React) instead of always scaffolding
@@ -16,6 +16,30 @@ interface FrameworkPick extends vscode.QuickPickItem {
 /** Default when the user dismisses a pick — matches the previous hardcoded scaffold, so
  * cancelling never breaks or surprises. */
 export const PCF_INIT_DEFAULTS: PcfInitOptions = { template: "field", framework: "none" };
+
+/** pac's own defaults when `--namespace`/`--name` are omitted, which is what every control this
+ * extension scaffolded used to be called. Kept as the last-resort fallback only. */
+export const PCF_FALLBACK_NAMESPACE = "SampleNamespace";
+export const PCF_FALLBACK_NAME = "SampleControl";
+
+/**
+ * Turn a folder name into a PascalCase identifier usable as a control name — `acc-pcf` →
+ * `AccPcf`, `my control 2` → `MyControl2`. Returns `fallback` when nothing usable survives.
+ *
+ * This is what makes two PCF components in one workspace get DIFFERENT control names by default
+ * (#258): the deployed `customcontrol` row is named `{prefix}_{namespace}.{constructor}`, so
+ * before this every control the extension scaffolded was `SampleNamespace.SampleControl` and the
+ * second one deployed over the first.
+ */
+export function suggestPcfName(folderName: string, fallback = PCF_FALLBACK_NAME): string {
+  const segments = folderName.split(/[^A-Za-z0-9]+/).filter(Boolean);
+  const pascal = segments.map((s) => s[0].toUpperCase() + s.slice(1)).join("");
+  if (!pascal) {
+    return fallback;
+  }
+  // A leading digit is legal in a folder name and not in an identifier.
+  return isValidPcfName(pascal) ? pascal : `_${pascal}`;
+}
 
 /** Control-template choices (pure — unit-tested). field = a single bound property control;
  * dataset = a grid/data-set control. */
@@ -41,7 +65,7 @@ export function pcfFrameworkChoices(): FrameworkPick[] {
  * scaffold still proceeds exactly as it did before). Never returns free-text — the argv tokens
  * come only from the fixed enums, so nothing user-typed reaches the command line.
  */
-export async function promptPcfInitArgs(): Promise<string[]> {
+export async function promptPcfInitArgs(componentFolderName?: string): Promise<string[]> {
   const template = await vscode.window.showQuickPick(pcfTemplateChoices(), {
     placeHolder: "PCF control template",
     ignoreFocusOut: true,
@@ -50,9 +74,32 @@ export async function promptPcfInitArgs(): Promise<string[]> {
     placeHolder: "PCF rendering framework",
     ignoreFocusOut: true,
   });
+  // The suggested name is derived from the component folder, so two PCF components in one
+  // workspace differ by default. Escaping KEEPS the suggestion rather than reverting to pac's
+  // SampleControl: the value is shown prefilled, so accepting it by escaping isn't a surprise —
+  // and reverting would put the collision back (#258).
+  const suggested = suggestPcfName(componentFolderName ?? "");
+  const name =
+    (await vscode.window.showInputBox({
+      title: "PCF control name",
+      prompt: "The control's name — part of how it is identified in Dataverse.",
+      value: suggested,
+      ignoreFocusOut: true,
+      validateInput: (v) => (isValidPcfName(v.trim()) ? undefined : "Letters, digits and underscores only, and not starting with a digit."),
+    })) ?? suggested;
+  const namespace =
+    (await vscode.window.showInputBox({
+      title: "PCF control namespace",
+      prompt: "The control's namespace — usually your company or product.",
+      value: PCF_FALLBACK_NAMESPACE,
+      ignoreFocusOut: true,
+      validateInput: (v) => (isValidPcfNamespace(v.trim()) ? undefined : "Letters, digits, underscores and dots, and no segment starting with a digit."),
+    })) ?? PCF_FALLBACK_NAMESPACE;
   const options: PcfInitOptions = {
     template: template?.value ?? PCF_INIT_DEFAULTS.template,
     framework: framework?.value ?? PCF_INIT_DEFAULTS.framework,
+    namespace: namespace.trim(),
+    name: name.trim(),
   };
   // pcfInitArgs yields ["pcf","init",…]; the restore runner prefixes "pac".
   return ["pac", ...pcfInitArgs(options)];

--- a/src/projectTypes/activation.ts
+++ b/src/projectTypes/activation.ts
@@ -5,6 +5,7 @@ import { ProjectTypes, getProjectTypeDescriptor, projectTypeRegistry } from "./r
 import { runForComponent } from "../components/componentDiscovery";
 import { runTracked } from "../panel/operationTracker";
 import { initialiseWebresources } from "../webresources/initialiseWebresources";
+import { defaultLibraryBaseName } from "../webresources/libraryNames";
 import { initialiseSolutions } from "../solution/initialiseSolutions";
 import { initialisePortals } from "../portals/initialisePortals";
 import { initialisePlugins } from "../plugins/initialisePlugins";
@@ -212,6 +213,11 @@ export const projectTypeActivations: Record<ProjectTypes, ProjectTypeActivation>
         { placeHolder: "How should web resources be built?" },
       );
       context.projectSettings.webresourceOutput = pick?.target ?? "bundle";
+      // Bundle output name (#258). Only ever set HERE, on a freshly scaffolded component: the
+      // root keeps "library" so existing projects are untouched, while a sub-component takes its
+      // folder name so two web-resource components stop deploying over each other's
+      // {prefix}_library.js. Renaming an existing component's would orphan a deployed resource.
+      context.projectSettings.webresourceLibraryName = defaultLibraryBaseName(context.activeComponent?.relativeRoot ?? "");
       await context.writeSettings();
     },
     commands: {

--- a/src/projectTypes/registry.ts
+++ b/src/projectTypes/registry.ts
@@ -163,7 +163,10 @@ export const projectTypeRegistry: readonly ProjectTypeDescriptor[] = [
     contextKey: "isWebResource",
     // Rev 1 = the 0.7.4/0.7.5 config wave: per-file output ternary, inline
     // source maps, modern tsconfig, ts-jest transform config.
-    configRevision: 1,
+    // Rev 2 (#258) = webpack.common.js reads webresourceLibraryName, so the bundle output name
+    // is configurable. Harmless to refresh into a project that doesn't set it — the name falls
+    // back to "library", which is exactly what the old hardcoded template emitted.
+    configRevision: 2,
     refreshableFiles: [
       ".eslintrc.json",
       ".prettierrc.json",

--- a/src/ui-test/e2e/fixtureNames.spec.ts
+++ b/src/ui-test/e2e/fixtureNames.spec.ts
@@ -1,0 +1,112 @@
+import { describe, it, expect } from "vitest";
+import { scopedName, scopedIdentifier, assertUsableRunId, profilerStepDisposition, LOCAL_RUN_ID } from "./fixtureNames";
+
+// #258 — the e2e suites share one Dataverse environment, so overlapping runs must not collide.
+// These are the naming rules; the suites that apply them only run inside ExTester, so this is
+// the only layer that can check the rules cheaply.
+describe("e2e fixture names (#258)", () => {
+  describe("scopedName", () => {
+    it("appends the run id so two runs never share a fixture", () => {
+      expect(scopedName("AcceptancePlugin", "1abc2d")).toBe("AcceptancePlugin1abc2d");
+      expect(scopedName("AcceptancePlugin", "9zzz1")).toBe("AcceptancePlugin9zzz1");
+      expect(scopedName("AcceptancePlugin", "1abc2d")).not.toBe(scopedName("AcceptancePlugin", "9zzz1"));
+    });
+
+    it("leaves the name unscoped for a bare local run", () => {
+      expect(scopedName("AcceptancePlugin", LOCAL_RUN_ID)).toBe("AcceptancePlugin");
+    });
+
+    it("is stable — the same base and run id always give the same name", () => {
+      // Cleanup finds rows by rebuilding the name, so this has to hold across calls.
+      expect(scopedName("E2EPluginIntPkg", "1abc2d")).toBe(scopedName("E2EPluginIntPkg", "1abc2d"));
+    });
+
+    it("keeps distinct bases distinct within one run", () => {
+      expect(scopedName("AcceptancePlugin", "1abc2d")).not.toBe(scopedName("CustomApiE2E", "1abc2d"));
+    });
+
+    it("suffixes rather than prefixes, so a publisher prefix stays at the front", () => {
+      // The deployed package is `{publisherPrefix}_{name}` and web resources are looked up by
+      // their leading prefix — anything prepended would break both.
+      expect(scopedName("ContosoTerritories", "1abc2d").startsWith("ContosoTerritories")).toBe(true);
+    });
+
+    it("refuses an empty base — an unnamed fixture cannot be cleaned up by name", () => {
+      expect(() => scopedName("", "1abc2d")).toThrow(/non-empty base/);
+    });
+
+    it("refuses a run id that would need escaping in an OData filter", () => {
+      expect(() => scopedName("Plugin", "it's")).toThrow(/alphanumeric/);
+      expect(() => scopedName("Plugin", "a b")).toThrow(/alphanumeric/);
+      expect(() => scopedName("Plugin", "a-b")).toThrow(/alphanumeric/);
+    });
+  });
+
+  describe("scopedIdentifier", () => {
+    it("scopes a name that also has to compile as a C#/TS identifier", () => {
+      expect(scopedIdentifier("TerritoryOnboarding", "1abc2d")).toBe("TerritoryOnboarding1abc2d");
+      expect(scopedIdentifier("E2EPerFile", LOCAL_RUN_ID)).toBe("E2EPerFile");
+    });
+
+    it("stays legal when the run id starts with a digit", () => {
+      // Base-36 minutes-since-epoch usually does. A digit is only illegal at the START of an
+      // identifier, and the id is a suffix — so this must pass, not throw.
+      expect(scopedIdentifier("ContosoTerritories", "1abc2d")).toBe("ContosoTerritories1abc2d");
+    });
+
+    it("rejects a base that is not a legal identifier, naming the reason", () => {
+      expect(() => scopedIdentifier("acc-plugin", "1abc2d")).toThrow(/legal identifier/);
+      expect(() => scopedIdentifier("2Plugins", "1abc2d")).toThrow(/legal identifier/);
+      expect(() => scopedIdentifier("", "1abc2d")).toThrow(/legal identifier/);
+    });
+  });
+
+  // The other half of #258: a cleanup that deletes rows it doesn't own is as damaging as a
+  // fixture name that collides — it takes out a concurrent run mid-capture.
+  describe("profilerStepDisposition", () => {
+    const OURS = "Create territory (DVPT profiler e2e 1abc2d) (Profiler)";
+    const THEIRS = "Create territory (DVPT profiler e2e 9zzz1) (Profiler)";
+
+    it("keeps ordinary steps — they belong to the org, not to us", () => {
+      expect(profilerStepDisposition("Some business step", "Contoso.Plugins.Thing", "1abc2d")).toBe("keep");
+      // Not a clone, even though the run id happens to appear in it.
+      expect(profilerStepDisposition("Create territory (DVPT profiler e2e 1abc2d)", "Contoso.Plugins.Thing", "1abc2d")).toBe("keep");
+    });
+
+    it("recognises a clone by its plug-in type or by its name suffix", () => {
+      expect(profilerStepDisposition("anything", "PluginProfiler.Plugins.ProfilerPlugin")).toBe("delete");
+      expect(profilerStepDisposition("Create territory (Profiler)", "Contoso.Plugins.Thing")).toBe("delete");
+      expect(profilerStepDisposition("Create territory (Profiled)", "Contoso.Plugins.Thing")).toBe("delete");
+    });
+
+    it("deletes this run's clone and spares a concurrent run's", () => {
+      expect(profilerStepDisposition(OURS, "PluginProfiler.Plugins.ProfilerPlugin", "1abc2d")).toBe("delete");
+      expect(profilerStepDisposition(THEIRS, "PluginProfiler.Plugins.ProfilerPlugin", "1abc2d")).toBe("foreign");
+    });
+
+    it("sweeps the entity org-wide when no marker is given (a solo local run)", () => {
+      expect(profilerStepDisposition(THEIRS, "PluginProfiler.Plugins.ProfilerPlugin")).toBe("delete");
+      expect(profilerStepDisposition(OURS, "PluginProfiler.Plugins.ProfilerPlugin")).toBe("delete");
+    });
+
+    it("never reports a non-clone as foreign — 'foreign' must mean a leftover worth warning about", () => {
+      // The suite prints a warning per foreign row; classing ordinary org steps as foreign would
+      // make that warning noise and get it ignored.
+      expect(profilerStepDisposition("Some business step", "Contoso.Plugins.Thing", "1abc2d")).toBe("keep");
+    });
+  });
+
+  describe("assertUsableRunId", () => {
+    it("accepts the local sentinel and any alphanumeric id", () => {
+      expect(() => assertUsableRunId(LOCAL_RUN_ID)).not.toThrow();
+      expect(() => assertUsableRunId("1abc2d")).not.toThrow();
+      expect(() => assertUsableRunId("ABC123")).not.toThrow();
+    });
+
+    it("rejects ids that would break a name", () => {
+      expect(() => assertUsableRunId("")).toThrow();
+      expect(() => assertUsableRunId("run_1")).toThrow();
+      expect(() => assertUsableRunId("run.1")).toThrow();
+    });
+  });
+});

--- a/src/ui-test/e2e/fixtureNames.ts
+++ b/src/ui-test/e2e/fixtureNames.ts
@@ -1,0 +1,96 @@
+// Pure fixture-name scoping for the e2e suites (#258).
+//
+// Every suite creates rows in ONE shared Dataverse environment, so two runs that overlap —
+// a CI job and a developer's box, or two developers — will delete each other's fixtures and
+// assert against each other's leftovers unless the names differ. That has already produced a
+// real false pass (#249): an "the web resource exists" assertion satisfied by a DIFFERENT
+// suite's row, proving nothing.
+//
+// This module holds the naming rules and nothing else — no selenium, no `vscode`, no I/O — so
+// it runs in the ordinary vitest layer rather than only inside an hour-long ExTester run. The
+// suites reach it through `runScopedName` / `runScopedIdentifier` in lib.ts, which supply the
+// current run's id.
+
+/** The run id used when the suite was NOT launched through `scripts/runE2E.mjs`, which is the
+ * only thing that sets `DVPT_E2E_RUN_ID`. A bare `extest` run keeps the unscoped names, so a
+ * developer debugging one suite still gets the short, readable fixtures they can recognise in
+ * the org — the isolation only matters when runs actually overlap, and a bare run is a
+ * deliberate solo one. */
+export const LOCAL_RUN_ID = "local";
+
+/** `scripts/runE2E.mjs` generates base-36 minutes-since-epoch. Anything outside this set would
+ * either break a C# identifier or need OData escaping at every call site. */
+const RUN_ID_PATTERN = /^[a-z0-9]+$/i;
+
+/** C# and TypeScript agree on this much: a leading letter/underscore, then word characters. */
+const IDENTIFIER_PATTERN = /^[A-Za-z_][A-Za-z0-9_]*$/;
+
+/** Reject a run id that would produce an unusable or unsafe fixture name, at the point the name
+ * is built rather than minutes later inside a `dotnet build` or an OData filter. */
+export function assertUsableRunId(runId: string): void {
+  if (runId === LOCAL_RUN_ID) {
+    return;
+  }
+  if (!RUN_ID_PATTERN.test(runId)) {
+    throw new Error(`DVPT_E2E_RUN_ID must be alphanumeric (got ${JSON.stringify(runId)}) — it is appended to Dataverse names and C# identifiers.`);
+  }
+}
+
+/**
+ * `base` with this run's id appended, for a fixture that lives in the shared environment.
+ *
+ * Deliberately a SUFFIX, not a prefix: plug-in package names carry the publisher prefix at the
+ * front (`dvpt_AcceptancePlugin`) and web-resource names are matched by their leading prefix, so
+ * anything prepended would either be stripped or break the lookup.
+ */
+export function scopedName(base: string, runId: string): string {
+  if (!base) {
+    throw new Error("scopedName needs a non-empty base — an unnamed fixture cannot be cleaned up by name.");
+  }
+  assertUsableRunId(runId);
+  return runId === LOCAL_RUN_ID ? base : `${base}${runId}`;
+}
+
+/**
+ * As `scopedName`, for a base that also has to be a legal C#/TypeScript identifier — a plug-in
+ * project, namespace or class name, or a web-resource class.
+ *
+ * These reach a compiler rather than the Web API, so a name that scoping made illegal surfaces
+ * as a build error deep into a suite. Checking here names the cause instead.
+ */
+export function scopedIdentifier(base: string, runId: string): string {
+  if (!IDENTIFIER_PATTERN.test(base)) {
+    throw new Error(`fixture base ${JSON.stringify(base)} is not a legal identifier — it is used as a C#/TypeScript name.`);
+  }
+  const name = scopedName(base, runId);
+  if (!IDENTIFIER_PATTERN.test(name)) {
+    throw new Error(`scoping ${JSON.stringify(base)} with run id ${JSON.stringify(runId)} produced ${JSON.stringify(name)}, which is not a legal identifier.`);
+  }
+  return name;
+}
+
+/** What a profiler clone step found on a shared entity should have done to it. */
+export type StepDisposition = "delete" | "foreign" | "keep";
+
+/**
+ * Decide the fate of one `sdkmessageprocessingstep` row during the profiler suite's cleanup.
+ *
+ * The profiler works by CLONING a step onto its own plug-in type and disabling the original, so
+ * the rows worth deleting are the clones: their plug-in type is the profiler's, or their name ends
+ * in "(Profiler)"/"(Profiled)". Everything else on the entity belongs to the org, not to us.
+ *
+ * `ownedMarker` narrows that to the current run (#258). A clone inherits the original step's name,
+ * so a run id registered into the step name is still present on the clone — which is the only
+ * thing distinguishing two concurrent runs' clones on the same entity. Without the marker the
+ * sweep is org-wide, which is what a solo local run wants and what an overlapping run must not do.
+ */
+export function profilerStepDisposition(stepName: string, pluginTypeName: string, ownedMarker?: string): StepDisposition {
+  const isClone = /ProfilerPlugin/.test(pluginTypeName) || /\((Profiler|Profiled)\)\s*$/.test(stepName);
+  if (!isClone) {
+    return "keep";
+  }
+  if (ownedMarker && !stepName.includes(ownedMarker)) {
+    return "foreign";
+  }
+  return "delete";
+}

--- a/src/ui-test/e2e/lib.ts
+++ b/src/ui-test/e2e/lib.ts
@@ -10,6 +10,7 @@ import { VSBrowser, Workbench, InputBox, BottomBarPanel, Key, ModalDialog } from
 // The SAME lookups the product uses. Keeping a second copy here is what let the product and the test
 // agree on a wrong assumption about how Dataverse stores a name, so a working push read as broken.
 import { customControlLookup, pluginTraceLogLookup, pickMatchingRow } from "../../general/dataverse/rowLookups";
+import { scopedName, scopedIdentifier, profilerStepDisposition } from "./fixtureNames";
 
 export const repoRoot = path.resolve(__dirname, "..", "..", "..");
 
@@ -76,10 +77,16 @@ export function runId(): string {
   return process.env.DVPT_E2E_RUN_ID || "local";
 }
 
-/** `base` with this run's id appended, for fixtures that live in the shared environment. */
+/** `base` with this run's id appended, for fixtures that live in the shared environment.
+ * The rules live in fixtureNames.ts so they can be unit-tested outside an ExTester run (#258). */
 export function runScopedName(base: string): string {
-  const id = runId();
-  return id === "local" ? base : `${base}${id}`;
+  return scopedName(base, runId());
+}
+
+/** As `runScopedName`, for a fixture whose name also has to compile as a C#/TypeScript
+ * identifier — a plug-in project/namespace/class, or a web-resource class (#258). */
+export function runScopedIdentifier(base: string): string {
+  return scopedIdentifier(base, runId());
 }
 
 /** Remove onboarding/notification/modal overlays that intercept clicks. */
@@ -1132,25 +1139,42 @@ export class E2EClient {
     return reactivated;
   }
 
-  async cleanupProfilerSteps(entityLogicalName: string): Promise<number> {
+  /**
+   * Delete the profiler's clone steps on an entity.
+   *
+   * `ownedMarker` scopes the sweep to THIS run (#258): the clone's name is the original step's
+   * name plus " (Profiler)", so a run id in the registered step name is still there on the clone.
+   * Without it this deleted every profiler step on the entity whoever created it — so a run
+   * finishing would delete a concurrent run's live clone mid-capture.
+   *
+   * Foreign clones are counted and returned rather than silently ignored: one left behind keeps
+   * firing on every create in the shared org, so it needs to be VISIBLE in the log even though
+   * deleting it is not this run's business.
+   */
+  async cleanupProfilerSteps(entityLogicalName: string, ownedMarker?: string): Promise<{ deleted: number; foreign: number }> {
     const filter = `sdkmessagefilterid/primaryobjecttypecode eq '${entityLogicalName.replace(/'/g, "''")}'`;
     const res = await this.request("GET", `sdkmessageprocessingsteps?$select=name,sdkmessageprocessingstepid&$expand=plugintypeid($select=typename)&$filter=${filter}`);
     if (!res.ok) {
-      return 0;
+      return { deleted: 0, foreign: 0 };
     }
     const rows: any[] = ((await res.json()) as any).value ?? [];
     let deleted = 0;
+    let foreign = 0;
     for (const s of rows) {
-      const typeName = (s.plugintypeid?.typename as string) ?? "";
-      const name = (s.name as string) ?? "";
-      if (/ProfilerPlugin/.test(typeName) || /\((Profiler|Profiled)\)\s*$/.test(name)) {
-        const del = await this.request("DELETE", `sdkmessageprocessingsteps(${s.sdkmessageprocessingstepid})`);
-        if (del.ok || del.status === 204) {
-          deleted++;
-        }
+      const disposition = profilerStepDisposition((s.name as string) ?? "", (s.plugintypeid?.typename as string) ?? "", ownedMarker);
+      if (disposition === "keep") {
+        continue;
+      }
+      if (disposition === "foreign") {
+        foreign++;
+        continue;
+      }
+      const del = await this.request("DELETE", `sdkmessageprocessingsteps(${s.sdkmessageprocessingstepid})`);
+      if (del.ok || del.status === 204) {
+        deleted++;
       }
     }
-    return deleted;
+    return { deleted, foreign };
   }
 
   /**

--- a/src/ui-test/e2e/lib.ts
+++ b/src/ui-test/e2e/lib.ts
@@ -89,6 +89,20 @@ export function runScopedIdentifier(base: string): string {
   return scopedIdentifier(base, runId());
 }
 
+/**
+ * Set one field in a component's `dataverse-powertools.json`, in place.
+ *
+ * Used to give a web-resource component a run-scoped bundle name (#258). The bundle name is read
+ * at BUILD time by the project's own webpack.common.js, so writing it any time between scaffold
+ * and build is enough — no template regeneration needed.
+ */
+export function setComponentSetting(componentRoot: string, key: string, value: unknown): void {
+  const file = path.join(componentRoot, "dataverse-powertools.json");
+  const settings = JSON.parse(fs.readFileSync(file, "utf8"));
+  settings[key] = value;
+  fs.writeFileSync(file, JSON.stringify(settings, null, 2), "utf8");
+}
+
 /** Remove onboarding/notification/modal overlays that intercept clicks. */
 export async function dismissOverlays(): Promise<void> {
   try {

--- a/src/ui-test/e2e/pcfAcceptance.e2e.ts
+++ b/src/ui-test/e2e/pcfAcceptance.e2e.ts
@@ -55,6 +55,10 @@ describe("ACCEPTANCE: PCF — build, code, publish via panel buttons", function 
   let solutionFriendlyName: string;
   let client: E2EClient;
 
+  // NOT run-scoped (#258). `pac pcf init` is invoked without --namespace/--name
+  // (src/pcf/pcfArgs.ts), so EVERY control the extension scaffolds is SampleNamespace.SampleControl
+  // — which means the two PCF suites collide with each other within a single run, not just across
+  // runs. Scoping needs the product to pass those flags.
   /** Namespace + constructor from the scaffolded control manifest (for the deployed bundle name). */
   function manifest(): { namespace: string; constructor: string } {
     const file = findDeep(workspace, (name) => name === "ControlManifest.Input.xml");

--- a/src/ui-test/e2e/pcfAcceptance.e2e.ts
+++ b/src/ui-test/e2e/pcfAcceptance.e2e.ts
@@ -2,7 +2,7 @@ import * as path from "path";
 import * as fs from "fs";
 import { expect } from "chai";
 import { VSBrowser } from "vscode-extension-tester";
-import { openWorkspaceFolder, loadE2EEnv, freshWorkspace, pickByLabel, dismissOverlays, sleep, E2EClient } from "./lib";
+import { openWorkspaceFolder, loadE2EEnv, freshWorkspace, pickByLabel, dismissOverlays, sleep, answerText, runScopedIdentifier, E2EClient } from "./lib";
 import { clickPanelButton, clickOverflowItem, expandComponentCards } from "../supervised/supervisedLib";
 import { initProject, step, showLog } from "./acceptanceLib";
 
@@ -55,10 +55,13 @@ describe("ACCEPTANCE: PCF — build, code, publish via panel buttons", function 
   let solutionFriendlyName: string;
   let client: E2EClient;
 
-  // NOT run-scoped (#258). `pac pcf init` is invoked without --namespace/--name
-  // (src/pcf/pcfArgs.ts), so EVERY control the extension scaffolds is SampleNamespace.SampleControl
-  // — which means the two PCF suites collide with each other within a single run, not just across
-  // runs. Scoping needs the product to pass those flags.
+  // Run-scoped (#258). The deployed `customcontrol` row is `{prefix}_{namespace}.{constructor}`,
+  // and both come from `pac pcf init`. The extension now asks for them, so the suite can give each
+  // run its own control instead of every run (and BOTH PCF suites) sharing pac's default
+  // SampleNamespace.SampleControl and deploying over each other.
+  const controlName = runScopedIdentifier("AccPcfControl");
+  const CONTROL_NAMESPACE = "DvptE2E";
+
   /** Namespace + constructor from the scaffolded control manifest (for the deployed bundle name). */
   function manifest(): { namespace: string; constructor: string } {
     const file = findDeep(workspace, (name) => name === "ControlManifest.Input.xml");
@@ -91,6 +94,8 @@ describe("ACCEPTANCE: PCF — build, code, publish via panel buttons", function 
       await initProject("PCF Control", env!, solutionFriendlyName, async () => {
         await pickByLabel("Field"); // control template
         await pickByLabel("Standard (no framework)"); // rendering framework
+        await answerText(controlName); // control name — run-scoped (#258)
+        await answerText(CONTROL_NAMESPACE); // control namespace
       });
       const idx = await pollDeep(workspace, (name) => name === "index.ts", 300000);
       const man = await pollDeep(workspace, (name) => name === "ControlManifest.Input.xml", 60000);

--- a/src/ui-test/e2e/pcfInteractiveLifecycle.e2e.ts
+++ b/src/ui-test/e2e/pcfInteractiveLifecycle.e2e.ts
@@ -20,6 +20,7 @@ import {
   logFileSize,
   E2EClient,
   resetAllCredentials,
+  runScopedIdentifier,
 } from "./lib";
 import { clickPanelButton, expandComponentCards } from "../supervised/supervisedLib";
 import { completeDeviceCodeLogin, parseDeviceCode } from "./browserLib";
@@ -165,6 +166,12 @@ describe("PCF lifecycle — interactive auth (e2e)", function () {
     await pickByLabel("Field", 120000);
     log("rendering framework");
     await pickByLabel("Standard (no framework)", 120000);
+    // Control name + namespace (#258): run-scoped, so this suite's control is distinct from
+    // pcfAcceptance's and from a concurrent run's rather than all being SampleNamespace.SampleControl.
+    log("control name");
+    await answerText(runScopedIdentifier("IntPcfControl"));
+    log("control namespace");
+    await answerText("DvptE2E");
     // pac pcf init + npm install run here, so allow for the restore.
     expect(await waitForFile(path.join(workspace, "dataverse-powertools.json"), 300000), "dataverse-powertools.json").to.equal(true);
     const manifestPath = await pollDeep(workspace, (name) => name === "ControlManifest.Input.xml", 600000);

--- a/src/ui-test/e2e/pluginProfilerReplay.e2e.ts
+++ b/src/ui-test/e2e/pluginProfilerReplay.e2e.ts
@@ -22,7 +22,10 @@ import {
   shot,
   shotWithHighlight,
   runCommandResilient,
+  runScopedIdentifier,
+  runId,
 } from "./lib";
+import { LOCAL_RUN_ID } from "./fixtureNames";
 import { clickPanelButton, expandComponentCards } from "../supervised/supervisedLib";
 import { initProject, step, showLog } from "./acceptanceLib";
 
@@ -105,7 +108,7 @@ async function waitForMatchDeep(dir: string, predicate: (name: string) => boolea
  *  background job, so the test never reasons about the trigger's own response.
  *  The namespace/class must match the scaffolded file so `Build & deploy` finds the
  *  [CrmPluginRegistration]. */
-function territoryPluginSource(namespaceName: string, className: string): string {
+function territoryPluginSource(namespaceName: string, className: string, stepMarkerName: string): string {
   return `using Microsoft.Xrm.Sdk;
 using System;
 
@@ -115,7 +118,7 @@ namespace ${namespaceName}
     /// Onboards a new territory: validates the name, derives the sales region and the territory code
     /// from it, and traces what it worked out.
     /// </summary>
-    [CrmPluginRegistration(MessageNameEnum.Create, "territory", StageEnum.PostOperation, ExecutionModeEnum.Asynchronous, "", "Create territory (DVPT profiler e2e)", 1, IsolationModeEnum.Sandbox)]
+    [CrmPluginRegistration(MessageNameEnum.Create, "territory", StageEnum.PostOperation, ExecutionModeEnum.Asynchronous, "", "Create territory (DVPT profiler e2e ${stepMarkerName})", 1, IsolationModeEnum.Sandbox)]
     public class ${className} : PluginBase
     {
         public ${className}(string unsecureConfiguration, string secureConfiguration)
@@ -185,9 +188,15 @@ describe("DEBUGGING: Plugin — profile capture → replay → execute via panel
   let client: E2EClient;
   // Named like a project someone would really have: these names appear in the wiki walkthrough's
   // screenshots, and "ProfilerE2E/ProfilerProbe" told the reader nothing except that it was a test.
-  const projectName = "ContosoTerritories";
-  const packageName = "ContosoTerritories";
-  const className = "TerritoryOnboarding";
+  // Scoped per run (#258): all three end up as rows in the ONE shared org — the plug-in package,
+  // its assembly/type, and the registered step — so two overlapping runs would otherwise deploy
+  // over each other and each suite's cleanup would delete the other's.
+  const projectName = runScopedIdentifier("ContosoTerritories");
+  const packageName = runScopedIdentifier("ContosoTerritories");
+  const className = runScopedIdentifier("TerritoryOnboarding");
+  // Goes into the step's registered NAME, which the profiler's clone inherits (plus " (Profiler)"),
+  // so `cleanupProfilerSteps` can tell this run's clone from a concurrent run's.
+  const stepMarker = runId();
   let typeName = `${projectName}.${className}`; // refined from the scaffolded file's real namespace
   let triggeredTerritoryId: string | undefined;
   /** The second trigger, fired with tracing ON so the viewer has a real row to show (#231). */
@@ -238,7 +247,7 @@ describe("DEBUGGING: Plugin — profile capture → replay → execute via panel
       const scaffolded = fs.readFileSync(cs, "utf8");
       const ns = /namespace\s+([A-Za-z0-9_.]+)/.exec(scaffolded)?.[1] ?? projectName;
       typeName = `${ns}.${className}`;
-      fs.writeFileSync(cs, territoryPluginSource(ns, className), "utf8");
+      fs.writeFileSync(cs, territoryPluginSource(ns, className, stepMarker), "utf8");
       return `wrote ${projectName}/${className}.cs — [CrmPluginRegistration(Create, territory, Post, Async)] type ${typeName}`;
     });
   });
@@ -839,9 +848,14 @@ describe("DEBUGGING: Plugin — profile capture → replay → execute via panel
     // "(Profiler)" step keeps firing on Create-of-territory and every territory create in the shared
     // org then 400s. This must run regardless of how the tail failed.
     try {
-      const removed = await client.cleanupProfilerSteps("territory");
-      if (removed > 0) {
-        console.log(`[cleanup] removed ${removed} leftover profiler step(s) on territory`);
+      const { deleted, foreign } = await client.cleanupProfilerSteps("territory", stepMarker === LOCAL_RUN_ID ? undefined : stepMarker);
+      if (deleted > 0) {
+        console.log(`[cleanup] removed ${deleted} leftover profiler step(s) on territory`);
+      }
+      if (foreign > 0) {
+        // Another run's, or an abandoned one. Not ours to delete — but a live "(Profiler)" step
+        // makes every territory create in the shared org fail, so say so loudly.
+        console.log(`[cleanup] WARNING: left ${foreign} profiler step(s) on territory belonging to another run — if no run is active, delete them by hand`);
       }
     } catch {
       /* best-effort */

--- a/src/ui-test/e2e/webresourceAcceptance.e2e.ts
+++ b/src/ui-test/e2e/webresourceAcceptance.e2e.ts
@@ -35,6 +35,11 @@ describe("ACCEPTANCE: Web Resource — build, code, register, publish via panel 
 
   function libraryName(): string {
     const settings = JSON.parse(fs.readFileSync(path.join(workspace, "dataverse-powertools.json"), "utf8"));
+    // NOT run-scoped (#258). In bundle output mode the deployed name is `{prefix}_library.js`, and
+    // BOTH halves are fixed: the prefix is inferred from the chosen solution's publisher (an invented
+    // one would be rejected by Dataverse), and "library" is hardcoded by the product — in
+    // src/webresources/libraryNames.ts and in templates/webresources/webpack.common.js. Scoping this
+    // therefore needs a configurable bundle name in the product, not a change here.
     return `${settings.prefix ?? env?.prefix}_library.js`;
   }
 

--- a/src/ui-test/e2e/webresourceAcceptance.e2e.ts
+++ b/src/ui-test/e2e/webresourceAcceptance.e2e.ts
@@ -15,6 +15,8 @@ import {
   E2EClient,
   waitForLogFile,
   logFileSize,
+  runScopedName,
+  setComponentSetting,
 } from "./lib";
 import { clickPanelButton, clickOverflowItem, expandComponentCards } from "../supervised/supervisedLib";
 import { initProject, step, showLog } from "./acceptanceLib";
@@ -33,14 +35,16 @@ describe("ACCEPTANCE: Web Resource — build, code, register, publish via panel 
   let client: E2EClient;
   const className = "AcceptanceWebResource";
 
+  // The bundle output name for this run (#258). The product defaults it to "library"; the suite
+  // overrides it right after scaffold so each run deploys to its own web resource.
+  const LIBRARY_BASE = runScopedName("library");
   function libraryName(): string {
     const settings = JSON.parse(fs.readFileSync(path.join(workspace, "dataverse-powertools.json"), "utf8"));
-    // NOT run-scoped (#258). In bundle output mode the deployed name is `{prefix}_library.js`, and
-    // BOTH halves are fixed: the prefix is inferred from the chosen solution's publisher (an invented
-    // one would be rejected by Dataverse), and "library" is hardcoded by the product — in
-    // src/webresources/libraryNames.ts and in templates/webresources/webpack.common.js. Scoping this
-    // therefore needs a configurable bundle name in the product, not a change here.
-    return `${settings.prefix ?? env?.prefix}_library.js`;
+    // Run-scoped (#258): the deployed bundle is `{prefix}_{webresourceLibraryName}.js`. The prefix
+    // is the solution publisher's and can't change, but the bundle name is now a project setting
+    // the suite writes right after scaffold — so two overlapping runs stop deploying over each
+    // other's `{prefix}_library.js`.
+    return `${settings.prefix ?? env?.prefix}_${LIBRARY_BASE}.js`;
   }
 
   before(async function () {
@@ -65,6 +69,9 @@ describe("ACCEPTANCE: Web Resource — build, code, register, publish via panel 
         await pickByLabel("No", 600000); // "create a new webresource?" — restores + typings run first
       });
       expect(await waitForFile(path.join(workspace, "dataverse-powertools.json"), 300000), "project scaffolded").to.equal(true);
+      // Give this run its own bundle name before anything builds (#258) — webpack.common.js reads
+      // it from dataverse-powertools.json at build time, so this is the only step needed.
+      setComponentSetting(workspace, "webresourceLibraryName", LIBRARY_BASE);
       return "Web Resources project scaffolded + connected (service principal)";
     });
   });

--- a/src/ui-test/e2e/webresourceComprehensive.e2e.ts
+++ b/src/ui-test/e2e/webresourceComprehensive.e2e.ts
@@ -67,6 +67,11 @@ describe("Web resources — comprehensive UI lifecycle (e2e)", function () {
   function libraryName(): string {
     try {
       const settings = JSON.parse(fs.readFileSync(path.join(workspace, "dataverse-powertools.json"), "utf8"));
+      // NOT run-scoped (#258). In bundle output mode the deployed name is `{prefix}_library.js`, and
+      // BOTH halves are fixed: the prefix is inferred from the chosen solution's publisher (an invented
+      // one would be rejected by Dataverse), and "library" is hardcoded by the product — in
+      // src/webresources/libraryNames.ts and in templates/webresources/webpack.common.js. Scoping this
+      // therefore needs a configurable bundle name in the product, not a change here.
       return `${settings.prefix}_library.js`;
     } catch {
       return `${env?.prefix}_library.js`;

--- a/src/ui-test/e2e/webresourceComprehensive.e2e.ts
+++ b/src/ui-test/e2e/webresourceComprehensive.e2e.ts
@@ -19,6 +19,8 @@ import {
   dismissOverlays,
   sleep,
   E2EClient,
+  runScopedName,
+  setComponentSetting,
 } from "./lib";
 import { resetAllCredentials, shot, shotEditorHalf, SIDE_BY_SIDE_HALF } from "./lib";
 import {
@@ -64,15 +66,17 @@ describe("Web resources — comprehensive UI lifecycle (e2e)", function () {
   const orgHost = env ? new URL(env.url).host : "";
   const classFile = () => path.join(workspace, "webresources_src", `${className}.ts`);
 
+  // The bundle output name for this run (#258). The product defaults it to "library"; the suite
+  // overrides it right after scaffold so each run deploys to its own web resource.
+  const LIBRARY_BASE = runScopedName("library");
   function libraryName(): string {
     try {
       const settings = JSON.parse(fs.readFileSync(path.join(workspace, "dataverse-powertools.json"), "utf8"));
-      // NOT run-scoped (#258). In bundle output mode the deployed name is `{prefix}_library.js`, and
-      // BOTH halves are fixed: the prefix is inferred from the chosen solution's publisher (an invented
-      // one would be rejected by Dataverse), and "library" is hardcoded by the product — in
-      // src/webresources/libraryNames.ts and in templates/webresources/webpack.common.js. Scoping this
-      // therefore needs a configurable bundle name in the product, not a change here.
-      return `${settings.prefix}_library.js`;
+      // Run-scoped (#258): the deployed bundle is `{prefix}_{webresourceLibraryName}.js`. The prefix
+      // is the solution publisher's and can't change, but the bundle name is now a project setting
+      // the suite writes right after scaffold — so two overlapping runs stop deploying over each
+      // other's `{prefix}_library.js`.
+      return `${settings.prefix}_${LIBRARY_BASE}.js`;
     } catch {
       return `${env?.prefix}_library.js`;
     }
@@ -142,6 +146,9 @@ describe("Web resources — comprehensive UI lifecycle (e2e)", function () {
     await dismissOverlays();
 
     expect(await waitForFile(path.join(workspace, "dataverse-powertools.json"), 60000), "dataverse-powertools.json").to.equal(true);
+    // Give this run its own bundle name before anything builds (#258) — webpack.common.js reads
+    // it from dataverse-powertools.json at build time, so this is the only step needed.
+    setComponentSetting(workspace, "webresourceLibraryName", LIBRARY_BASE);
     // #78: the old Windows-only nuget XrmDefinitelyTyped.exe must NOT be restored any more.
     expect(fs.existsSync(path.join(workspace, "packages", "Delegate.XrmDefinitelyTyped")), "old XrmDefinitelyTyped nuget should be gone").to.equal(false);
   });

--- a/src/ui-test/e2e/webresourceInteractiveLifecycle.e2e.ts
+++ b/src/ui-test/e2e/webresourceInteractiveLifecycle.e2e.ts
@@ -17,6 +17,8 @@ import {
   dismissOverlays,
   sleep,
   E2EClient,
+  runScopedName,
+  setComponentSetting,
 } from "./lib";
 import { resetAllCredentials } from "./lib";
 
@@ -34,15 +36,17 @@ describe("Web resources lifecycle — interactive auth (e2e)", function () {
   let workspace: string;
   let solutionFriendlyName: string;
 
+  // The bundle output name for this run (#258). The product defaults it to "library"; the suite
+  // overrides it right after scaffold so each run deploys to its own web resource.
+  const LIBRARY_BASE = runScopedName("library");
   function libraryName(): string {
     try {
       const settings = JSON.parse(fs.readFileSync(path.join(workspace, "dataverse-powertools.json"), "utf8"));
-      // NOT run-scoped (#258). In bundle output mode the deployed name is `{prefix}_library.js`, and
-      // BOTH halves are fixed: the prefix is inferred from the chosen solution's publisher (an invented
-      // one would be rejected by Dataverse), and "library" is hardcoded by the product — in
-      // src/webresources/libraryNames.ts and in templates/webresources/webpack.common.js. Scoping this
-      // therefore needs a configurable bundle name in the product, not a change here.
-      return `${settings.prefix}_library.js`;
+      // Run-scoped (#258): the deployed bundle is `{prefix}_{webresourceLibraryName}.js`. The prefix
+      // is the solution publisher's and can't change, but the bundle name is now a project setting
+      // the suite writes right after scaffold — so two overlapping runs stop deploying over each
+      // other's `{prefix}_library.js`.
+      return `${settings.prefix}_${LIBRARY_BASE}.js`;
     } catch {
       return `${env?.prefix}_library.js`;
     }
@@ -104,6 +108,9 @@ describe("Web resources lifecycle — interactive auth (e2e)", function () {
     await dismissOverlays();
 
     expect(await waitForFile(path.join(workspace, "dataverse-powertools.json"), 60000), "dataverse-powertools.json").to.equal(true);
+    // Give this run its own bundle name before anything builds (#258) — webpack.common.js reads
+    // it from dataverse-powertools.json at build time, so this is the only step needed.
+    setComponentSetting(workspace, "webresourceLibraryName", LIBRARY_BASE);
   });
 
   it("generates typings under interactive auth (bundled net8 tool, #91)", async () => {

--- a/src/ui-test/e2e/webresourceInteractiveLifecycle.e2e.ts
+++ b/src/ui-test/e2e/webresourceInteractiveLifecycle.e2e.ts
@@ -37,6 +37,11 @@ describe("Web resources lifecycle — interactive auth (e2e)", function () {
   function libraryName(): string {
     try {
       const settings = JSON.parse(fs.readFileSync(path.join(workspace, "dataverse-powertools.json"), "utf8"));
+      // NOT run-scoped (#258). In bundle output mode the deployed name is `{prefix}_library.js`, and
+      // BOTH halves are fixed: the prefix is inferred from the chosen solution's publisher (an invented
+      // one would be rejected by Dataverse), and "library" is hardcoded by the product — in
+      // src/webresources/libraryNames.ts and in templates/webresources/webpack.common.js. Scoping this
+      // therefore needs a configurable bundle name in the product, not a change here.
       return `${settings.prefix}_library.js`;
     } catch {
       return `${env?.prefix}_library.js`;

--- a/src/ui-test/e2e/webresourcePerFileLifecycle.e2e.ts
+++ b/src/ui-test/e2e/webresourcePerFileLifecycle.e2e.ts
@@ -17,6 +17,7 @@ import {
   dismissOverlays,
   sleep,
   E2EClient,
+  runScopedIdentifier,
 } from "./lib";
 import { resetAllCredentials, assertSourceMapBindsBreakpoints } from "./lib";
 
@@ -31,7 +32,10 @@ import { resetAllCredentials, assertSourceMapBindsBreakpoints } from "./lib";
 describe("Web resources lifecycle — per-file output (e2e)", function () {
   this.timeout(900000);
   const env = loadE2EEnv();
-  const className = "E2EPerFile";
+  // Scoped per run (#258): in per-file output mode the deployed web resource is
+  // `{prefix}_{className}.js`, so the class name is what keeps two overlapping runs from
+  // deploying over each other's row — and from each cleaning up the other's.
+  const className = runScopedIdentifier("E2EPerFile");
   let workspace: string;
   let solutionFriendlyName: string;
   let formId = "";

--- a/src/webresources/libraryNames.spec.ts
+++ b/src/webresources/libraryNames.spec.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { webresourceLibraryName, candidateLibraryNames } from "./libraryNames";
+import { webresourceLibraryName, candidateLibraryNames, defaultLibraryBaseName, libraryBaseFor, DEFAULT_LIBRARY_BASE } from "./libraryNames";
 
 describe("webresourceLibraryName", () => {
   it("bundle mode maps every source file to the bundled library", () => {
@@ -21,5 +21,80 @@ describe("candidateLibraryNames", () => {
   it("covers both modes so a mode switch's leftovers are cleanable", () => {
     const names = candidateLibraryNames("dvpt", ["/p/webresources_src/Account.ts", "/p/webresources_src/Contact.ts"]);
     expect(names).toEqual(new Set(["dvpt_library.js", "dvpt_Account.js", "dvpt_Contact.js"]));
+  });
+});
+
+// #258 — deployWebresources uploads everything in bin/ BY FILENAME, so two web-resource
+// components that both emit {prefix}_library.js silently deploy over each other.
+describe("configurable bundle name (#258)", () => {
+  it("still emits the historical name when nothing configures one", () => {
+    // The whole migration story rests on this: no existing project changes.
+    expect(webresourceLibraryName("dvpt", "bundle", "/p/webresources_src/Account.ts")).toBe("dvpt_library.js");
+    expect(DEFAULT_LIBRARY_BASE).toBe("library");
+  });
+
+  it("uses a configured bundle base in bundle mode", () => {
+    expect(webresourceLibraryName("dvpt", "bundle", "/p/webresources_src/Account.ts", "grid")).toBe("dvpt_grid.js");
+    expect(webresourceLibraryName("dvpt", undefined, "/p/webresources_src/Account.ts", "grid")).toBe("dvpt_grid.js");
+  });
+
+  it("does not affect per-file names, which are already unique per source file", () => {
+    expect(webresourceLibraryName("dvpt", "perFile", "/p/webresources_src/Account.ts", "grid")).toBe("dvpt_Account.js");
+    // library.ts is the barrel, so it maps to the bundle name even in per-file mode.
+    expect(webresourceLibraryName("dvpt", "perFile", "/p/webresources_src/library.ts", "grid")).toBe("dvpt_grid.js");
+  });
+
+  it("falls back rather than emitting a nameless resource for junk input", () => {
+    // A nameless <Library> is what Dataverse rejected with 0x80048425 — never emit one.
+    expect(webresourceLibraryName("dvpt", "bundle", "/p/x.ts", "")).toBe("dvpt_library.js");
+    expect(webresourceLibraryName("dvpt", "bundle", "/p/x.ts", "!!!")).toBe("dvpt_library.js");
+    expect(webresourceLibraryName("dvpt", "bundle", "/p/x.ts", "my grid!")).toBe("dvpt_mygrid.js");
+  });
+
+  describe("defaultLibraryBaseName", () => {
+    it("keeps the root component on library, so existing projects are untouched", () => {
+      expect(defaultLibraryBaseName("")).toBe("library");
+    });
+
+    it("names a sub-component after its folder, so two of them differ", () => {
+      expect(defaultLibraryBaseName("controls")).toBe("controls");
+      expect(defaultLibraryBaseName("src/accountForms")).toBe("accountForms");
+      expect(defaultLibraryBaseName("src\\contactForms")).toBe("contactForms");
+      expect(defaultLibraryBaseName("web-one")).not.toBe(defaultLibraryBaseName("web-two"));
+    });
+
+    it("strips what a web-resource name cannot carry, and falls back if nothing survives", () => {
+      expect(defaultLibraryBaseName("my-forms")).toBe("myforms");
+      expect(defaultLibraryBaseName("---")).toBe("library");
+    });
+  });
+
+  describe("libraryBaseFor", () => {
+    it("defaults when unset, empty, or all-junk", () => {
+      expect(libraryBaseFor(undefined)).toBe("library");
+      expect(libraryBaseFor({})).toBe("library");
+      expect(libraryBaseFor({ webresourceLibraryName: "" })).toBe("library");
+      expect(libraryBaseFor({ webresourceLibraryName: "!!" })).toBe("library");
+    });
+
+    it("returns the configured name", () => {
+      expect(libraryBaseFor({ webresourceLibraryName: "grid" })).toBe("grid");
+    });
+  });
+
+  describe("candidateLibraryNames keeps the OLD name deletable", () => {
+    it("owns both the configured bundle and the historical library name", () => {
+      // A project that renames its bundle still has handlers pointing at {prefix}_library.js.
+      // Dropping it from the owned set would strand them on a resource nobody deploys any more.
+      const names = candidateLibraryNames("dvpt", ["/p/webresources_src/Account.ts"], "grid");
+      expect(names.has("dvpt_grid.js")).toBe(true);
+      expect(names.has("dvpt_library.js")).toBe(true);
+      expect(names.has("dvpt_Account.js")).toBe(true);
+    });
+
+    it("is unchanged for a project that configures nothing", () => {
+      const names = candidateLibraryNames("dvpt", ["/p/webresources_src/Account.ts"]);
+      expect([...names].sort()).toEqual(["dvpt_Account.js", "dvpt_library.js"]);
+    });
   });
 });

--- a/src/webresources/libraryNames.ts
+++ b/src/webresources/libraryNames.ts
@@ -6,7 +6,42 @@
 // ternary, which serialized a <Library> element WITHOUT its required `name`
 // attribute and had Dataverse reject the whole form (0x80048425).
 
-export function webresourceLibraryName(prefix: string, output: "bundle" | "perFile" | undefined, sourceFilePath: string): string {
+/** The bundle base name used when a project doesn't configure one — i.e. every project
+ * scaffolded before #258, and every root component since. Changing this would rename the
+ * deployed web resource of every existing project, orphaning it and breaking the form
+ * registrations that point at it. Don't. */
+export const DEFAULT_LIBRARY_BASE = "library";
+
+/** Only what a Dataverse web-resource name segment safely allows. */
+function sanitiseLibraryBase(raw: string): string {
+  return raw.replace(/[^A-Za-z0-9_]/g, "");
+}
+
+/**
+ * The bundle base name a NEWLY scaffolded component should be given (#258).
+ *
+ * Bundle mode deploys to `{prefix}_{base}.js`, and `deployWebresources` uploads everything in
+ * `bin/` BY FILENAME — so before this, two web-resource components in one workspace (#47) both
+ * produced `{prefix}_library.js` and the second silently deployed over the first.
+ *
+ * The root component keeps `library`, so single-component projects — which is nearly all of them
+ * — are completely unaffected. A sub-component is named after its folder, which is unique within
+ * the workspace by construction. Only ever called at scaffold time: applying it to an EXISTING
+ * component would rename a resource that is already deployed.
+ */
+export function defaultLibraryBaseName(relativeRoot: string): string {
+  const leaf = relativeRoot.replace(/\\/g, "/").split("/").filter(Boolean).pop() ?? "";
+  const sanitised = sanitiseLibraryBase(leaf);
+  return sanitised || DEFAULT_LIBRARY_BASE;
+}
+
+/** The configured bundle base for a component, falling back to the historical `library`. */
+export function libraryBaseFor(settings: { webresourceLibraryName?: string } | undefined): string {
+  const configured = sanitiseLibraryBase(settings?.webresourceLibraryName ?? "");
+  return configured || DEFAULT_LIBRARY_BASE;
+}
+
+export function webresourceLibraryName(prefix: string, output: "bundle" | "perFile" | undefined, sourceFilePath: string, bundleBase: string = DEFAULT_LIBRARY_BASE): string {
   if (output === "perFile") {
     const base = sourceFilePath.replace(/\\/g, "/").split("/").pop()!.replace(/\.ts$/, "");
     // library.ts isn't a per-file entry — it (and bundle mode) maps to the bundled name.
@@ -14,15 +49,18 @@ export function webresourceLibraryName(prefix: string, output: "bundle" | "perFi
       return `${prefix}_${base}.js`;
     }
   }
-  return `${prefix}_library.js`;
+  return `${prefix}_${sanitiseLibraryBase(bundleBase) || DEFAULT_LIBRARY_BASE}.js`;
 }
 
 /** Every library name this project could have produced in EITHER output mode.
  * The registration cleanup may only delete handlers whose library is in this
  * set — never another solution's — and covering both modes means leftovers
  * from a mode switch are cleaned up too. */
-export function candidateLibraryNames(prefix: string, sourceFilePaths: string[]): Set<string> {
-  const names = new Set([`${prefix}_library.js`]);
+export function candidateLibraryNames(prefix: string, sourceFilePaths: string[], bundleBase: string = DEFAULT_LIBRARY_BASE): Set<string> {
+  // Both the CONFIGURED bundle name and the historical `library`: a project that renames its
+  // bundle still has handlers pointing at the old name, and those are ours to clean up. Missing
+  // the old name would strand them on a web resource that no longer gets deployed.
+  const names = new Set([`${prefix}_${sanitiseLibraryBase(bundleBase) || DEFAULT_LIBRARY_BASE}.js`, `${prefix}_${DEFAULT_LIBRARY_BASE}.js`]);
   for (const file of sourceFilePaths) {
     names.add(webresourceLibraryName(prefix, "perFile", file));
   }

--- a/src/webresources/saveFormData.ts
+++ b/src/webresources/saveFormData.ts
@@ -3,7 +3,7 @@ import * as vscode from "vscode";
 import { DataverseForm } from "../general/dataverse/DataverseForm";
 import { randomUUID } from "crypto";
 import { parseRegisterEvents, validateRegisterEvent, RegisterEventDecoration } from "./registerEventParser";
-import { webresourceLibraryName, candidateLibraryNames } from "./libraryNames";
+import { webresourceLibraryName, candidateLibraryNames, libraryBaseFor } from "./libraryNames";
 import { applyFormRegistrations, ResolvedRegistration } from "./formRegistrationXml";
 import { activeComponentRoot } from "../components/componentDiscovery";
 
@@ -90,12 +90,14 @@ export async function saveFormDataExec(context: DataversePowerToolsContext, opti
     throw new Error("No publisher prefix in dataverse-powertools.json — cannot determine the web resource library name. No forms were changed.");
   }
   const outputMode = context.projectSettings.webresourceOutput;
-  const libraryFor = (event: SourcedRegisterEvent) => webresourceLibraryName(prefix, outputMode, event.sourceFile);
+  const bundleBase = libraryBaseFor(context.projectSettings);
+  const libraryFor = (event: SourcedRegisterEvent) => webresourceLibraryName(prefix, outputMode, event.sourceFile, bundleBase);
   // Only handlers bound to one of OUR possible library names (either mode) may be
   // cleaned up — other solutions' handlers on the same form are untouchable.
   const ownedLibraries = candidateLibraryNames(
     prefix,
     files.map((file) => file.fsPath),
+    bundleBase,
   );
 
   let totalForms = 0;

--- a/src/webresources/webpackTemplateOutput.spec.ts
+++ b/src/webresources/webpackTemplateOutput.spec.ts
@@ -1,0 +1,73 @@
+// @vitest-environment node
+//
+// The SHIPPING webpack.common.js template decides the deployed bundle's filename; libraryNames.ts
+// decides what form registrations point AT. They have to agree, and nothing but this test checks
+// that they do — which is the exact failure the module header of libraryNames.ts records: the old
+// regex scrape of this template silently drifted and produced a <Library> with no name attribute,
+// so Dataverse rejected whole forms with 0x80048425.
+//
+// So this loads the real template, with a real settings file, and asserts the filename it computes
+// is character-for-character what webresourceLibraryName predicts.
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import * as fs from "fs";
+import * as path from "path";
+import { createRequire } from "module";
+import { webresourceLibraryName } from "./libraryNames";
+import { applyProjectPlaceholders } from "../general/templateSubstitution";
+
+const TEMPLATE = path.resolve(__dirname, "../../templates/webresources/webpack.common.js/1.js");
+const PREFIX = "dvpt";
+
+let root: string;
+
+/** Materialise a project the template can load: its settings file, and the one module it
+ * require.resolve()s at load time. */
+function project(settings: Record<string, unknown>): string {
+  const dir = fs.mkdtempSync(path.join(root, "proj-"));
+  fs.mkdirSync(path.join(dir, "webresources_src", "lib"), { recursive: true });
+  fs.writeFileSync(path.join(dir, "webresources_src", "lib", "dg.xrmquery.web.min.js"), "module.exports = {};", "utf8");
+  fs.writeFileSync(path.join(dir, "webresources_src", "library.ts"), "export {};", "utf8");
+  fs.writeFileSync(path.join(dir, "dataverse-powertools.json"), JSON.stringify({ prefix: PREFIX, ...settings }), "utf8");
+  fs.writeFileSync(path.join(dir, "webpack.common.js"), applyProjectPlaceholders(fs.readFileSync(TEMPLATE, "utf8"), { prefix: PREFIX }), "utf8");
+  return dir;
+}
+
+/** The output filename the project's own webpack config would use. */
+function outputFilename(settings: Record<string, unknown>): string {
+  const dir = project(settings);
+  const config = createRequire(path.join(dir, "webpack.common.js"))(path.join(dir, "webpack.common.js"));
+  return config.output.filename;
+}
+
+describe("webpack.common.js template vs libraryNames (#258)", () => {
+  beforeAll(() => {
+    // Inside the repo, not the system temp dir: the template `require("webpack")`, and node only
+    // finds it by walking up to this repo's node_modules — exactly as it does in a real project
+    // that has webpack as a local devDependency.
+    root = fs.mkdtempSync(path.resolve(__dirname, "../../.tmp-webpack-spec-"));
+  });
+  afterAll(() => {
+    fs.rmSync(root, { recursive: true, force: true });
+  });
+
+  it("emits the historical name when the project configures nothing", () => {
+    expect(outputFilename({})).toBe("dvpt_library.js");
+    expect(outputFilename({})).toBe(webresourceLibraryName(PREFIX, "bundle", "library.ts"));
+  });
+
+  it("emits the configured bundle name, matching what registrations will point at", () => {
+    expect(outputFilename({ webresourceLibraryName: "grid" })).toBe("dvpt_grid.js");
+    expect(outputFilename({ webresourceLibraryName: "grid" })).toBe(webresourceLibraryName(PREFIX, "bundle", "library.ts", "grid"));
+  });
+
+  it("agrees with libraryNames on junk input rather than emitting a nameless resource", () => {
+    for (const configured of ["", "!!!", "my grid!"]) {
+      expect(outputFilename({ webresourceLibraryName: configured }), configured).toBe(webresourceLibraryName(PREFIX, "bundle", "library.ts", configured));
+    }
+  });
+
+  it("leaves per-file mode on webpack's own [name] token", () => {
+    // Per-file names come from the source filenames, so the bundle setting must not touch them.
+    expect(outputFilename({ webresourceOutput: "perFile", webresourceLibraryName: "grid" })).toBe("dvpt_[name].js");
+  });
+});

--- a/templates/webresources/webpack.common.js/1.js
+++ b/templates/webresources/webpack.common.js/1.js
@@ -16,6 +16,11 @@ const settings = (() => {
   }
 })();
 const perFile = settings.webresourceOutput === "perFile";
+// Bundle output name (#258): the deployed web resource is SOLUTIONPREFIX_<this>.js. Defaults to
+// "library" — every project scaffolded before this setting existed keeps exactly the name it
+// already deploys to. A sub-component is given its folder name at scaffold so two web-resource
+// components in one workspace stop overwriting each other's resource.
+const libraryName = String(settings.webresourceLibraryName || "library").replace(/[^A-Za-z0-9_]/g, "") || "library";
 const perFileEntries = () =>
   Object.fromEntries(
     Fs.readdirSync(Path.resolve(__dirname, "webresources_src"))
@@ -57,7 +62,7 @@ module.exports = {
         library: { name: "SOLUTIONPREFIX", type: "assign-properties" },
       }
     : {
-        filename: "SOLUTIONPREFIX_library.js",
+        filename: "SOLUTIONPREFIX_" + libraryName + ".js",
         library: ["SOLUTIONPREFIX"], //used to call functions on forms eg: LIBRARYPREFIX.Class.Function
         libraryTarget: "var",
       },

--- a/test/live/webresourceScaffoldLifecycle.spec.ts
+++ b/test/live/webresourceScaffoldLifecycle.spec.ts
@@ -143,6 +143,35 @@ live("web resources scaffold -> restore -> build -> deploy (command level)", () 
     expect(fs.existsSync(path.join(projectDir, "bin", libraryName)), `bin/${libraryName} produced by webpack`).toBe(true);
   }, 180000);
 
+  // #258 — the bundle output name is a project setting now, so two web-resource components in one
+  // workspace stop both deploying to {prefix}_library.js. The default above proves nothing changed
+  // for existing projects; this proves the setting actually reaches a REAL webpack build. Reuses
+  // the same project (node_modules already installed) rather than scaffolding a second one.
+  it("honours webresourceLibraryName, so a second component can deploy alongside the first", () => {
+    // The settings file is written by the WIZARD, not the template, so a scaffold made here has
+    // none — which is itself the default case the previous test covers. Write one, as a real
+    // project has.
+    const settingsFile = path.join(projectDir, "dataverse-powertools.json");
+    const original = fs.existsSync(settingsFile) ? fs.readFileSync(settingsFile, "utf8") : undefined;
+    const scoped = `${cfg.prefix}_secondcomponent.js`;
+    try {
+      const settings = { ...(original ? JSON.parse(original) : {}), webresourceLibraryName: "secondcomponent" };
+      fs.writeFileSync(settingsFile, JSON.stringify(settings, null, 2), "utf8");
+      cp.execSync("webpack --config webpack.dev.js", { cwd: projectDir, stdio: "pipe", timeout: 180000 });
+      expect(fs.existsSync(path.join(projectDir, "bin", scoped)), `bin/${scoped} produced by webpack`).toBe(true);
+      // A DIFFERENT resource, not a rename — the first component's bundle is still there, which is
+      // exactly what makes two components able to coexist.
+      expect(scoped).not.toBe(libraryName);
+      expect(fs.existsSync(path.join(projectDir, "bin", libraryName)), `bin/${libraryName} still present`).toBe(true);
+    } finally {
+      if (original === undefined) {
+        fs.rmSync(settingsFile, { force: true });
+      } else {
+        fs.writeFileSync(settingsFile, original, "utf8");
+      }
+    }
+  }, 180000);
+
   it("deploys the built webresource through the extension code and verifies it in Dataverse", async () => {
     const content = fs.readFileSync(path.join(projectDir, "bin", libraryName)).toString("base64");
     const webresource = new DataverseWebresource(libraryName, context);


### PR DESCRIPTION
Closes #258.

Two commits: the e2e fixture scoping, and the two **product** changes that turned out to block the rest of it. Both product changes fix a real user-facing collision in a multi-component workspace (#47) — they are not test accommodations.

## 1. Name your PCF control when you scaffold it

`promptPcfInitArgs` never passed `--namespace`/`--name`, so pac used its defaults and **every** control this extension has ever scaffolded is `SampleNamespace.SampleControl`. Two PCF components in one workspace therefore push to the same `customcontrol` row and the second replaces the first.

Confirmed directly rather than inferred — pac 2.8.1, no flags:

```
$ mkdir acc-pcf-ab12cd && cd acc-pcf-ab12cd && pac pcf init --template field --framework none
namespace="SampleNamespace"   constructor="SampleControl"     # the folder name has no effect
```

It now asks, suggesting a PascalCase name derived from the component folder. Escaping **keeps the suggestion** rather than reverting to the colliding default — the value is shown prefilled, so that isn't a surprise, and reverting would put the collision back.

These two tokens are the only free text that has ever reached this argv, so `pcfInitArgs` validates them as identifiers as well as the prompt's `validateInput` does. pac is spawned with an args array and no shell (`src/general/pac.ts`), so this is about pac rejecting a malformed name, not injection.

## 2. Two Web Resources components no longer deploy over each other

In bundle mode the deployed name was a fixed `{prefix}_library.js`, and `deploy()` uploads everything in `bin/` **by filename** — so two components both emitted it and whichever deployed second won.

The name is now the `webresourceLibraryName` setting, read at **build** time by the project's own `webpack.common.js` (which already reads that file for `webresourceOutput`) — so no placeholder plumbing was needed.

**The migration story is the important part.** A new *subfolder* component is given its folder name; the **root keeps `library`**. So no existing project's deployed resource is renamed, orphaned, or has its form registrations broken. `candidateLibraryNames` still owns the old name, so renaming a bundle cleans up handlers pointing at the previous one instead of stranding them. `configRevision` 1 → 2 offers existing projects the new template.

### A contract that nothing was checking

The template and `libraryNames.ts` must agree on the filename, and nothing verified that — which is the exact drift `libraryNames.ts`'s own header records (a `<Library>` with no `name` attribute, rejected as 0x80048425). `webpackTemplateOutput.spec.ts` now loads the **shipping template** with a real settings file and asserts its filename is what `webresourceLibraryName` predicts. Reverting the template fails two of its four cases.

## 3. The e2e fixtures these unblocked

Both PCF suites now take a run-scoped control name — they previously collided **with each other inside a single run**. The three bundle-mode web-resource suites take a run-scoped bundle name. Plus the first commit's work: profiler/per-file fixtures scoped, and `cleanupProfilerSteps` no longer deletes a concurrent run's live clone mid-capture (it counts and warns about foreign ones instead, since one left behind breaks every territory create in the shared org).

## Verification

- `lint`, `compile`, **1357 unit tests**, **22 integration tests**.
- **Live command-level lifecycle** (`test/live/webresourceScaffoldLifecycle.spec.ts`, 7 passing): drives a **real webpack build** and asserts the configured name lands as `bin/{prefix}_secondcomponent.js` *alongside* the default library bundle.
- The three non-deploying e2e suites: 25 passing, 12m, run id `hqh1s`.
- pac 2.8.1 confirmed to accept the generated `--namespace`/`--name`.

**Not run:** the deploying ExTester suites. Per CLAUDE.md a full credentialed run has never been done off Windows, so the scoped e2e names are verified by construction and unit tests, not observed landing in Dataverse.

**Conflicts with #272** (the #259 overflow-menu fix) on `CHANGELOG-prerelease.md` and `pcfAcceptance.e2e.ts` — both additive, in different regions. Merge #272 first and I'll rebase.

🤖 Generated with [Claude Code](https://claude.com/claude-code)