### PR TITLE
Rename a bundle after the fact, warn on clashes, and fix two per-file gaps

### DIFF
--- a/CHANGELOG-prerelease.md
+++ b/CHANGELOG-prerelease.md
@@ -9,6 +9,28 @@ Everything below has shipped to the pre-release channel and is not yet in a full
 
 ## 1.0.8 (pre-release)
 
+**Change a web resource's bundle name after the fact — and be told when two components clash**
+
+The new bundle name only helped components created after 1.0.7; anything older still shared
+`<prefix>_library.js` with every other component in the workspace and quietly overwrote it. There
+is now a *Change Web Resource Bundle Name* command (in the card's overflow, next to *Output mode*),
+and Deploy warns when more than one component in the workspace would deploy the same web resource
+name — in either output mode. Renaming keeps the previous name registered as yours, so handlers
+still bound to it are cleaned up rather than left pointing at a resource nobody deploys.
+
+**Fixed: Debug Web Resources did nothing for a component with its own bundle name**
+
+The debug session hardcoded `<prefix>_library.js` when deciding which request to intercept and
+which built file to serve, so for any component that had been given its own bundle name it
+intercepted nothing, served nothing, and never hot-reloaded.
+
+**Fixed: form registrations in files that per-file mode doesn't build**
+
+In one-file-per-web-resource mode only the top-level `webresources_src/*.ts` are built —
+`library.ts` and anything in a subfolder are not. A form registration in one of those was still
+written to the form, pointing at a web resource that never gets deployed. Those registrations are
+now skipped with a message naming the files, instead of leaving a form bound to a missing library.
+
 **Choose your web resource's bundle name when you create the component**
 
 1.0.7 gave each Web Resources component its own bundle name so two of them stop deploying over

--- a/package.json
+++ b/package.json
@@ -701,6 +701,11 @@
         "enablement": "dataverse-powertools.showLoaded && dataverse-powertools.isWebResource"
       },
       {
+        "command": "dataverse-powertools.switchWebresourceLibraryName",
+        "title": "Dataverse PowerTools: Change Web Resource Bundle Name",
+        "enablement": "dataverse-powertools.showLoaded && dataverse-powertools.isWebResource"
+      },
+      {
         "command": "dataverse-powertools.runWebresourceTests",
         "title": "Dataverse PowerTools: Run Web Resource Tests",
         "enablement": "dataverse-powertools.showLoaded && dataverse-powertools.isWebResource"

--- a/src/context.ts
+++ b/src/context.ts
@@ -238,6 +238,10 @@ interface ProjectSettings {
    * `library`. Set per component at scaffold so two web-resource components in one workspace
    * don't deploy over each other. Read at BUILD time by the project's webpack.common.js. */
   webresourceLibraryName?: string;
+  /** Bundle names this component USED to deploy under (#258). Kept so form handlers bound to a
+   * previous name stay in `candidateLibraryNames` and can still be cleaned up — dropping them
+   * would strand those handlers on a web resource that is no longer deployed. */
+  webresourcePreviousLibraryNames?: string[];
   tenantId?: string;
   /** Optional environment tag (e.g. DEV / TEST / PROD) shown as a badge in the actions panel. */
   environmentLabel?: string;

--- a/src/projectTypes/activation.ts
+++ b/src/projectTypes/activation.ts
@@ -34,6 +34,7 @@ import { saveFormData } from "../webresources/saveFormData";
 import { upgradeFromSpkl } from "../webresources/upgradeFromSpkl";
 import { debugWebResources, stopDebugWebResources } from "../webresources/debug/debugWebresources";
 import { switchWebresourceOutput } from "../webresources/switchOutputMode";
+import { switchWebresourceLibraryName } from "../webresources/switchLibraryName";
 import { runWebresourceTests } from "../webresources/runTests";
 import { openFormIntersects } from "../webresources/tableIntersects/tableIntersects";
 import { refreshConfigFiles } from "../general/configRefresh";
@@ -207,7 +208,7 @@ export const projectTypeActivations: Record<ProjectTypes, ProjectTypeActivation>
       // Output mode (#88): the webpack template reads this setting at build time.
       const pick = await vscode.window.showQuickPick(
         [
-          { label: "Single bundled library (recommended)", description: "one <prefix>_library.js from library.ts", target: "bundle" as const },
+          { label: "Single bundled library (recommended)", description: "one <prefix>_<name>.js built from library.ts", target: "bundle" as const },
           { label: "One file per web resource", description: "one <prefix>_<name>.js per webresources_src/*.ts", target: "perFile" as const },
         ],
         { placeHolder: "How should web resources be built?" },
@@ -249,6 +250,7 @@ export const projectTypeActivations: Record<ProjectTypes, ProjectTypeActivation>
       "dataverse-powertools.debugWebresources": (context) => debugWebResources(context),
       "dataverse-powertools.stopDebugWebresources": () => stopDebugWebResources(),
       "dataverse-powertools.switchWebresourceOutput": (context) => switchWebresourceOutput(context),
+      "dataverse-powertools.switchWebresourceLibraryName": (context) => switchWebresourceLibraryName(context),
       "dataverse-powertools.runWebresourceTests": tracked("Tests", runWebresourceTests),
       "dataverse-powertools.openFormIntersects": (context) => openFormIntersects(context),
       "dataverse-powertools.refreshConfigFiles": (context) => refreshConfigFiles(context),

--- a/src/projectTypes/registry.ts
+++ b/src/projectTypes/registry.ts
@@ -190,6 +190,7 @@ export const projectTypeRegistry: readonly ProjectTypeDescriptor[] = [
       `${prefix}debugWebresources`,
       `${prefix}stopDebugWebresources`,
       `${prefix}switchWebresourceOutput`,
+      `${prefix}switchWebresourceLibraryName`,
       `${prefix}runWebresourceTests`,
       `${prefix}openFormIntersects`,
       `${prefix}refreshConfigFiles`,
@@ -215,6 +216,8 @@ export const projectTypeRegistry: readonly ProjectTypeDescriptor[] = [
           { command: `${prefix}openFormIntersects`, label: "Configure form intersects" },
           { command: `${prefix}refreshConfigFiles`, label: "Refresh config files" },
           { command: `${prefix}switchWebresourceOutput`, label: `Output mode (${state.webresourceOutput === "perFile" ? "per-file" : "bundled"})…` },
+          // Only meaningful in bundled mode — per-file names come from the source filenames.
+          ...(state.webresourceOutput === "perFile" ? [] : [{ command: `${prefix}switchWebresourceLibraryName`, label: "Bundle name…" }]),
           ...(state.hasSpkl ? [{ command: `${prefix}upgradeFromSpkl`, label: "Upgrade from Spkl" }] : []),
         ],
       };

--- a/src/webresources/debug/debugWebresources.ts
+++ b/src/webresources/debug/debugWebresources.ts
@@ -11,6 +11,7 @@ import { isWebresourceBundleUrl, bundleCdpPattern, bundleContentType } from "./w
 import { buildAttachDebugConfig } from "./debugConfig";
 import { activeComponentRoot } from "../../components/componentDiscovery";
 import { findFreePort, killProcessTree, connectCdpWithRetry } from "./cdpProcess";
+import { webresourceLibraryName, libraryBaseFor } from "../libraryNames";
 
 // "Debug Web Resources": run the local webpack bundle *inside the real model-driven app*.
 // A dedicated Edge/Chrome instance is launched under the DevTools Protocol; the browser's
@@ -74,7 +75,11 @@ export async function debugWebResources(context: DataversePowerToolsContext): Pr
     vscode.window.showErrorMessage("This project has no solution prefix configured, so the bundle name is unknown.");
     return;
   }
-  const bundleName = `${prefix}_library.js`;
+  // The bundle name is per-component (#258), not a fixed "library" — it drives the CDP intercept
+  // pattern, the URL match against the live app, AND the hot-reload watcher's filename check, so
+  // hardcoding it made the whole debug session a no-op for any component with its own name:
+  // nothing to serve, nothing intercepted, no reload.
+  const bundleName = webresourceLibraryName(prefix, "bundle", "library.ts", libraryBaseFor(context.projectSettings));
   const binDir = path.join(workspacePath, "bin");
   const bundlePath = path.join(binDir, bundleName);
 

--- a/src/webresources/deployWebresources.ts
+++ b/src/webresources/deployWebresources.ts
@@ -5,6 +5,7 @@ import { DataverseWebresource } from "../general/dataverse/DataverseWebresource"
 import { runWebresourceBuild } from "./webpackBuild";
 import { saveFormDataExec } from "./saveFormData";
 import { activeComponentRoot } from "../components/componentDiscovery";
+import { webresourceCollisionsInWorkspace } from "./switchLibraryName";
 
 export async function deployWebresources(context: DataversePowerToolsContext) {
   await vscode.window.withProgress(
@@ -100,6 +101,25 @@ export async function deploy(context: DataversePowerToolsContext, options?: { pu
         if (filesToDeploy.length === 0) {
           vscode.window.showWarningMessage("No built webresources found in the bin folder.");
           return;
+        }
+
+        // Two components deploying the same name means whichever runs second silently replaces the
+        // first — no error, and the loser only notices when their code stops running (#258). New
+        // components get distinct names at scaffold, but anything created before that doesn't, so
+        // say something at the point the overwrite would actually happen.
+        const prefix = context.projectSettings.prefix;
+        if (prefix) {
+          const collisions = webresourceCollisionsInWorkspace(context, prefix);
+          for (const collision of collisions) {
+            context.channel.appendLine(
+              `Warning: ${collision.name} is deployed by more than one component in this workspace (${collision.components.map((c) => c || "<root>").join(", ")}) — they overwrite each other.`,
+            );
+          }
+          if (collisions.length > 0) {
+            vscode.window.showWarningMessage(
+              `${collisions.length} web resource name(s) are claimed by more than one component and will overwrite each other. Use "Change Web Resource Bundle Name" to give each its own.`,
+            );
+          }
         }
 
         let deployedCount = 0;

--- a/src/webresources/libraryNames.spec.ts
+++ b/src/webresources/libraryNames.spec.ts
@@ -1,5 +1,17 @@
 import { describe, expect, it } from "vitest";
-import { webresourceLibraryName, candidateLibraryNames, defaultLibraryBaseName, libraryBaseFor, isValidLibraryBase, DEFAULT_LIBRARY_BASE } from "./libraryNames";
+import {
+  webresourceLibraryName,
+  candidateLibraryNames,
+  defaultLibraryBaseName,
+  libraryBaseFor,
+  isValidLibraryBase,
+  isPerFileEntry,
+  pathBelowSourceRoot,
+  deployedWebresourceNames,
+  findWebresourceNameCollisions,
+  freeLibraryBase,
+  DEFAULT_LIBRARY_BASE,
+} from "./libraryNames";
 
 describe("webresourceLibraryName", () => {
   it("bundle mode maps every source file to the bundled library", () => {
@@ -121,5 +133,147 @@ describe("configurable bundle name (#258)", () => {
       const names = candidateLibraryNames("dvpt", ["/p/webresources_src/Account.ts"]);
       expect([...names].sort()).toEqual(["dvpt_Account.js", "dvpt_library.js"]);
     });
+  });
+});
+
+// Per-file mode builds only the TOP-LEVEL webresources_src/*.ts (not library.ts) — but the form
+// registration scan is recursive and includes the barrel, so a registration in a file that mode
+// never builds used to bind a handler to a web resource that doesn't exist.
+describe("isPerFileEntry — what per-file mode actually builds", () => {
+  it("matches the webpack template's filter for top-level sources", () => {
+    expect(isPerFileEntry("Account.ts")).toBe(true);
+    expect(isPerFileEntry("Contact.ts")).toBe(true);
+  });
+
+  it("excludes the barrel, type declarations and nested files", () => {
+    expect(isPerFileEntry("library.ts")).toBe(false);
+    expect(isPerFileEntry("PowerTools.d.ts")).toBe(false);
+    expect(isPerFileEntry("sub/Thing.ts")).toBe(false);
+    expect(isPerFileEntry("lib/dg.xrmquery.web.min.ts")).toBe(false);
+  });
+
+  it("excludes non-TypeScript files", () => {
+    expect(isPerFileEntry("Account.js")).toBe(false);
+    expect(isPerFileEntry("")).toBe(false);
+  });
+});
+
+describe("pathBelowSourceRoot", () => {
+  it("returns the path below webresources_src, on either separator", () => {
+    expect(pathBelowSourceRoot("/p/webresources_src/Account.ts")).toBe("Account.ts");
+    expect(pathBelowSourceRoot("C:\\p\\webresources_src\\sub\\Thing.ts")).toBe("sub/Thing.ts");
+  });
+
+  it("falls back to the filename when it can't place the path", () => {
+    // Treated as top-level, i.e. buildable — skipping a registration we merely failed to classify
+    // would be worse than processing it.
+    expect(pathBelowSourceRoot("/somewhere/else/Account.ts")).toBe("Account.ts");
+    expect(isPerFileEntry(pathBelowSourceRoot("/somewhere/else/Account.ts"))).toBe(true);
+  });
+});
+
+describe("deployedWebresourceNames — a component's claim on the shared namespace", () => {
+  it("bundle mode claims exactly one name", () => {
+    expect(deployedWebresourceNames("dvpt", undefined, ["Account.ts", "Contact.ts"])).toEqual(["dvpt_library.js"]);
+    expect(deployedWebresourceNames("dvpt", { webresourceLibraryName: "grid" }, ["Account.ts"])).toEqual(["dvpt_grid.js"]);
+  });
+
+  it("per-file mode claims one name per BUILDABLE source file", () => {
+    const names = deployedWebresourceNames("dvpt", { webresourceOutput: "perFile" }, ["Account.ts", "Contact.ts", "library.ts", "sub/Thing.ts", "PowerTools.d.ts"]);
+    expect(names.sort()).toEqual(["dvpt_Account.js", "dvpt_Contact.js"]);
+  });
+
+  it("per-file mode ignores the configured bundle name — it deploys no bundle", () => {
+    expect(deployedWebresourceNames("dvpt", { webresourceOutput: "perFile", webresourceLibraryName: "grid" }, ["Account.ts"])).toEqual(["dvpt_Account.js"]);
+  });
+});
+
+describe("findWebresourceNameCollisions", () => {
+  it("finds two bundle components claiming the same name", () => {
+    const collisions = findWebresourceNameCollisions([
+      { relativeRoot: "", names: ["dvpt_library.js"] },
+      { relativeRoot: "controls", names: ["dvpt_library.js"] },
+    ]);
+    expect(collisions).toEqual([{ name: "dvpt_library.js", components: ["", "controls"] }]);
+  });
+
+  it("finds two PER-FILE components sharing a source filename", () => {
+    // The case a bundle-only detector would miss: both components have an Account.ts, so both
+    // deploy dvpt_Account.js and the second silently replaces the first.
+    const collisions = findWebresourceNameCollisions([
+      { relativeRoot: "a", names: ["dvpt_Account.js", "dvpt_Lead.js"] },
+      { relativeRoot: "b", names: ["dvpt_Account.js", "dvpt_Case.js"] },
+    ]);
+    expect(collisions).toEqual([{ name: "dvpt_Account.js", components: ["a", "b"] }]);
+  });
+
+  it("finds a bundle name colliding with a per-file name", () => {
+    // A per-file component with library.ts renamed, or a bundle named after a class — same clash.
+    const collisions = findWebresourceNameCollisions([
+      { relativeRoot: "a", names: ["dvpt_Account.js"] },
+      { relativeRoot: "b", names: ["dvpt_Account.js"] },
+    ]);
+    expect(collisions.map((c) => c.name)).toEqual(["dvpt_Account.js"]);
+  });
+
+  it("is quiet when every component claims distinct names", () => {
+    expect(
+      findWebresourceNameCollisions([
+        { relativeRoot: "", names: ["dvpt_library.js"] },
+        { relativeRoot: "controls", names: ["dvpt_controls.js"] },
+      ]),
+    ).toEqual([]);
+  });
+
+  it("does not report a component colliding with itself", () => {
+    expect(findWebresourceNameCollisions([{ relativeRoot: "a", names: ["dvpt_Account.js", "dvpt_Account.js"] }])).toEqual([]);
+  });
+
+  it("reports every contested name, not just the first", () => {
+    const collisions = findWebresourceNameCollisions([
+      { relativeRoot: "a", names: ["dvpt_Account.js", "dvpt_Lead.js"] },
+      { relativeRoot: "b", names: ["dvpt_Account.js", "dvpt_Lead.js"] },
+    ]);
+    expect(collisions.map((c) => c.name)).toEqual(["dvpt_Account.js", "dvpt_Lead.js"]);
+  });
+});
+
+describe("freeLibraryBase", () => {
+  it("keeps the preferred name when it is free", () => {
+    expect(freeLibraryBase("controls", ["library"])).toBe("controls");
+  });
+
+  it("suffixes until it finds a free one", () => {
+    expect(freeLibraryBase("library", ["library"])).toBe("library2");
+    expect(freeLibraryBase("library", ["library", "library2"])).toBe("library3");
+  });
+
+  it("compares case-insensitively, since Dataverse names are", () => {
+    expect(freeLibraryBase("Library", ["library"])).toBe("Library2");
+  });
+
+  it("always returns something the naming rules accept", () => {
+    expect(freeLibraryBase("", [])).toBe("library");
+    expect(freeLibraryBase("!!!", ["library"])).toBe("library2");
+  });
+});
+
+// Renaming a bundle leaves handlers on forms bound to the OLD name. Those are ours; if they drop
+// out of the owned set they can never be cleaned up and stay pointed at a resource nobody deploys.
+describe("candidateLibraryNames keeps previous names owned after a rename (#258)", () => {
+  it("owns the current name, the historical library, and every previous name", () => {
+    const names = candidateLibraryNames("dvpt", ["/p/webresources_src/Account.ts"], "grid3", ["grid", "grid2"]);
+    expect([...names].sort()).toEqual(["dvpt_Account.js", "dvpt_grid.js", "dvpt_grid2.js", "dvpt_grid3.js", "dvpt_library.js"]);
+  });
+
+  it("is unchanged when a component has never been renamed", () => {
+    const names = candidateLibraryNames("dvpt", ["/p/webresources_src/Account.ts"], "grid", []);
+    expect([...names].sort()).toEqual(["dvpt_Account.js", "dvpt_grid.js", "dvpt_library.js"]);
+  });
+
+  it("sanitises previous names rather than emitting a nameless library", () => {
+    const names = candidateLibraryNames("dvpt", [], "grid", ["!!!"]);
+    expect(names.has("dvpt_library.js")).toBe(true);
+    expect([...names].every((n) => n !== "dvpt_.js")).toBe(true);
   });
 });

--- a/src/webresources/libraryNames.ts
+++ b/src/webresources/libraryNames.ts
@@ -63,13 +63,116 @@ export function webresourceLibraryName(prefix: string, output: "bundle" | "perFi
  * The registration cleanup may only delete handlers whose library is in this
  * set — never another solution's — and covering both modes means leftovers
  * from a mode switch are cleaned up too. */
-export function candidateLibraryNames(prefix: string, sourceFilePaths: string[], bundleBase: string = DEFAULT_LIBRARY_BASE): Set<string> {
-  // Both the CONFIGURED bundle name and the historical `library`: a project that renames its
-  // bundle still has handlers pointing at the old name, and those are ours to clean up. Missing
-  // the old name would strand them on a web resource that no longer gets deployed.
-  const names = new Set([`${prefix}_${sanitiseLibraryBase(bundleBase) || DEFAULT_LIBRARY_BASE}.js`, `${prefix}_${DEFAULT_LIBRARY_BASE}.js`]);
+export function candidateLibraryNames(prefix: string, sourceFilePaths: string[], bundleBase: string = DEFAULT_LIBRARY_BASE, previousBases: string[] = []): Set<string> {
+  // The CONFIGURED bundle name, the historical `library`, and any name this component previously
+  // deployed under: a renamed bundle still has handlers pointing at the old name, and those are
+  // ours to clean up. Missing one strands its handlers on a web resource nobody deploys.
+  const names = new Set([
+    `${prefix}_${sanitiseLibraryBase(bundleBase) || DEFAULT_LIBRARY_BASE}.js`,
+    `${prefix}_${DEFAULT_LIBRARY_BASE}.js`,
+    ...previousBases.map((base) => `${prefix}_${sanitiseLibraryBase(base) || DEFAULT_LIBRARY_BASE}.js`),
+  ]);
   for (const file of sourceFilePaths) {
     names.add(webresourceLibraryName(prefix, "perFile", file));
   }
   return names;
+}
+
+/**
+ * The part of a source path below `webresources_src` — `Account.ts`, `sub/Thing.ts`.
+ *
+ * Falls back to the bare filename when there is no `webresources_src` segment, so a path we can't
+ * place is treated as top-level (i.e. buildable). The callers use this to decide what to SKIP, and
+ * skipping a registration we merely failed to classify would be worse than processing it.
+ */
+export function pathBelowSourceRoot(sourceFilePath: string): string {
+  const normalised = sourceFilePath.replace(/\\/g, "/");
+  const marker = "/webresources_src/";
+  const index = normalised.lastIndexOf(marker);
+  return index === -1 ? (normalised.split("/").pop() ?? "") : normalised.slice(index + marker.length);
+}
+
+/**
+ * Whether per-file output mode actually BUILDS this source file.
+ *
+ * Mirrors the filter in templates/webresources/webpack.common.js exactly: per-file entries are the
+ * TOP-LEVEL `webresources_src/*.ts`, excluding `.d.ts` and the `library.ts` barrel. A file that
+ * isn't an entry produces no output, so a form registration inside one would bind a handler to a
+ * web resource that is never deployed — the `<Library>` names something that isn't there.
+ *
+ * `relativeToSourceRoot` is the path BELOW `webresources_src`, e.g. `Account.ts` or `sub/Thing.ts`.
+ */
+export function isPerFileEntry(relativeToSourceRoot: string): boolean {
+  const normalised = relativeToSourceRoot.replace(/\\/g, "/").replace(/^\/+/, "");
+  if (normalised.includes("/")) {
+    return false; // nested — perFileEntries() only reads the top level
+  }
+  if (!normalised.endsWith(".ts") || normalised.endsWith(".d.ts")) {
+    return false;
+  }
+  return normalised !== "library.ts";
+}
+
+/**
+ * Every web resource a component would DEPLOY, in whichever mode it is in.
+ *
+ * `deployWebresources` upserts each file in `bin/` by name, so this is the component's claim on
+ * the shared namespace — bundle mode claims one name, per-file mode claims one per buildable
+ * source file. Used to find collisions between components (#258); two components claiming the
+ * same name means whichever deploys second silently replaces the first.
+ */
+export function deployedWebresourceNames(
+  prefix: string,
+  settings: { webresourceLibraryName?: string; webresourceOutput?: "bundle" | "perFile" } | undefined,
+  sourceFilesRelativeToSourceRoot: string[],
+): string[] {
+  if (settings?.webresourceOutput !== "perFile") {
+    return [webresourceLibraryName(prefix, "bundle", "library.ts", libraryBaseFor(settings))];
+  }
+  const names = sourceFilesRelativeToSourceRoot.filter(isPerFileEntry).map((f) => webresourceLibraryName(prefix, "perFile", f));
+  return [...new Set(names)];
+}
+
+/** A component's claim on the deployed-name namespace. */
+export interface WebresourceClaim {
+  /** Component path relative to the workspace root; "" for the root component. */
+  relativeRoot: string;
+  /** What that component would deploy — from `deployedWebresourceNames`. */
+  names: string[];
+}
+
+/**
+ * Deployed names claimed by more than one component (#258).
+ *
+ * Covers BOTH modes deliberately. It would be easy to assume only bundle-mode components can
+ * collide, since per-file names come from source filenames — but two per-file components that
+ * both contain `Account.ts` both deploy `{prefix}_Account.js`, which is the same silent overwrite.
+ * Returns one entry per contested name, listing every component claiming it; empty when clean.
+ */
+export function findWebresourceNameCollisions(claims: WebresourceClaim[]): Array<{ name: string; components: string[] }> {
+  const byName = new Map<string, string[]>();
+  for (const claim of claims) {
+    for (const name of new Set(claim.names)) {
+      byName.set(name, [...(byName.get(name) ?? []), claim.relativeRoot]);
+    }
+  }
+  return [...byName.entries()]
+    .filter(([, components]) => components.length > 1)
+    .map(([name, components]) => ({ name, components }))
+    .sort((a, b) => a.name.localeCompare(b.name));
+}
+
+/** A bundle base name not already claimed — `base`, else `base2`, `base3`… */
+export function freeLibraryBase(base: string, taken: Iterable<string>): string {
+  const used = new Set([...taken].map((t) => t.toLowerCase()));
+  const start = sanitiseLibraryBase(base) || DEFAULT_LIBRARY_BASE;
+  if (!used.has(start.toLowerCase())) {
+    return start;
+  }
+  for (let n = 2; ; n++) {
+    const candidate = `${start}${n}`;
+    if (!used.has(candidate.toLowerCase())) {
+      return candidate;
+    }
+  }
 }

--- a/src/webresources/saveFormData.ts
+++ b/src/webresources/saveFormData.ts
@@ -3,7 +3,7 @@ import * as vscode from "vscode";
 import { DataverseForm } from "../general/dataverse/DataverseForm";
 import { randomUUID } from "crypto";
 import { parseRegisterEvents, validateRegisterEvent, RegisterEventDecoration } from "./registerEventParser";
-import { webresourceLibraryName, candidateLibraryNames, libraryBaseFor } from "./libraryNames";
+import { webresourceLibraryName, candidateLibraryNames, libraryBaseFor, isPerFileEntry, pathBelowSourceRoot } from "./libraryNames";
 import { applyFormRegistrations, ResolvedRegistration } from "./formRegistrationXml";
 import { activeComponentRoot } from "../components/componentDiscovery";
 
@@ -43,7 +43,21 @@ export async function saveFormDataExec(context: DataversePowerToolsContext, opti
     : await vscode.workspace.findFiles("webresources_src/**/*.ts");
   const registerEvents: SourcedRegisterEvent[] = [];
   let malformedBlocks = 0;
+  const unbuildable: string[] = [];
+  // In per-file mode only the TOP-LEVEL webresources_src/*.ts are webpack entries, but this scan
+  // is recursive and includes library.ts — so a registration in a nested file, or in the barrel,
+  // used to bind a handler to a web resource that mode never builds or deploys. The form then
+  // referenced a <Library> that isn't in the environment. Skip those and say which, rather than
+  // writing a registration that cannot work.
+  const perFileMode = context.projectSettings.webresourceOutput === "perFile";
   for (const file of files) {
+    if (perFileMode && !isPerFileEntry(pathBelowSourceRoot(file.fsPath))) {
+      const document = await vscode.workspace.openTextDocument(file);
+      if (parseRegisterEvents(document.getText()).events.length > 0) {
+        unbuildable.push(vscode.workspace.asRelativePath(file));
+      }
+      continue;
+    }
     const document = await vscode.workspace.openTextDocument(file);
     const parsed = parseRegisterEvents(document.getText());
     malformedBlocks += parsed.malformedBlocks;
@@ -52,6 +66,13 @@ export async function saveFormDataExec(context: DataversePowerToolsContext, opti
   }
   if (malformedBlocks > 0) {
     context.channel.appendLine(`Warning: skipped ${malformedBlocks} malformed RegisterEvent decoration block(s).`);
+  }
+  if (unbuildable.length > 0) {
+    context.channel.appendLine(
+      `Warning: skipped form registrations in ${unbuildable.length} file(s) that per-file output mode does not build, so no web resource would exist to bind to: ${unbuildable.join(", ")}. ` +
+        `Per-file mode builds only the top-level webresources_src/*.ts (not library.ts) — move the registration into one of those, or switch to the bundled output mode.`,
+    );
+    vscode.window.showWarningMessage(`${unbuildable.length} form registration file(s) are not built in per-file mode and were skipped — see the log.`);
   }
 
   if (registerEvents.length === 0) {
@@ -98,6 +119,7 @@ export async function saveFormDataExec(context: DataversePowerToolsContext, opti
     prefix,
     files.map((file) => file.fsPath),
     bundleBase,
+    context.projectSettings.webresourcePreviousLibraryNames ?? [],
   );
 
   let totalForms = 0;

--- a/src/webresources/switchLibraryName.ts
+++ b/src/webresources/switchLibraryName.ts
@@ -1,0 +1,151 @@
+import * as vscode from "vscode";
+import * as fs from "fs";
+import * as path from "path";
+import DataversePowerToolsContext from "../context";
+import { activeComponentRoot } from "../components/componentDiscovery";
+import { ProjectTypes } from "../projectTypes/registry";
+import {
+  deployedWebresourceNames,
+  findWebresourceNameCollisions,
+  freeLibraryBase,
+  libraryBaseFor,
+  isValidLibraryBase,
+  webresourceLibraryName,
+  DEFAULT_LIBRARY_BASE,
+} from "./libraryNames";
+
+// Change a web-resource component's bundle name after scaffold (#258 follow-up).
+//
+// The scaffold prompt gives NEW components distinct names, but anything created before that shares
+// `{prefix}_library.js` with every other component — and deploy upserts bin/ by filename, so the
+// second one to deploy silently replaces the first. This is the only in-product way to fix an
+// existing project; without it the answer was "hand-edit dataverse-powertools.json".
+//
+// Renaming has two consequences the command has to handle rather than leave as surprises:
+//  1. bin/ still holds the bundle under the OLD name, and deploy would upload it again — so the
+//     stale artefact is cleared, exactly as switchOutputMode does on a mode change.
+//  2. forms still carry handlers bound to the OLD name. Those are ours, so they must stay
+//     deletable: the previous name is recorded in settings and candidateLibraryNames keeps
+//     owning it, otherwise the next Register Form Events would strand them on a web resource
+//     that is no longer deployed.
+
+/** The two fields that decide what a component deploys, pulled out of its loose settings bag. */
+function outputSettings(settings: { [key: string]: unknown } | undefined): { webresourceLibraryName?: string; webresourceOutput?: "bundle" | "perFile" } {
+  const name = settings?.webresourceLibraryName;
+  const output = settings?.webresourceOutput;
+  return {
+    webresourceLibraryName: typeof name === "string" ? name : undefined,
+    webresourceOutput: output === "perFile" ? "perFile" : output === "bundle" ? "bundle" : undefined,
+  };
+}
+
+/** Names every OTHER web-resource component in this workspace would deploy. */
+function namesClaimedByOtherComponents(context: DataversePowerToolsContext, prefix: string): Set<string> {
+  // Identify "this component" by relativeRoot, not by comparing absolute paths: activeComponentRoot
+  // falls back to the raw workspace fsPath, which on Windows is backslashed while
+  // DiscoveredComponent.root is normalised — so a string compare would fail to exclude the current
+  // component and it would be reported as colliding with itself.
+  const currentRelativeRoot = context.activeComponent?.relativeRoot ?? "";
+  const claimed = new Set<string>();
+  for (const component of context.components) {
+    if (component.relativeRoot === currentRelativeRoot || component.settings?.type !== ProjectTypes.webresource) {
+      continue;
+    }
+    const sourceRoot = path.join(component.root, "webresources_src");
+    let sources: string[] = [];
+    try {
+      sources = fs.readdirSync(sourceRoot);
+    } catch {
+      sources = [];
+    }
+    for (const name of deployedWebresourceNames(prefix, outputSettings(component.settings), sources)) {
+      claimed.add(name);
+    }
+  }
+  return claimed;
+}
+
+export async function switchWebresourceLibraryName(context: DataversePowerToolsContext): Promise<void> {
+  const componentRoot = activeComponentRoot(context);
+  if (!componentRoot) {
+    vscode.window.showErrorMessage("Open a workspace folder first.");
+    return;
+  }
+  const prefix = context.projectSettings.prefix;
+  if (!prefix) {
+    vscode.window.showErrorMessage("This project has no solution prefix configured, so the deployed name is unknown. Connect to an environment first.");
+    return;
+  }
+  if (context.projectSettings.webresourceOutput === "perFile") {
+    // Nothing to rename: per-file names come from the source filenames.
+    vscode.window.showInformationMessage("This component builds one web resource per source file, so there is no bundle name to change. Switch to the bundled output mode first.");
+    return;
+  }
+
+  const current = libraryBaseFor(context.projectSettings);
+  const claimed = namesClaimedByOtherComponents(context, prefix);
+  // Offer a name that is actually free, so accepting the default resolves a collision rather than
+  // reproducing one.
+  const claimedBases = [...claimed].map((name) => (name.startsWith(`${prefix}_`) ? name.slice(prefix.length + 1) : name).replace(/\.js$/, ""));
+  const suggestion = freeLibraryBase(current, claimedBases);
+
+  const answer = await vscode.window.showInputBox({
+    title: "Web resource bundle name",
+    prompt: `Currently deploys as ${webresourceLibraryName(prefix, "bundle", "library.ts", current)}. Each component needs its own name — they overwrite each other otherwise.`,
+    value: suggestion,
+    ignoreFocusOut: true,
+    validateInput: (value) => {
+      const trimmed = value.trim();
+      if (!isValidLibraryBase(trimmed)) {
+        return "Letters, digits and underscores only.";
+      }
+      const proposed = webresourceLibraryName(prefix, "bundle", "library.ts", trimmed);
+      // Say so while they type rather than after they've rebuilt and deployed over someone.
+      return claimed.has(proposed) ? `${proposed} is already deployed by another component in this workspace.` : undefined;
+    },
+  });
+  const next = answer?.trim();
+  if (!next || next === current) {
+    return;
+  }
+
+  // Keep the old name owned so its handlers stay deletable (see the header note).
+  const history = new Set(context.projectSettings.webresourcePreviousLibraryNames ?? []);
+  history.add(current);
+  history.delete(next);
+  // "library" needs no recording — candidateLibraryNames always owns it.
+  context.projectSettings.webresourcePreviousLibraryNames = [...history].filter((name) => name !== DEFAULT_LIBRARY_BASE);
+  context.projectSettings.webresourceLibraryName = next;
+  await context.writeSettings();
+
+  // bin/ still holds the bundle under the old name; deploy would upload it again.
+  const binDir = path.join(componentRoot, "bin");
+  const stale = webresourceLibraryName(prefix, "bundle", "library.ts", current);
+  const stalePath = path.join(binDir, stale);
+  if (fs.existsSync(stalePath)) {
+    await fs.promises.rm(stalePath, { force: true });
+    context.channel.appendLine(`Removed bin/${stale} — it would otherwise be deployed again under the old name.`);
+  }
+
+  const renamed = webresourceLibraryName(prefix, "bundle", "library.ts", next);
+  context.channel.appendLine(`Web resource bundle renamed: ${stale} -> ${renamed}. Run Build, then Deploy.`);
+  context.channel.appendLine(`${stale} is still deployed in the environment — delete it there once no form references it.`);
+  context.refreshPanel?.();
+  vscode.window.showInformationMessage(`Bundle renamed to ${renamed}. Run Build then Deploy; the old ${stale} is still in the environment.`);
+}
+
+/** Collisions between this workspace's web-resource components, for surfacing to the user. */
+export function webresourceCollisionsInWorkspace(context: DataversePowerToolsContext, prefix: string): Array<{ name: string; components: string[] }> {
+  const claims = context.components
+    .filter((component) => component.settings?.type === ProjectTypes.webresource)
+    .map((component) => {
+      let sources: string[] = [];
+      try {
+        sources = fs.readdirSync(path.join(component.root, "webresources_src"));
+      } catch {
+        sources = [];
+      }
+      return { relativeRoot: component.relativeRoot, names: deployedWebresourceNames(prefix, outputSettings(component.settings), sources) };
+    });
+  return findWebresourceNameCollisions(claims);
+}

--- a/src/webresources/switchOutputMode.ts
+++ b/src/webresources/switchOutputMode.ts
@@ -18,7 +18,7 @@ export async function switchWebresourceOutput(context: DataversePowerToolsContex
   const current = context.projectSettings.webresourceOutput === "perFile" ? "perFile" : "bundle";
   const pick = await vscode.window.showQuickPick(
     [
-      { label: `${current === "bundle" ? "$(check) " : ""}Single bundled library`, description: "one <prefix>_library.js from library.ts", target: "bundle" as const },
+      { label: `${current === "bundle" ? "$(check) " : ""}Single bundled library`, description: "one <prefix>_<name>.js built from library.ts", target: "bundle" as const },
       {
         label: `${current === "perFile" ? "$(check) " : ""}One file per web resource`,
         description: "one <prefix>_<name>.js per webresources_src/*.ts",


### PR DESCRIPTION
Replaces #276, which GitHub auto-closed when its base branch (#275's) was deleted on merge. Same work, rebased onto main; CI was green on the identical diff before the rebase.

The bundle name in 1.0.7 only helped **new** components. Anything older still shares `{prefix}_library.js`, and deploy upserts `bin/` by filename, so the second to deploy silently replaces the first. Five things, one theme: make the per-component name real everywhere.

## 1. `Change Web Resource Bundle Name`

In the card's overflow next to *Output mode*. It suggests a name that's actually free, refuses one another component already claims **while you type**, clears the stale `bin/` artefact that would otherwise redeploy under the old name, and **records the previous name** so `candidateLibraryNames` keeps owning it — without that, the next Register Form Events would strand handlers on a resource nobody deploys.

## 2. Deploy warns when two components claim the same name

At the point the overwrite would actually happen.

## 3. Fixed: Debug Web Resources was a no-op for a renamed component

It hardcoded `${prefix}_library.js`, and that name drives the CDP intercept pattern, the live-app URL match **and** the hot-reload watcher's filename check. So for any component with its own bundle name: nothing served, nothing intercepted, no reload.

**This is a regression shipped in 1.0.7** and it was my own miss — it built the name inline rather than using the helper, so my #258 call-site sweep didn't find it. Found by grepping for inline `${prefix}_` construction instead of for the helper.

## 4. Fixed: registrations in files per-file mode doesn't build

Per-file mode builds only the **top-level** `webresources_src/*.ts`; `library.ts` and anything nested are excluded. But the registration scan is recursive, so a registration in one of those was still written to the form, naming a `<Library>` that isn't in the environment. Now skipped, with the files named.

## 5. Two stale quick-pick descriptions

Both still said the bundle was "one `<prefix>_library.js`".

## The detector covers both modes on purpose

The obvious version skips per-file components — their names come from filenames, so they "can't" contend for the bundle name. That's wrong: two per-file components that both contain `Account.ts` both deploy `{prefix}_Account.js`, the same silent overwrite. A bundle-only detector would have been blind to half of them. There's a test for exactly that case.

## Verification

`lint`, `compile`, **1390 unit tests**, **22 integration tests** — including the #147 registration test, which proves the new command is declared in *both* `package.json` and the registry rather than only one (the two-places trap).

Not run: the e2e suites. Nothing here changes the wizard flow they drive.

🤖 Generated with [Claude Code](https://claude.com/claude-code)