### PR TITLE
1.0.8 — Debug Web Resources works again, and bundles can be renamed (#258)

### DIFF
--- a/CHANGELOG-prerelease.md
+++ b/CHANGELOG-prerelease.md
@@ -7,34 +7,4 @@ is cleared to start accumulating the next cycle (`node scripts/rollupChangelog.m
 
 Everything below has shipped to the pre-release channel and is not yet in a full release.
 
-## 1.0.8 (pre-release)
-
-**Change a web resource's bundle name after the fact — and be told when two components clash**
-
-The new bundle name only helped components created after 1.0.7; anything older still shared
-`<prefix>_library.js` with every other component in the workspace and quietly overwrote it. There
-is now a *Change Web Resource Bundle Name* command (in the card's overflow, next to *Output mode*),
-and Deploy warns when more than one component in the workspace would deploy the same web resource
-name — in either output mode. Renaming keeps the previous name registered as yours, so handlers
-still bound to it are cleaned up rather than left pointing at a resource nobody deploys.
-
-**Fixed: Debug Web Resources did nothing for a component with its own bundle name**
-
-The debug session hardcoded `<prefix>_library.js` when deciding which request to intercept and
-which built file to serve, so for any component that had been given its own bundle name it
-intercepted nothing, served nothing, and never hot-reloaded.
-
-**Fixed: form registrations in files that per-file mode doesn't build**
-
-In one-file-per-web-resource mode only the top-level `webresources_src/*.ts` are built —
-`library.ts` and anything in a subfolder are not. A form registration in one of those was still
-written to the form, pointing at a web resource that never gets deployed. Those registrations are
-now skipped with a message naming the files, instead of leaving a form bound to a missing library.
-
-**Choose your web resource's bundle name when you create the component**
-
-1.0.7 gave each Web Resources component its own bundle name so two of them stop deploying over
-each other, but it picked that name for you. Creating a component in bundled output mode now asks,
-prefilled with the same suggestion and showing the full name it will deploy as
-(`<prefix>_<name>.js`). Per-file mode doesn't ask, because those names come from your source
-filenames.
+_Nothing yet — the next pre-release adds its section here._

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,40 @@ All notable changes to the "dataverse-powertools" extension will be documented i
 Pre-release builds get a per-version entry in [CHANGELOG-prerelease.md](CHANGELOG-prerelease.md);
 those entries are rolled up into one section here when a full release ships.
 
+## 1.0.8
+
+Fixes Debug Web Resources for components with their own bundle name, adds a command to rename a bundle, and warns when two components would deploy over each other.
+
+**Change a web resource's bundle name after the fact — and be told when two components clash**
+
+The new bundle name only helped components created after 1.0.7; anything older still shared
+`<prefix>_library.js` with every other component in the workspace and quietly overwrote it. There
+is now a *Change Web Resource Bundle Name* command (in the card's overflow, next to *Output mode*),
+and Deploy warns when more than one component in the workspace would deploy the same web resource
+name — in either output mode. Renaming keeps the previous name registered as yours, so handlers
+still bound to it are cleaned up rather than left pointing at a resource nobody deploys.
+
+**Fixed: Debug Web Resources did nothing for a component with its own bundle name**
+
+The debug session hardcoded `<prefix>_library.js` when deciding which request to intercept and
+which built file to serve, so for any component that had been given its own bundle name it
+intercepted nothing, served nothing, and never hot-reloaded.
+
+**Fixed: form registrations in files that per-file mode doesn't build**
+
+In one-file-per-web-resource mode only the top-level `webresources_src/*.ts` are built —
+`library.ts` and anything in a subfolder are not. A form registration in one of those was still
+written to the form, pointing at a web resource that never gets deployed. Those registrations are
+now skipped with a message naming the files, instead of leaving a form bound to a missing library.
+
+**Choose your web resource's bundle name when you create the component**
+
+1.0.7 gave each Web Resources component its own bundle name so two of them stop deploying over
+each other, but it picked that name for you. Creating a component in bundled output mode now asks,
+prefilled with the same suggestion and showing the full name it will deploy as
+(`<prefix>_<name>.js`). Per-file mode doesn't ask, because those names come from your source
+filenames.
+
 ## 1.0.7
 
 Multi-component workspaces stop colliding: name your PCF control, give each Web Resources component its own bundle, and the panel's ⋯ menu stays open.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "dataverse-powertools",
-  "version": "1.0.7",
+  "version": "1.0.8",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "dataverse-powertools",
-      "version": "1.0.7",
+      "version": "1.0.8",
       "hasInstallScript": true,
       "dependencies": {
         "@azure/msal-node": "^5.4.0",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "type": "git",
     "url": "https://github.com/pete-mc/dataverse-powertools"
   },
-  "version": "1.0.7",
+  "version": "1.0.8",
   "engines": {
     "vscode": "^1.95.0"
   },


### PR DESCRIPTION
Release PR: rolls the pre-release notes into `CHANGELOG.md` and bumps `package.json` to **1.0.8**, which is what `main.yml` gates publishing on.

## Why this follows 1.0.7 quickly

**1.0.7 introduced a regression.** Debug Web Resources hardcoded `{prefix}_library.js`, and that name drives the CDP intercept pattern, the live-app URL match *and* the hot-reload watcher. So for any component given its own bundle name — which 1.0.7 does automatically for subfolder components — the debug session intercepted nothing, served nothing, and never hot-reloaded. Anyone who scaffolded a subfolder web-resource component since 1.0.7 has a broken Debug Web Resources today.

## Also ships

- **`Change Web Resource Bundle Name`** — 1.0.7 only gave *newly scaffolded* components their own name; existing ones still shared `{prefix}_library.js`. This is the in-product way to fix them, and it keeps the previous name registered so form handlers bound to it are still cleaned up.
- **Deploy warns** when two components would deploy the same web resource name, in either output mode.
- **Per-file registrations in unbuilt files are skipped** with a message, instead of binding a form to a `<Library>` that isn't in the environment.

## Changelog note

Same tidy as 1.0.7: `rollupChangelog.mjs` demotes each pre-release section to `###` so several stay distinct under one heading, but there was one section carrying this release's own version — so it rendered as `## 1.0.8` followed by `### 1.0.8 (pre-release)`. Dropped that line.

## Verification

`lint`, `compile`, 1390 unit tests, 22 integration tests, and CI green on both merged PRs (#275, #277).

🤖 Generated with [Claude Code](https://claude.com/claude-code)