### PR TITLE
fix(earlybound): pac filters are semicolon-separated, not comma (silent empty generation)

### DIFF
--- a/CHANGELOG-prerelease.md
+++ b/CHANGELOG-prerelease.md
@@ -7,4 +7,19 @@ is cleared to start accumulating the next cycle (`node scripts/rollupChangelog.m
 
 Everything below has shipped to the pre-release channel and is not yet in a full release.
 
-_Nothing yet — the next pre-release adds its section here._
+## 1.0.9 (pre-release)
+
+**Fixed: Generate Early Bound Classes silently generated nothing when a table filter was set**
+
+If you had configured an entity filter, the generated folder came back empty — and the run looked
+like it had succeeded. `pac modelbuilder` takes its `--entitynamesfilter` and `--messagenamesfilter`
+as **semicolon**-separated lists; we were passing commas, so pac read the whole thing as one table
+name, matched nothing, wrote no classes and still exited successfully. Nothing surfaced the
+failure, so a later *Build & deploy* would ship a package with none of the expected early-bound
+classes in it.
+
+Both filters are now joined the way pac documents. If you worked around this by entering your
+tables with semicolons, switch back to the normal comma-separated list — the settings format is
+unchanged, only what we hand to pac was wrong.
+
+Reported from a pilot running 0.14.48; the bug was still present in 1.0.8.

--- a/src/general/modelbuilder/args.spec.ts
+++ b/src/general/modelbuilder/args.spec.ts
@@ -1,0 +1,96 @@
+import { describe, it, expect } from "vitest";
+import { buildModelBuilderArgs, joinPacFilter, PAC_FILTER_SEPARATOR } from "./args";
+
+const base = { namespace: "Contoso.Plugins", serviceContextName: "Ctx", outputDirectory: "EarlyBound" };
+/** The value pac actually receives for a flag. */
+const valueOf = (args: string[], flag: string) => args[args.indexOf(flag) + 1];
+
+describe("buildModelBuilderArgs", () => {
+  it("always emits the required flags", () => {
+    expect(buildModelBuilderArgs(base)).toEqual(["modelbuilder", "build", "--namespace", "Contoso.Plugins", "--serviceContextName", "Ctx", "--outdirectory", "EarlyBound"]);
+  });
+
+  // The bug: joined with "," pac 2.8.1 treats the whole string as ONE entity name, matches
+  // nothing, reports "Read 0 Entities", writes no classes and STILL EXITS 0 — so the command
+  // looked successful and left an empty generated folder. Verified against 2.8.1+ga4eb71c.
+  describe("filters are SEMICOLON separated, as pac documents", () => {
+    it("joins the entity filter with semicolons, never commas", () => {
+      const args = buildModelBuilderArgs({ ...base, entityNamesFilter: ["team", "teamtemplate"] });
+      expect(valueOf(args, "--entityNamesFilter")).toBe("team;teamtemplate");
+      expect(valueOf(args, "--entityNamesFilter")).not.toContain(",");
+    });
+
+    it("joins the message filter with semicolons too — the same flag family, same rule", () => {
+      const args = buildModelBuilderArgs({ ...base, messageNamesFilter: ["Create", "Update"] });
+      expect(valueOf(args, "--messageNamesFilter")).toBe("Create;Update");
+      expect(valueOf(args, "--messageNamesFilter")).not.toContain(",");
+    });
+
+    it("pins the separator so it can't be 'tidied' back to a comma", () => {
+      expect(PAC_FILTER_SEPARATOR).toBe(";");
+    });
+
+    it("passes a single entity through unchanged", () => {
+      expect(valueOf(buildModelBuilderArgs({ ...base, entityNamesFilter: ["account"] }), "--entityNamesFilter")).toBe("account");
+    });
+
+    it("emits no filter flag at all when the list is empty", () => {
+      // An empty --entitynamesfilter is not the same as omitting it; omit it.
+      expect(buildModelBuilderArgs({ ...base, entityNamesFilter: [], messageNamesFilter: [] })).not.toContain("--entityNamesFilter");
+      expect(buildModelBuilderArgs({ ...base })).not.toContain("--messageNamesFilter");
+    });
+  });
+
+  describe("joinPacFilter", () => {
+    it("trims and drops blanks, so a stray separator can't emit an empty name", () => {
+      // Settings are entered/stored as CSV and split upstream; a trailing comma yields "".
+      expect(joinPacFilter([" team ", "", "teamtemplate", "   "])).toBe("team;teamtemplate");
+    });
+
+    it("returns an empty string when nothing survives, so the caller omits the flag", () => {
+      expect(joinPacFilter([])).toBe("");
+      expect(joinPacFilter(["", "  "])).toBe("");
+    });
+  });
+
+  describe("the remaining flags", () => {
+    it("includes folder overrides only when set", () => {
+      const args = buildModelBuilderArgs({ ...base, entityTypesFolder: "Entities", messagesTypesFolder: "Messages", optionSetsTypesFolder: "OptionSets" });
+      expect(valueOf(args, "--entityTypesFolder")).toBe("Entities");
+      expect(valueOf(args, "--messagesTypesFolder")).toBe("Messages");
+      expect(valueOf(args, "--optionSetsTypesFolder")).toBe("OptionSets");
+      expect(buildModelBuilderArgs(base)).not.toContain("--entityTypesFolder");
+    });
+
+    it("emits each boolean switch as a bare flag when true, and not at all when false", () => {
+      const on = buildModelBuilderArgs({
+        ...base,
+        emitEntityEtc: true,
+        emitFieldsClasses: true,
+        emitVirtualAttributes: true,
+        generateGlobalOptionSets: true,
+        generateSdkMessages: true,
+        suppressGeneratedCodeAttribute: true,
+        suppressINotifyPattern: true,
+      });
+      for (const flag of [
+        "--emitEntityETC",
+        "--emitFieldsClasses",
+        "--emitVirtualAttributes",
+        "--generateGlobalOptionSets",
+        "--generateSdkMessages",
+        "--suppressGeneratedCodeAttribute",
+        "--suppressINotifyPattern",
+      ]) {
+        expect(on, flag).toContain(flag);
+      }
+      const off = buildModelBuilderArgs({ ...base, emitEntityEtc: false, generateSdkMessages: false });
+      expect(off).not.toContain("--emitEntityETC");
+      expect(off).not.toContain("--generateSdkMessages");
+    });
+
+    it("passes the log level through", () => {
+      expect(valueOf(buildModelBuilderArgs({ ...base, logLevel: "Trace" }), "--logLevel")).toBe("Trace");
+    });
+  });
+});

--- a/src/general/modelbuilder/args.ts
+++ b/src/general/modelbuilder/args.ts
@@ -1,0 +1,94 @@
+import { PluginModelBuilderSettings } from "../../context";
+
+// Pure argv builder for `pac modelbuilder build`, mirroring src/solution/pacArgs.ts and
+// generateTypings' buildTypingsArgs: the exact flags live in one unit-tested place so they can be
+// checked against the pac reference without an org.
+//
+// https://learn.microsoft.com/power-platform/developer/cli/reference/modelbuilder
+
+/**
+ * `--entitynamesfilter` and `--messagenamesfilter` are SEMICOLON separated. pac's own help:
+ *
+ *   --entitynamesfilter   Passed in as a semicolon separated list.
+ *                         Using the form <entitylogicalname>;<entitylogicalname>
+ *   --messagenamesfilter  Passed in as a semicolon separated list ...
+ *                         Using the form <messagename>;<messagename>
+ *
+ * These were joined with "," which pac 2.8.1 treats as ONE entity name that matches nothing: it
+ * reports "Read 0 Entities", writes no classes, and STILL EXITS 0 — so the command looked like it
+ * succeeded and left an empty generated folder, and a later Build & deploy shipped a package with
+ * no early-bound classes. Verified against 2.8.1+ga4eb71c: "team,teamtemplate" -> 0 entities;
+ * "team;teamtemplate" -> "Read 2 Entities".
+ *
+ * The comma form remains the SETTINGS/UI format (settingsFile parses CSV, the pickers display CSV);
+ * only the CLI boundary is semicolon-separated.
+ */
+export const PAC_FILTER_SEPARATOR = ";";
+
+/** Join a filter list the way pac expects, dropping blanks so a stray comma can't emit an empty name. */
+export function joinPacFilter(values: string[]): string {
+  return values
+    .map((value) => value.trim())
+    .filter((value) => value.length > 0)
+    .join(PAC_FILTER_SEPARATOR);
+}
+
+/**
+ * argv for `pac modelbuilder build` from the component's settings (the leading "pac" is added by
+ * the runner). Returns only the flags the settings actually populate.
+ */
+export function buildModelBuilderArgs(settings: PluginModelBuilderSettings): string[] {
+  const args = [
+    "modelbuilder",
+    "build",
+    "--namespace",
+    settings.namespace ?? "",
+    "--serviceContextName",
+    settings.serviceContextName ?? "",
+    "--outdirectory",
+    settings.outputDirectory ?? "",
+  ];
+
+  const entityFilter = joinPacFilter(settings.entityNamesFilter ?? []);
+  if (entityFilter) {
+    args.push("--entityNamesFilter", entityFilter);
+  }
+  if (settings.entityTypesFolder) {
+    args.push("--entityTypesFolder", settings.entityTypesFolder);
+  }
+  const messageFilter = joinPacFilter(settings.messageNamesFilter ?? []);
+  if (messageFilter) {
+    args.push("--messageNamesFilter", messageFilter);
+  }
+  if (settings.messagesTypesFolder) {
+    args.push("--messagesTypesFolder", settings.messagesTypesFolder);
+  }
+  if (settings.optionSetsTypesFolder) {
+    args.push("--optionSetsTypesFolder", settings.optionSetsTypesFolder);
+  }
+  if (settings.emitEntityEtc) {
+    args.push("--emitEntityETC");
+  }
+  if (settings.emitFieldsClasses) {
+    args.push("--emitFieldsClasses");
+  }
+  if (settings.emitVirtualAttributes) {
+    args.push("--emitVirtualAttributes");
+  }
+  if (settings.generateGlobalOptionSets) {
+    args.push("--generateGlobalOptionSets");
+  }
+  if (settings.generateSdkMessages) {
+    args.push("--generateSdkMessages");
+  }
+  if (settings.logLevel) {
+    args.push("--logLevel", settings.logLevel);
+  }
+  if (settings.suppressGeneratedCodeAttribute) {
+    args.push("--suppressGeneratedCodeAttribute");
+  }
+  if (settings.suppressINotifyPattern) {
+    args.push("--suppressINotifyPattern");
+  }
+  return args;
+}

--- a/src/general/modelbuilder/index.ts
+++ b/src/general/modelbuilder/index.ts
@@ -14,6 +14,7 @@ import {
 } from "./settingsFile";
 import { configureEditableSettings, editSingleSetting, ModelBuilderSettingKey } from "./ui";
 import { activeComponentRoot } from "../../components/componentDiscovery";
+import { buildModelBuilderArgs } from "./args";
 
 /** Run pac; if it fails with a pac AUTH error, re-establish the extension's pac
  * profile and retry ONCE before giving up. runPac (commandRunner) rejects with
@@ -245,68 +246,8 @@ export async function generateEarlyBoundV3(context: DataversePowerToolsContext) 
   }
 
   const workspacePath = activeComponentRoot(context)!;
-  const args = [
-    "modelbuilder",
-    "build",
-    "--namespace",
-    activeSettings.namespace,
-    "--serviceContextName",
-    activeSettings.serviceContextName,
-    "--outdirectory",
-    activeSettings.outputDirectory,
-  ];
-
-  if (activeSettings.entityNamesFilter && activeSettings.entityNamesFilter.length > 0) {
-    args.push("--entityNamesFilter", activeSettings.entityNamesFilter.join(","));
-  }
-
-  if (activeSettings.entityTypesFolder) {
-    args.push("--entityTypesFolder", activeSettings.entityTypesFolder);
-  }
-
-  if (activeSettings.messageNamesFilter && activeSettings.messageNamesFilter.length > 0) {
-    args.push("--messageNamesFilter", activeSettings.messageNamesFilter.join(","));
-  }
-
-  if (activeSettings.messagesTypesFolder) {
-    args.push("--messagesTypesFolder", activeSettings.messagesTypesFolder);
-  }
-
-  if (activeSettings.optionSetsTypesFolder) {
-    args.push("--optionSetsTypesFolder", activeSettings.optionSetsTypesFolder);
-  }
-
-  if (activeSettings.emitEntityEtc) {
-    args.push("--emitEntityETC");
-  }
-
-  if (activeSettings.emitFieldsClasses) {
-    args.push("--emitFieldsClasses");
-  }
-
-  if (activeSettings.emitVirtualAttributes) {
-    args.push("--emitVirtualAttributes");
-  }
-
-  if (activeSettings.generateGlobalOptionSets) {
-    args.push("--generateGlobalOptionSets");
-  }
-
-  if (activeSettings.generateSdkMessages) {
-    args.push("--generateSdkMessages");
-  }
-
-  if (activeSettings.logLevel) {
-    args.push("--logLevel", activeSettings.logLevel);
-  }
-
-  if (activeSettings.suppressGeneratedCodeAttribute) {
-    args.push("--suppressGeneratedCodeAttribute");
-  }
-
-  if (activeSettings.suppressINotifyPattern) {
-    args.push("--suppressINotifyPattern");
-  }
+  // Flags (and the semicolon-separated filter delimiter pac requires) live in the pure builder.
+  const args = buildModelBuilderArgs(activeSettings);
 
   await vscode.window.withProgress(
     {


### PR DESCRIPTION
External bug report from an Application Engine pilot. **Valid, still present in 1.0.8**, and worse than reported.

## The bug

`pac modelbuilder` documents both list flags as semicolon separated:

```
--entitynamesfilter   Passed in as a semicolon separated list.
                      Using the form <entitylogicalname>;<entitylogicalname>
--messagenamesfilter  Passed in as a semicolon separated list ...
```

We joined with `","`, so pac read the whole list as **one** table name, matched nothing, wrote no classes — and **exited 0**. Completely silent: a clean-looking run, an empty generated folder, and a subsequent *Build & deploy* shipping a package with none of the expected early-bound classes.

## Verified, not just read off the docs

Against pac 2.8.1+ga4eb71c on a real org:

| filter | result |
| --- | --- |
| `"team,teamtemplate"` | Read **0** Entities, exit 0, 1 file |
| `"team;teamtemplate"` | Read **2** Entities, exit 0, 5 files |

Then re-run with the argv the **shipping builder** produces after the fix → Read 2 Entities, 5 files.

## Two corrections to the report

1. **The location moved.** They cite `src/plugins/modelbuilder.ts:260` on commit `1d1c967` (0.14.48). That file is now a 6-line re-export; the live code is `src/general/modelbuilder/index.ts:260`. Same bug, same line number, different file — worth telling them so they don't think a newer version fixed it.
2. **They missed one.** `messageNamesFilter` on the next line had the identical bug. Fixed too.

## Approach

Rather than change two joins in place, the argv now comes from a pure `buildModelBuilderArgs` — matching `pacArgs.ts` and `buildTypingsArgs`, per the repo convention that pac flags live in one unit-tested place checkable against the reference without an org. The separator is a named constant with a test pinning it to `";"` so it can't be tidied back.

The comma form remains the **settings/UI** format (`settingsFile` parses CSV, the pickers display CSV). Only the CLI boundary changed, so **no user settings need editing** — and anyone who worked around this by typing semicolons should switch back.

## Verification

`lint`, `compile`, **1401 unit tests** (11 new), **22 integration tests**, plus the live pac runs above.

## Their secondary observation — filed, not fixed here

They're right that `buildTypingsArgs` only scopes with `/ss:<solution>`, so entities outside the solution can't get typings. That's an enhancement needing a settings surface and UI, not a bug, and folding a new feature into a bug-fix release would be wrong. Filed separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)