### PR TITLE
Ask for the web resource bundle name at scaffold

### DIFF
--- a/CHANGELOG-prerelease.md
+++ b/CHANGELOG-prerelease.md
@@ -7,4 +7,12 @@ is cleared to start accumulating the next cycle (`node scripts/rollupChangelog.m
 
 Everything below has shipped to the pre-release channel and is not yet in a full release.
 
-_Nothing yet — the next pre-release adds its section here._
+## 1.0.8 (pre-release)
+
+**Choose your web resource's bundle name when you create the component**
+
+1.0.7 gave each Web Resources component its own bundle name so two of them stop deploying over
+each other, but it picked that name for you. Creating a component in bundled output mode now asks,
+prefilled with the same suggestion and showing the full name it will deploy as
+(`<prefix>_<name>.js`). Per-file mode doesn't ask, because those names come from your source
+filenames.

--- a/src/projectTypes/activation.ts
+++ b/src/projectTypes/activation.ts
@@ -5,7 +5,7 @@ import { ProjectTypes, getProjectTypeDescriptor, projectTypeRegistry } from "./r
 import { runForComponent } from "../components/componentDiscovery";
 import { runTracked } from "../panel/operationTracker";
 import { initialiseWebresources } from "../webresources/initialiseWebresources";
-import { defaultLibraryBaseName } from "../webresources/libraryNames";
+import { defaultLibraryBaseName, isValidLibraryBase } from "../webresources/libraryNames";
 import { initialiseSolutions } from "../solution/initialiseSolutions";
 import { initialisePortals } from "../portals/initialisePortals";
 import { initialisePlugins } from "../plugins/initialisePlugins";
@@ -217,7 +217,24 @@ export const projectTypeActivations: Record<ProjectTypes, ProjectTypeActivation>
       // root keeps "library" so existing projects are untouched, while a sub-component takes its
       // folder name so two web-resource components stop deploying over each other's
       // {prefix}_library.js. Renaming an existing component's would orphan a deployed resource.
-      context.projectSettings.webresourceLibraryName = defaultLibraryBaseName(context.activeComponent?.relativeRoot ?? "");
+      const suggested = defaultLibraryBaseName(context.activeComponent?.relativeRoot ?? "");
+      // Only worth asking in bundle mode — per-file names come from the source filenames. The
+      // setting is still recorded either way, so it's already right if the user switches modes.
+      if (context.projectSettings.webresourceOutput === "bundle") {
+        const prefix = context.projectSettings.prefix ?? "<prefix>";
+        const answer = await vscode.window.showInputBox({
+          title: "Web resource bundle name",
+          prompt: `The built library deploys as ${prefix}_<name>.js. Give each component its own name so they don't overwrite each other.`,
+          value: suggested,
+          ignoreFocusOut: true,
+          validateInput: (v) => (isValidLibraryBase(v.trim()) ? undefined : "Letters, digits and underscores only."),
+        });
+        // Escaping keeps the suggestion rather than falling back to the shared "library" — the
+        // value is shown prefilled, and reverting would reintroduce the collision.
+        context.projectSettings.webresourceLibraryName = answer?.trim() || suggested;
+      } else {
+        context.projectSettings.webresourceLibraryName = suggested;
+      }
       await context.writeSettings();
     },
     commands: {

--- a/src/ui-test/e2e/configRefresh.e2e.ts
+++ b/src/ui-test/e2e/configRefresh.e2e.ts
@@ -73,6 +73,7 @@ describe("Config refresh (#113) — repairs stale config and rebuilds (e2e)", fu
     await answerFlexible(env!.url);
     await pickByLabel(solutionFriendlyName);
     await pickByLabel("Single bundled library (recommended)", 600000);
+    await answerText("library"); // bundle name (#258) — this suite never deploys, so the default is fine
     await pickByLabel("No", 600000); // create a webresource? — restores run first
     await sleep(4000);
     await dismissOverlays();

--- a/src/ui-test/e2e/lib.ts
+++ b/src/ui-test/e2e/lib.ts
@@ -89,20 +89,6 @@ export function runScopedIdentifier(base: string): string {
   return scopedIdentifier(base, runId());
 }
 
-/**
- * Set one field in a component's `dataverse-powertools.json`, in place.
- *
- * Used to give a web-resource component a run-scoped bundle name (#258). The bundle name is read
- * at BUILD time by the project's own webpack.common.js, so writing it any time between scaffold
- * and build is enough — no template regeneration needed.
- */
-export function setComponentSetting(componentRoot: string, key: string, value: unknown): void {
-  const file = path.join(componentRoot, "dataverse-powertools.json");
-  const settings = JSON.parse(fs.readFileSync(file, "utf8"));
-  settings[key] = value;
-  fs.writeFileSync(file, JSON.stringify(settings, null, 2), "utf8");
-}
-
 /** Remove onboarding/notification/modal overlays that intercept clicks. */
 export async function dismissOverlays(): Promise<void> {
   try {

--- a/src/ui-test/e2e/webresourceAcceptance.e2e.ts
+++ b/src/ui-test/e2e/webresourceAcceptance.e2e.ts
@@ -16,7 +16,6 @@ import {
   waitForLogFile,
   logFileSize,
   runScopedName,
-  setComponentSetting,
 } from "./lib";
 import { clickPanelButton, clickOverflowItem, expandComponentCards } from "../supervised/supervisedLib";
 import { initProject, step, showLog } from "./acceptanceLib";
@@ -66,12 +65,10 @@ describe("ACCEPTANCE: Web Resource — build, code, register, publish via panel 
     await step(COMPONENT, "Start project (Initialise button)", async () => {
       await initProject("Web Resources", env!, solutionFriendlyName, async () => {
         await pickByLabel("Single bundled library (recommended)", 600000); // output mode (restores run first)
+        await answerText(LIBRARY_BASE); // bundle name (#258) — run-scoped so suites/runs don't share a resource
         await pickByLabel("No", 600000); // "create a new webresource?" — restores + typings run first
       });
       expect(await waitForFile(path.join(workspace, "dataverse-powertools.json"), 300000), "project scaffolded").to.equal(true);
-      // Give this run its own bundle name before anything builds (#258) — webpack.common.js reads
-      // it from dataverse-powertools.json at build time, so this is the only step needed.
-      setComponentSetting(workspace, "webresourceLibraryName", LIBRARY_BASE);
       return "Web Resources project scaffolded + connected (service principal)";
     });
   });

--- a/src/ui-test/e2e/webresourceComprehensive.e2e.ts
+++ b/src/ui-test/e2e/webresourceComprehensive.e2e.ts
@@ -20,7 +20,6 @@ import {
   sleep,
   E2EClient,
   runScopedName,
-  setComponentSetting,
 } from "./lib";
 import { resetAllCredentials, shot, shotEditorHalf, SIDE_BY_SIDE_HALF } from "./lib";
 import {
@@ -140,15 +139,13 @@ describe("Web resources — comprehensive UI lifecycle (e2e)", function () {
     await pickByLabel(solutionFriendlyName);
     log("output mode prompt");
     await pickByLabel("Single bundled library (recommended)", 600000); // output mode (#88) — restores run first
+    await answerText(LIBRARY_BASE); // bundle name (#258) — run-scoped so suites/runs don't share a resource
     log("waiting for restore + create-webresource prompt");
     await pickByLabel("No", 600000); // "create a new webresource?" — npm restore runs first
     await sleep(4000);
     await dismissOverlays();
 
     expect(await waitForFile(path.join(workspace, "dataverse-powertools.json"), 60000), "dataverse-powertools.json").to.equal(true);
-    // Give this run its own bundle name before anything builds (#258) — webpack.common.js reads
-    // it from dataverse-powertools.json at build time, so this is the only step needed.
-    setComponentSetting(workspace, "webresourceLibraryName", LIBRARY_BASE);
     // #78: the old Windows-only nuget XrmDefinitelyTyped.exe must NOT be restored any more.
     expect(fs.existsSync(path.join(workspace, "packages", "Delegate.XrmDefinitelyTyped")), "old XrmDefinitelyTyped nuget should be gone").to.equal(false);
   });

--- a/src/ui-test/e2e/webresourceInteractiveLifecycle.e2e.ts
+++ b/src/ui-test/e2e/webresourceInteractiveLifecycle.e2e.ts
@@ -18,7 +18,6 @@ import {
   sleep,
   E2EClient,
   runScopedName,
-  setComponentSetting,
 } from "./lib";
 import { resetAllCredentials } from "./lib";
 
@@ -102,15 +101,13 @@ describe("Web resources lifecycle — interactive auth (e2e)", function () {
     await pickByLabel(solutionFriendlyName);
     log("output mode prompt");
     await pickByLabel("Single bundled library (recommended)", 600000); // output mode (#88) — restores run first
+    await answerText(LIBRARY_BASE); // bundle name (#258) — run-scoped so suites/runs don't share a resource
     log("waiting for restores + create-webresource prompt");
     await pickByLabel("No", 600000);
     await sleep(4000);
     await dismissOverlays();
 
     expect(await waitForFile(path.join(workspace, "dataverse-powertools.json"), 60000), "dataverse-powertools.json").to.equal(true);
-    // Give this run its own bundle name before anything builds (#258) — webpack.common.js reads
-    // it from dataverse-powertools.json at build time, so this is the only step needed.
-    setComponentSetting(workspace, "webresourceLibraryName", LIBRARY_BASE);
   });
 
   it("generates typings under interactive auth (bundled net8 tool, #91)", async () => {

--- a/src/webresources/libraryNames.spec.ts
+++ b/src/webresources/libraryNames.spec.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { webresourceLibraryName, candidateLibraryNames, defaultLibraryBaseName, libraryBaseFor, DEFAULT_LIBRARY_BASE } from "./libraryNames";
+import { webresourceLibraryName, candidateLibraryNames, defaultLibraryBaseName, libraryBaseFor, isValidLibraryBase, DEFAULT_LIBRARY_BASE } from "./libraryNames";
 
 describe("webresourceLibraryName", () => {
   it("bundle mode maps every source file to the bundled library", () => {
@@ -66,6 +66,31 @@ describe("configurable bundle name (#258)", () => {
     it("strips what a web-resource name cannot carry, and falls back if nothing survives", () => {
       expect(defaultLibraryBaseName("my-forms")).toBe("myforms");
       expect(defaultLibraryBaseName("---")).toBe("library");
+    });
+  });
+
+  // Backs the scaffold prompt's validateInput: reject as the user types rather than silently
+  // sanitising into a name they didn't choose and won't recognise in the maker portal.
+  describe("isValidLibraryBase", () => {
+    it("accepts what survives sanitising unchanged", () => {
+      expect(isValidLibraryBase("library")).toBe(true);
+      expect(isValidLibraryBase("account_forms")).toBe(true);
+      expect(isValidLibraryBase("Grid2")).toBe(true);
+    });
+
+    it("rejects anything that would be silently rewritten", () => {
+      expect(isValidLibraryBase("")).toBe(false);
+      expect(isValidLibraryBase("my grid")).toBe(false);
+      expect(isValidLibraryBase("my-grid")).toBe(false);
+      expect(isValidLibraryBase("grid.js")).toBe(false);
+    });
+
+    it("accepts every name the scaffold would suggest", () => {
+      // The prompt is prefilled with the suggestion, so a suggestion its own validator rejects
+      // would present as an error box the user has to fix before they can continue.
+      for (const folder of ["", "controls", "account-forms", "2fast", "---", "src/deep/nested"]) {
+        expect(isValidLibraryBase(defaultLibraryBaseName(folder)), folder).toBe(true);
+      }
     });
   });
 

--- a/src/webresources/libraryNames.ts
+++ b/src/webresources/libraryNames.ts
@@ -35,6 +35,13 @@ export function defaultLibraryBaseName(relativeRoot: string): string {
   return sanitised || DEFAULT_LIBRARY_BASE;
 }
 
+/** Whether `value` is usable as a bundle base name — i.e. survives sanitising unchanged.
+ * Used by the scaffold prompt's `validateInput` so a name is rejected while it is being typed
+ * rather than silently sanitised into something else at build time. */
+export function isValidLibraryBase(value: string): boolean {
+  return value.length > 0 && sanitiseLibraryBase(value) === value;
+}
+
 /** The configured bundle base for a component, falling back to the historical `library`. */
 export function libraryBaseFor(settings: { webresourceLibraryName?: string } | undefined): string {
   const configured = sanitiseLibraryBase(settings?.webresourceLibraryName ?? "");


### PR DESCRIPTION
Follow-up to the gap flagged when #258 landed, per your steer: ask at scaffold rather than add a rename command.

## What changes

1.0.7 gave each Web Resources component its own bundle name so two of them stop deploying over each other's `{prefix}_library.js` — but it *chose* that name silently. Scaffolding in **bundle** mode now asks, prefilled with the same folder-derived suggestion and showing the full name it will deploy as (`<prefix>_<name>.js`), so the consequence is visible.

Per-file mode doesn't ask — those names come from your source filenames. The setting is still recorded either way, so it's already right if you later switch modes.

Escaping **keeps the suggestion** rather than falling back to the shared `library`, for the same reason as the PCF name prompt: the value is shown prefilled, so accepting it isn't a surprise, and reverting would put the collision back.

## Publisher prefix — deliberately not asked

The prefix is inferred from the chosen solution's publisher, and Dataverse rejects a name that doesn't start with a real publisher prefix. The connection wizard already prompts for it when it can't be inferred (`needsPrefixPrompt`), so asking again per component would be duplicative and would let someone enter a value that fails at deploy.

## Tests

`isValidLibraryBase` backs the input box's `validateInput`, so a name is rejected as it's typed rather than silently sanitised into something the user never chose. One test asserts **every name the scaffold can suggest passes that same validator** — a suggestion its own validator rejects would open the prompt in an error state the user has to clear before continuing.

## E2E

The four suites that scaffold in bundle mode answer the new prompt. The three deploying ones answer it with their run-scoped name, which **replaces** the post-scaffold settings write from the previous PR (and its now-unused helper) — going through the wizard exercises the real path instead of reaching around it.

## Verification

`lint`, `compile`, **1369 unit tests**, **22 integration tests**, and `configRefresh` driven headless through the **real wizard including the new prompt** — 4 passing, 4m.

## Still open

This doesn't help someone who *already* has two colliding web-resource components — there's still no in-product way to change an existing component's bundle name, only the scaffold prompt and hand-editing `dataverse-powertools.json`. Say the word if you want the `Switch Output Mode`-style command for it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)