### PR TITLE
1.0.9 — early-bound generation no longer silently produces nothing (#281)

### DIFF
--- a/CHANGELOG-prerelease.md
+++ b/CHANGELOG-prerelease.md
@@ -7,19 +7,4 @@ is cleared to start accumulating the next cycle (`node scripts/rollupChangelog.m
 
 Everything below has shipped to the pre-release channel and is not yet in a full release.
 
-## 1.0.9 (pre-release)
-
-**Fixed: Generate Early Bound Classes silently generated nothing when a table filter was set**
-
-If you had configured an entity filter, the generated folder came back empty — and the run looked
-like it had succeeded. `pac modelbuilder` takes its `--entitynamesfilter` and `--messagenamesfilter`
-as **semicolon**-separated lists; we were passing commas, so pac read the whole thing as one table
-name, matched nothing, wrote no classes and still exited successfully. Nothing surfaced the
-failure, so a later *Build & deploy* would ship a package with none of the expected early-bound
-classes in it.
-
-Both filters are now joined the way pac documents. If you worked around this by entering your
-tables with semicolons, switch back to the normal comma-separated list — the settings format is
-unchanged, only what we hand to pac was wrong.
-
-Reported from a pilot running 0.14.48; the bug was still present in 1.0.8.
+_Nothing yet — the next pre-release adds its section here._

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,25 @@ All notable changes to the "dataverse-powertools" extension will be documented i
 Pre-release builds get a per-version entry in [CHANGELOG-prerelease.md](CHANGELOG-prerelease.md);
 those entries are rolled up into one section here when a full release ships.
 
+## 1.0.9
+
+Fixes Generate Early Bound Classes silently generating nothing when a table filter was configured.
+
+**Fixed: Generate Early Bound Classes silently generated nothing when a table filter was set**
+
+If you had configured an entity filter, the generated folder came back empty — and the run looked
+like it had succeeded. `pac modelbuilder` takes its `--entitynamesfilter` and `--messagenamesfilter`
+as **semicolon**-separated lists; we were passing commas, so pac read the whole thing as one table
+name, matched nothing, wrote no classes and still exited successfully. Nothing surfaced the
+failure, so a later *Build & deploy* would ship a package with none of the expected early-bound
+classes in it.
+
+Both filters are now joined the way pac documents. If you worked around this by entering your
+tables with semicolons, switch back to the normal comma-separated list — the settings format is
+unchanged, only what we hand to pac was wrong.
+
+Reported from a pilot running 0.14.48; the bug was still present in 1.0.8.
+
 ## 1.0.8
 
 Fixes Debug Web Resources for components with their own bundle name, adds a command to rename a bundle, and warns when two components would deploy over each other.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "dataverse-powertools",
-  "version": "1.0.8",
+  "version": "1.0.9",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "dataverse-powertools",
-      "version": "1.0.8",
+      "version": "1.0.9",
       "hasInstallScript": true,
       "dependencies": {
         "@azure/msal-node": "^5.4.0",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "type": "git",
     "url": "https://github.com/pete-mc/dataverse-powertools"
   },
-  "version": "1.0.8",
+  "version": "1.0.9",
   "engines": {
     "vscode": "^1.95.0"
   },


### PR DESCRIPTION
Release PR: rolls the pre-release notes into `CHANGELOG.md` and bumps `package.json` to **1.0.9**, which is what `main.yml` gates publishing on.

## Ships one fix

Reported externally from an Application Engine pilot. `pac modelbuilder` takes `--entitynamesfilter` and `--messagenamesfilter` as **semicolon**-separated lists; we passed commas. pac read the list as one table name, matched nothing, generated no classes — and exited 0.

The failure was silent, which is what makes it worth a prompt release: a clean-looking run, an empty generated folder, and a subsequent *Build & deploy* shipping a package with none of the expected early-bound classes.

Verified against pac 2.8.1+ga4eb71c on a real org before and after, including with the argv the shipping builder produces.

## Verification

`lint`, `compile`, 1401 unit tests, 22 integration tests, CI green on #281.

🤖 Generated with [Claude Code](https://claude.com/claude-code)