### PR TITLE
e2e: make fixture cleanup actually delete, instead of failing silently

### DIFF
--- a/src/ui-test/e2e/lib.ts
+++ b/src/ui-test/e2e/lib.ts
@@ -7,6 +7,7 @@ import * as path from "path";
 import * as fs from "fs";
 import * as os from "os";
 import { VSBrowser, Workbench, InputBox, BottomBarPanel, Key, ModalDialog } from "vscode-extension-tester";
+import { XMLParser, XMLBuilder } from "fast-xml-parser";
 // The SAME lookups the product uses. Keeping a second copy here is what let the product and the test
 // agree on a wrong assumption about how Dataverse stores a name, so a working push read as broken.
 import { customControlLookup, pluginTraceLogLookup, pickMatchingRow } from "../../general/dataverse/rowLookups";
@@ -1004,11 +1005,101 @@ export class E2EClient {
     return data.value?.[0]?.webresourceid;
   }
 
-  async deleteWebresource(name: string): Promise<void> {
+  /**
+   * Delete a web resource, reporting whether it actually went.
+   *
+   * This used to ignore the response, which hid a real problem for as long as it existed: a web
+   * resource still referenced by a form handler cannot be deleted (0x8004f01f), so the delete
+   * failed every time a suite had registered form events — silently, because nothing checked.
+   * While fixture names were fixed that was invisible (the next run reused the same row); once
+   * names became run-scoped (#258) it meant every run left one behind forever. Deregister the
+   * handlers FIRST (see `deregisterFormHandlers`), and read this return value.
+   */
+  async deleteWebresource(name: string): Promise<boolean> {
     const id = await this.findWebresourceId(name);
-    if (id) {
-      await this.request("DELETE", `webresourceset(${id})`);
+    if (!id) {
+      return true; // nothing to delete is the state we wanted
     }
+    const res = await this.request("DELETE", `webresourceset(${id})`);
+    if (res.ok || res.status === 204) {
+      return true;
+    }
+    const body = await res.text().catch(() => "");
+    console.log(`    [e2e] WARNING: could not delete web resource ${name} (${res.status}): ${body.slice(0, 300)}`);
+    return false;
+  }
+
+  /**
+   * Strip every form handler bound to one of `libraryNames`, across all forms, then publish.
+   *
+   * A suite that registers form events must undo that before deleting its web resource — the
+   * handler is a dependency and blocks the delete. Only handlers naming one of OUR libraries are
+   * touched; anything else on the same form is left alone.
+   */
+  async deregisterFormHandlers(libraryNames: string[]): Promise<number> {
+    const owned = new Set(libraryNames.map((n) => n.toLowerCase()));
+    if (owned.size === 0) {
+      return 0;
+    }
+    // The SAME parser options the extension uses (DataverseForm.parsingOptions) — a mismatch would
+    // rewrite the form differently from the product and could corrupt it.
+    const parsingOptions = {
+      ignoreAttributes: false,
+      attributeNamePrefix: "@_",
+      suppressBooleanAttributes: false,
+      suppressEmptyNode: true,
+      isArray: (_name: string, jPath: unknown) =>
+        ["form.formLibraries.Library", "form.events.event", "form.events.event.Handlers.Handler"].includes(typeof jPath === "string" ? jPath : ""),
+    };
+    const res = await this.request("GET", "systemforms?$select=name,formxml,formid,objecttypecode");
+    if (!res.ok) {
+      return 0;
+    }
+    const forms: any[] = ((await res.json()) as any).value ?? [];
+    const isOurs = (name: unknown) => typeof name === "string" && owned.has(name.toLowerCase());
+    let removed = 0;
+    for (const form of forms) {
+      if (!form.formxml || !libraryNames.some((n) => form.formxml.includes(n))) {
+        continue;
+      }
+      const doc = new XMLParser(parsingOptions).parse(form.formxml);
+      const root = doc.form;
+      let removedHere = 0;
+      for (const event of root?.events?.event ?? []) {
+        const handlers = event?.Handlers?.Handler;
+        if (!Array.isArray(handlers)) {
+          continue;
+        }
+        const kept = handlers.filter((h: any) => !isOurs(h["@_libraryName"]));
+        removedHere += handlers.length - kept.length;
+        event.Handlers.Handler = kept;
+      }
+      if (removedHere === 0) {
+        continue;
+      }
+      // Prune what the product prunes: events with no handlers, and our <Library> entries.
+      if (Array.isArray(root?.events?.event)) {
+        root.events.event = root.events.event.filter((e: any) => (e?.Handlers?.Handler ?? []).length > 0);
+        if (root.events.event.length === 0) {
+          delete root.events;
+        }
+      }
+      if (Array.isArray(root?.formLibraries?.Library)) {
+        root.formLibraries.Library = root.formLibraries.Library.filter((l: any) => !isOurs(l["@_name"]));
+        if (root.formLibraries.Library.length === 0) {
+          delete root.formLibraries;
+        }
+      }
+      const formxml = new XMLBuilder(parsingOptions).build(doc).replace(/&quot;/g, '"');
+      const patch = await this.request("PATCH", `systemforms(${form.formid})`, { formxml });
+      if (patch.ok || patch.status === 204) {
+        removed += removedHere;
+      }
+    }
+    if (removed > 0) {
+      await this.request("POST", "PublishAllXml", {});
+    }
+    return removed;
   }
 
   /** The DEPLOYED JavaScript of a webresource (base64-decoded), or undefined. */

--- a/src/ui-test/e2e/pcfAcceptance.e2e.ts
+++ b/src/ui-test/e2e/pcfAcceptance.e2e.ts
@@ -165,7 +165,16 @@ describe("ACCEPTANCE: PCF — build, code, publish via panel buttons", function 
   after(async function () {
     try {
       const m = manifest();
-      await client.deleteWebresource(`cc_${m.namespace}.${m.constructor}/bundle.js`);
+      // The customcontrol row REFERENCES its bundle web resource, so the resource can't go until
+      // the control does — and the control was never deleted at all, so a run-scoped control (#258)
+      // accumulated one per run. pcfInteractiveLifecycle already did this; this suite didn't.
+      const control = `${m.namespace}.${m.constructor}`;
+      if (await client.deleteCustomControl(control)) {
+        console.log(`    [e2e] [cleanup] removed custom control ${control}`);
+      }
+      if (!(await client.deleteWebresource(`cc_${control}/bundle.js`))) {
+        console.log(`    [e2e] [cleanup] WARNING: cc_${control}/bundle.js is still deployed — delete it by hand`);
+      }
     } catch {
       /* best-effort cleanup */
     }

--- a/src/ui-test/e2e/webresourceComprehensive.e2e.ts
+++ b/src/ui-test/e2e/webresourceComprehensive.e2e.ts
@@ -388,6 +388,16 @@ describe("Web resources — comprehensive UI lifecycle (e2e)", function () {
     }
     const client = new E2EClient(env);
     await client.connect();
-    await client.deleteWebresource(libraryName());
+    // Order matters: the form handlers this suite registered are a DEPENDENCY of the web resource,
+    // so deleting the resource first fails with 0x8004f01f. That failure used to be swallowed, and
+    // once names became run-scoped (#258) every run left a resource and a handler behind on the
+    // shared org for good. Deregister, then delete, then say so if it still didn't go.
+    const handlers = await client.deregisterFormHandlers([libraryName()]);
+    if (handlers > 0) {
+      console.log(`    [e2e] [cleanup] removed ${handlers} form handler(s) bound to ${libraryName()}`);
+    }
+    if (!(await client.deleteWebresource(libraryName()))) {
+      console.log(`    [e2e] [cleanup] WARNING: ${libraryName()} is still deployed — delete it by hand`);
+    }
   });
 });


### PR DESCRIPTION
Found by running the deploying suites for the first time since #258 — which is exactly what that exercise was for.

## The bug

`deleteWebresource` ignored the response. A web resource still referenced by a form handler **cannot** be deleted, so for any suite that registered form events the delete failed *every single time* — silently:

```
0x8004f01f — The WebResource ... cannot be deleted because it is
             referenced by 1 other components.
```

(Confirmed by hand against the org before changing anything.)

## Why it only matters now

While fixture names were fixed this was invisible and harmless: the next run reused `dvpt_library.js` and re-registered the same handler, so the org stayed bounded and effectively self-cleaning.

**Run-scoping the names in #258 removed that property.** Every run now creates a *distinctly named* resource, so the silent failure turned into unbounded growth — one web resource plus one form handler left on the shared org per run, permanently. That's a consequence of my own change, and it only surfaced because the suites finally ran.

## The fix

- `deleteWebresource` returns whether it actually went and logs the body when it didn't.
- New `deregisterFormHandlers` strips handlers bound to our libraries across all forms and publishes. It uses the **same** `fast-xml-parser` options as `DataverseForm`, so it rewrites forms the way the product does rather than a lookalike. Only handlers naming our libraries are touched.
- `webresourceComprehensive` deregisters **before** deleting, and warns if the resource still won't go.
- `pcfAcceptance` deletes the `customcontrol` row, which it never did — the control references its bundle, so neither could go. `pcfInteractiveLifecycle` already did this.

## Verification

Re-ran both suites. Cleanup fired (`removed 1 form handler(s) bound to dvpt_libraryhqj8j.js`, `removed custom control DvptE2E.AccPcfControlhqj8j`) and the org audits **empty** afterwards — including on a run where a step failed, since the after hook still runs. Leftovers from earlier runs were cleaned separately, so the org is back to a clean baseline.

## Not fixed here

That re-run hit an unrelated flake: `webresourceComprehensive` step 8 failed in `TextEditor.toggleBreakpoint` — *"Condition not met within 1000ms"*, a hardcoded 1s wait inside `@redhat-developer/page-objects`. It passed on the earlier run today with identical product code, and it fails long before any cleanup code. Filed separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)